### PR TITLE
Added actions to upload components and sync issues

### DIFF
--- a/.github/workflows/sync_issues.yml
+++ b/.github/workflows/sync_issues.yml
@@ -1,0 +1,21 @@
+name: Sync issue comments to JIRA
+
+# This workflow will be triggered when new issue is created
+# or a new issue/PR comment is created
+on: [issues, issue_comment]
+
+jobs:
+  sync_issue_comments_to_jira:
+    name: Sync Issue Comments to Jira
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Sync issue comments to JIRA
+        uses: espressif/github-actions/sync_issues_to_jira@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          JIRA_PASS: ${{ secrets.JIRA_PASS }}
+          JIRA_PROJECT: IDFGH
+          JIRA_COMPONENT: esp-protocols
+          JIRA_URL: ${{ secrets.JIRA_URL }}
+          JIRA_USER: ${{ secrets.JIRA_USER }}

--- a/.github/workflows/upload_component.yml
+++ b/.github/workflows/upload_component.yml
@@ -1,0 +1,18 @@
+name: Push components to Espressif Component Service
+
+on: push
+
+jobs:
+  upload_components:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Upload components to component service
+        uses: espressif/github-actions/upload_components@master
+        with:
+          directories: "components/esp_modem"
+          name: "esp_modem"
+          namespace: "espressif"
+          api_token: ${{ secrets.IDF_COMPONENT_API_TOKEN }}
+

--- a/.github/workflows/upload_component.yml
+++ b/.github/workflows/upload_component.yml
@@ -1,6 +1,9 @@
 name: Push components to Espressif Component Service
 
-on: push
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   upload_components:


### PR DESCRIPTION
This PR defines two new actions:
* Uploads component `esp_modem` components to Espressif component registry
* Synchronizes issues/issue-comments to internal JIRA project (component=`esp-protocols`)