### PR TITLE
fix: add virtual destructors to ModuleIf and CommandableIf

### DIFF
--- a/components/esp_modem/examples/modem_console/main/httpget_handle.c
+++ b/components/esp_modem/examples/modem_console/main/httpget_handle.c
@@ -46,6 +46,7 @@ static esp_err_t http_event_handler(esp_http_client_event_t *evt)
         case HTTP_EVENT_DISCONNECTED:
             ESP_LOGI(TAG, "HTTP_EVENT_DISCONNECTED");
             break;
+        default: break;
     }
     return ESP_OK;
 }

--- a/components/esp_modem/include/cxx_include/esp_modem_types.hpp
+++ b/components/esp_modem/include/cxx_include/esp_modem_types.hpp
@@ -67,6 +67,12 @@ struct PdpContext {
  */
 class CommandableIf {
 public:
+    CommandableIf() = default;
+    CommandableIf(const CommandableIf&) = delete;
+    CommandableIf& operator=(const CommandableIf&) = delete;
+    CommandableIf(CommandableIf&&) = delete;
+    CommandableIf& operator=(CommandableIf&&) = delete;
+    virtual ~CommandableIf() = default;
     /**
      * @brief Sends custom AT command
      * @param command Command to be sent
@@ -83,6 +89,12 @@ public:
  */
 class ModuleIf {
 public:
+    ModuleIf() = default;
+    ModuleIf(const ModuleIf&) = delete;
+    ModuleIf& operator=(const ModuleIf&) = delete;
+    ModuleIf(ModuleIf&&) = delete;
+    ModuleIf& operator=(ModuleIf&&) = delete;
+    virtual ~ModuleIf() = default;
     /**
      * @brief Sets the data mode up (provides the necessary configuration to connect to the cellular network)
      * @return true on success


### PR DESCRIPTION
Closes #13 

The PR adds explicitly defaulted virtual destructors and explicitly deleted other special member functions for the `ModuleIf` and `CommandableIf` classes to follow the [rule of 5](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rc-five) and [this guideline](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rc-copy-virtual).

The second commit also fixes a compilation error from in the `modem_console` example with `-Werror -Wswitch-default` compile options.