### PR TITLE
 fix(esp_modem): Fix battery status parser

### DIFF
--- a/components/esp_modem/idf_component.yml
+++ b/components/esp_modem/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.1.12"
+version: "0.1.13"
 description: esp modem
 dependencies:
   # Required IDF version

--- a/components/esp_modem/src/esp_modem_command_library.cpp
+++ b/components/esp_modem/src/esp_modem_command_library.cpp
@@ -167,7 +167,7 @@ command_result get_battery_status(CommandableIf *t, int &voltage, int &bcs, int 
     // Parsing +CBC: <bcs>,<bcl>,<voltage>
     out = out.substr(pattern.size());
     int pos, value, property = 0;
-    while ((pos = out.find(',') != std::string::npos)) {
+    while ((pos = out.find(',')) != std::string::npos) {
         if (std::from_chars(out.data(), out.data() + pos, value).ec == std::errc::invalid_argument) {
             return command_result::FAIL;
         }

--- a/components/esp_modem/test/host_test/main/LoopbackTerm.cpp
+++ b/components/esp_modem/test/host_test/main/LoopbackTerm.cpp
@@ -31,7 +31,7 @@ int LoopbackTerm::write(uint8_t *data, size_t len)
         } else if (command.find("AT+CGMM\r") != std::string::npos) {
             response = "0G Dummy Model\n\r\nOK\r\n";
         } else if (command.find("AT+CBC\r") != std::string::npos) {
-            response = is_bg96 ? "+CBC: 1,2,123456V\r\r\n\r\nOK\r\n\n\r\n" :
+            response = is_bg96 ? "+CBC: 1,20,123456\r\r\n\r\nOK\r\n\n\r\n" :
                        "+CBC: 123.456V\r\r\n\r\nOK\r\n\n\r\n";
         } else if (command.find("AT+CPIN=1234\r") != std::string::npos) {
             response = "OK\r\n";

--- a/components/esp_modem/test/host_test/main/test_modem.cpp
+++ b/components/esp_modem/test/host_test/main/test_modem.cpp
@@ -24,7 +24,7 @@ TEST_CASE("DCE AT parser", "[esp_modem]")
     CHECK(dce->get_battery_status(milli_volt, bcl, bcs) == command_result::OK);
     CHECK(milli_volt == 123456);
     CHECK(bcl == 1);
-    CHECK(bcs == 2);
+    CHECK(bcs == 20);
 
     int rssi, ber;
     CHECK(dce->get_signal_quality(rssi, ber) == command_result::OK);


### PR DESCRIPTION
Variable `pos`  was meant to hold position of first `,` (comma) appearance in the parsed string, but due to wrong parentheses it contained the boolean representation of not equal to `string::npos`

It wasn't caught by the tests, since the case used one-letter properties (where the expected position equals to 1/`true`)
```
+CBC: 1,2,123456
```

Updated the tests, too.