### PR TITLE
fix(esp_modem): Read module name with AT commands

### DIFF
--- a/components/esp_modem/include/cxx_include/esp_modem_dce_module.hpp
+++ b/components/esp_modem/include/cxx_include/esp_modem_dce_module.hpp
@@ -119,7 +119,6 @@ protected:
 class SIM7600: public GenericModule {
     using GenericModule::GenericModule;
 public:
-    command_result get_module_name(std::string &name) override;
     command_result get_battery_status(int &voltage, int &bcs, int &bcl) override;
     command_result power_down() override;
 };
@@ -130,7 +129,6 @@ public:
 class SIM800: public GenericModule {
     using GenericModule::GenericModule;
 public:
-    command_result get_module_name(std::string &name) override;
     command_result power_down() override;
     command_result set_data_mode() override;
 };
@@ -140,8 +138,6 @@ public:
  */
 class BG96: public GenericModule {
     using GenericModule::GenericModule;
-public:
-    command_result get_module_name(std::string &name) override;
 };
 
 /**

--- a/components/esp_modem/src/esp_modem_modules.cpp
+++ b/components/esp_modem/src/esp_modem_modules.cpp
@@ -50,12 +50,6 @@ DECLARE_ALL_COMMAND_APIS(return_type name(...) )
 //
 // Handle specific commands for specific supported modems
 //
-command_result SIM7600::get_module_name(std::string &name)
-{
-    name = "7600";
-    return command_result::OK;
-}
-
 command_result SIM7600::get_battery_status(int &voltage, int &bcs, int &bcl)
 {
     return dce_commands::get_battery_status_sim7xxx(dte.get(), voltage, bcs, bcl);
@@ -66,12 +60,6 @@ command_result SIM7600::power_down()
     return dce_commands::power_down_sim7xxx(dte.get());
 }
 
-command_result SIM800::get_module_name(std::string &name)
-{
-    name = "800L";
-    return command_result::OK;
-}
-
 command_result SIM800::power_down()
 {
     return dce_commands::power_down_sim8xx(dte.get());
@@ -80,12 +68,6 @@ command_result SIM800::power_down()
 command_result SIM800::set_data_mode()
 {
     return dce_commands::set_data_mode_sim8xx(dte.get());
-}
-
-command_result BG96::get_module_name(std::string &name)
-{
-    name = "BG96";
-    return command_result::OK;
 }
 
 }

--- a/components/esp_modem/test/host_test/main/LoopbackTerm.cpp
+++ b/components/esp_modem/test/host_test/main/LoopbackTerm.cpp
@@ -28,6 +28,8 @@ int LoopbackTerm::write(uint8_t *data, size_t len)
             response = "CONNECT\r\n";
         } else if (command.find("AT+CSQ\r") != std::string::npos) {
             response = "+CSQ: 123,456\n\r\nOK\r\n";
+        } else if (command.find("AT+CGMM\r") != std::string::npos) {
+            response = "0G Dummy Model\n\r\nOK\r\n";
         } else if (command.find("AT+CBC\r") != std::string::npos) {
             response = is_bg96 ? "+CBC: 1,2,123456V\r\r\n\r\nOK\r\n\n\r\n" :
                        "+CBC: 123.456V\r\r\n\r\nOK\r\n\n\r\n";

--- a/components/esp_modem/test/host_test/main/test_modem.cpp
+++ b/components/esp_modem/test/host_test/main/test_modem.cpp
@@ -37,6 +37,10 @@ TEST_CASE("DCE AT parser", "[esp_modem]")
     CHECK(dce->set_pin("1234") == command_result::OK);
     CHECK(dce->read_pin(pin_ok) == command_result::OK);
     CHECK(pin_ok == true);
+
+    std::string model;
+    CHECK(dce->get_module_name(model) == command_result::OK);
+    CHECK(model == "0G Dummy Model");
 }
 
 


### PR DESCRIPTION
Module names were hard-coded strings defined as `override` method for different modules.
This fixes basic IDF test case which supplied dummy module name.