### PR TITLE
esp_modem: Update Task handle and Event Group handle to match freertos v10.4.3

### DIFF
--- a/components/esp_modem/include/cxx_include/esp_modem_primitives.hpp
+++ b/components/esp_modem/include/cxx_include/esp_modem_primitives.hpp
@@ -43,8 +43,8 @@ struct Lock {
 private:
     MutexT m{};
 };
-using TaskT = void*;
-using SignalT = void*;
+using TaskT = TaskHandle_t;
+using SignalT = EventGroupHandle_t;
 #else
 using Lock = std::mutex;
 struct SignalGroupInternal;


### PR DESCRIPTION

This commit updates the default handles for Task type and Signal Group
type to match the struct type handle from freertos v10.4.3.

Signed-off-by: Sudeep Mohanty <sudeep.mohanty@espressif.com>