### PR TITLE
esp_modem fix for SIM800 modem devices

### DIFF
--- a/components/esp_modem/examples/pppos_client/main/pppos_client_main.c
+++ b/components/esp_modem/examples/pppos_client/main/pppos_client_main.c
@@ -143,7 +143,21 @@ void app_main(void)
     // Init netif object
     esp_netif_t *esp_netif = esp_netif_new(&netif_ppp_config);
     assert(esp_netif);
+
+#if CONFIG_EXAMPLE_MODEM_DEVICE_BG96 == 1
+    ESP_LOGI(TAG, "Initializing esp_modem for the BG96 module...");
+    esp_modem_dce_t *dce = esp_modem_new_dev(ESP_MODEM_DCE_BG96, &dte_config, &dce_config, esp_netif);
+#elif CONFIG_EXAMPLE_MODEM_DEVICE_SIM800 == 1
+    ESP_LOGI(TAG, "Initializing esp_modem for the SIM800 module...");
+    esp_modem_dce_t *dce = esp_modem_new_dev(ESP_MODEM_DCE_SIM800, &dte_config, &dce_config, esp_netif);
+#elif CONFIG_EXAMPLE_MODEM_DEVICE_SIM7600 == 1
+    ESP_LOGI(TAG, "Initializing esp_modem for the SIM7600 module...");
+    esp_modem_dce_t *dce = esp_modem_new_dev(ESP_MODEM_DCE_SIM7600, &dte_config, &dce_config, esp_netif);
+#else
+    ESP_LOGI(TAG, "Initializing esp_modem for a generic module...");
     esp_modem_dce_t *dce = esp_modem_new(&dte_config, &dce_config, esp_netif);
+#endif
+    assert(dce);
 
 #if CONFIG_EXAMPLE_NEED_SIM_PIN == 1
     // check if PIN needed

--- a/components/esp_modem/src/esp_modem_command_library.cpp
+++ b/components/esp_modem/src/esp_modem_command_library.cpp
@@ -269,7 +269,7 @@ command_result set_data_mode(CommandableIf *t)
 command_result set_data_mode_sim8xx(CommandableIf *t)
 {
     ESP_LOGV(TAG, "%s", __func__ );
-    return generic_command(t, "ATD*99##\r", "CONNECT", "ERROR", 5000);
+    return generic_command(t, "ATD*99#\r", "CONNECT", "ERROR", 5000);
 }
 
 command_result resume_data_mode(CommandableIf *t)


### PR DESCRIPTION
This PR is meant to fix an issue experienced with the ‘pppos_client’ example in the ‘esp_modem’ library running on an ESP32 connected to a SIM800C module.

The ‘pppos_client’ example of the ‘esp_modem’ library was not working because of two reasons:

a) the AT command to start the PPP communication in the ‘esp_modem’ library was different from the one in the SIM800 Series AT Command Manual
b) the ‘pppos_client’ example was ignoring the type of modem device set through menuconfig

This fix should be compatible with all ESP32 chips and SIM800 series modules.