### PR TITLE
build: fix issue with passing cxx_std option, a common workaround (IDFGH-6876)

### DIFF
--- a/components/esp_modem/CMakeLists.txt
+++ b/components/esp_modem/CMakeLists.txt
@@ -34,16 +34,11 @@ idf_component_register(SRCS "${srcs}"
                     PRIV_INCLUDE_DIRS private_include
                     REQUIRES ${dependencies})
 
-
-# If CMake doesn't know C++17 features, set it manually via comile options
-# esp-modem component requires C++17 internally, but older CMake (< 3.8, but still supported in IDF)
-# doesn't support target_compile_features() for cxx_std_17.
-get_property(cxx_known_features GLOBAL PROPERTY CMAKE_CXX_KNOWN_FEATURES)
-if ("cxx_std_17" IN_LIST cxx_known_features)
-    target_compile_features(${COMPONENT_LIB} PRIVATE cxx_std_17)
-else()
-    target_compile_options(${COMPONENT_LIB} PRIVATE "-std=gnu++17")
-endif()
+set_target_properties(${COMPONENT_LIB} PROPERTIES
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED ON
+    CXX_EXTENSIONS ON
+)
 
 if(${target} STREQUAL "linux")
     # This is needed for ESP_LOGx() macros, as integer formats differ on ESP32(..) and x64

--- a/components/esp_modem/examples/linux_modem/main/CMakeLists.txt
+++ b/components/esp_modem/examples/linux_modem/main/CMakeLists.txt
@@ -5,5 +5,9 @@ set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 target_link_libraries(${COMPONENT_LIB}  PRIVATE Threads::Threads)
 
-target_compile_features(${COMPONENT_LIB} PRIVATE cxx_std_17)
+set_target_properties(${COMPONENT_LIB} PROPERTIES
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED ON
+    CXX_EXTENSIONS ON
+)
 target_compile_definitions(${COMPONENT_LIB} PRIVATE "-DCONFIG_IDF_TARGET_LINUX")

--- a/components/esp_modem/idf_component.yml
+++ b/components/esp_modem/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.1.13"
+version: "0.1.14"
 description: esp modem
 dependencies:
   # Required IDF version

--- a/components/esp_modem/test/host_test/main/CMakeLists.txt
+++ b/components/esp_modem/test/host_test/main/CMakeLists.txt
@@ -6,5 +6,9 @@ set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 target_link_libraries(${COMPONENT_LIB}  PRIVATE Threads::Threads)
 
-target_compile_features(${COMPONENT_LIB} PRIVATE cxx_std_17)
+set_target_properties(${COMPONENT_LIB} PROPERTIES
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED ON
+    CXX_EXTENSIONS ON
+)
 target_compile_definitions(${COMPONENT_LIB} PRIVATE "-DCONFIG_IDF_TARGET_LINUX")

--- a/components/esp_modem/test/target/main/CMakeLists.txt
+++ b/components/esp_modem/test/target/main/CMakeLists.txt
@@ -3,4 +3,8 @@ idf_component_register(SRCS "pppd_test.cpp"
         INCLUDE_DIRS "$ENV{IDF_PATH}/tools/catch"
         REQUIRES esp_modem)
 
-target_compile_features(${COMPONENT_LIB} PRIVATE cxx_std_17)
+set_target_properties(${COMPONENT_LIB} PROPERTIES
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED ON
+    CXX_EXTENSIONS ON
+)


### PR DESCRIPTION
issue: https://gitlab.kitware.com/cmake/cmake/-/issues/23297

It should work since CMake 3.1 version (https://cmake.org/cmake/help/latest/prop_tgt/CXX_STANDARD.html)