### PR TITLE
esp_modem: Update FreeRTOS EventQueueHandle_t forward declaration

### DIFF
--- a/components/esp_modem/idf_component.yml
+++ b/components/esp_modem/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.1.11"
+version: "0.1.12"
 description: esp modem
 dependencies:
   # Required IDF version

--- a/components/esp_modem/include/cxx_include/esp_modem_primitives.hpp
+++ b/components/esp_modem/include/cxx_include/esp_modem_primitives.hpp
@@ -22,9 +22,9 @@
 #include <thread>
 
 #else
+#include "freertos/event_groups.h"
 // forward declarations of FreeRTOS primitives
 struct QueueDefinition;
-typedef void *EventGroupHandle_t;
 #endif
 
 


### PR DESCRIPTION
This commit includes freertos/event_groups.h header and removes the
forward declaration for EventGroupHandle_t.

Signed-off-by: Sudeep Mohanty <sudeep.mohanty@espressif.com>