### PR TITLE
Feature/extended simcom support (IDFGH-7243)

### DIFF
--- a/components/esp_modem/include/cxx_include/esp_modem_api.hpp
+++ b/components/esp_modem/include/cxx_include/esp_modem_api.hpp
@@ -83,6 +83,11 @@ std::shared_ptr<DTE> create_vfs_dte(const dte_config *config);
 std::unique_ptr<DCE> create_SIM7600_dce(const dce_config *config, std::shared_ptr<DTE> dte, esp_netif_t *netif);
 
 /**
+ * @brief Create DCE based on SIM7070 module
+ */
+std::unique_ptr<DCE> create_SIM7070_dce(const dce_config *config, std::shared_ptr<DTE> dte, esp_netif_t *netif);
+
+/**
  * @brief Create DCE based on SIM800 module
  */
 std::unique_ptr<DCE> create_SIM800_dce(const dce_config *config, std::shared_ptr<DTE> dte, esp_netif_t *netif);

--- a/components/esp_modem/include/cxx_include/esp_modem_api.hpp
+++ b/components/esp_modem/include/cxx_include/esp_modem_api.hpp
@@ -88,6 +88,12 @@ std::unique_ptr<DCE> create_SIM7600_dce(const dce_config *config, std::shared_pt
 std::unique_ptr<DCE> create_SIM7070_dce(const dce_config *config, std::shared_ptr<DTE> dte, esp_netif_t *netif);
 
 /**
+ * @brief Create DCE based on SIM7000 module
+ */
+std::unique_ptr<DCE> create_SIM7000_dce(const dce_config *config, std::shared_ptr<DTE> dte, esp_netif_t *netif);
+
+
+/**
  * @brief Create DCE based on SIM800 module
  */
 std::unique_ptr<DCE> create_SIM800_dce(const dce_config *config, std::shared_ptr<DTE> dte, esp_netif_t *netif);

--- a/components/esp_modem/include/cxx_include/esp_modem_command_library.hpp
+++ b/components/esp_modem/include/cxx_include/esp_modem_command_library.hpp
@@ -44,8 +44,10 @@ DECLARE_ALL_COMMAND_APIS(declare name(Commandable *p, ...);)
  * @brief Following commands that are different for some specific modules
  */
 command_result get_battery_status_sim7xxx(CommandableIf *t, int &voltage, int &bcs, int &bcl);
+command_result set_gnss_power_mode_sim76xx(CommandableIf *t, int mode);
 command_result power_down_sim76xx(CommandableIf *t);
 command_result power_down_sim70xx(CommandableIf *t);
+command_result set_network_bands_sim76xx(CommandableIf *t, const std::string& mode, const int* bands, int size);
 command_result power_down_sim8xx(CommandableIf *t);
 command_result set_data_mode_sim8xx(CommandableIf *t);
 

--- a/components/esp_modem/include/cxx_include/esp_modem_command_library.hpp
+++ b/components/esp_modem/include/cxx_include/esp_modem_command_library.hpp
@@ -44,7 +44,8 @@ DECLARE_ALL_COMMAND_APIS(declare name(Commandable *p, ...);)
  * @brief Following commands that are different for some specific modules
  */
 command_result get_battery_status_sim7xxx(CommandableIf *t, int &voltage, int &bcs, int &bcl);
-command_result power_down_sim7xxx(CommandableIf *t);
+command_result power_down_sim7600(CommandableIf *t);
+command_result power_down_sim7070(CommandableIf *t);
 command_result power_down_sim8xx(CommandableIf *t);
 command_result set_data_mode_sim8xx(CommandableIf *t);
 

--- a/components/esp_modem/include/cxx_include/esp_modem_command_library.hpp
+++ b/components/esp_modem/include/cxx_include/esp_modem_command_library.hpp
@@ -44,8 +44,8 @@ DECLARE_ALL_COMMAND_APIS(declare name(Commandable *p, ...);)
  * @brief Following commands that are different for some specific modules
  */
 command_result get_battery_status_sim7xxx(CommandableIf *t, int &voltage, int &bcs, int &bcl);
-command_result power_down_sim7600(CommandableIf *t);
-command_result power_down_sim7070(CommandableIf *t);
+command_result power_down_sim76xx(CommandableIf *t);
+command_result power_down_sim70xx(CommandableIf *t);
 command_result power_down_sim8xx(CommandableIf *t);
 command_result set_data_mode_sim8xx(CommandableIf *t);
 

--- a/components/esp_modem/include/cxx_include/esp_modem_dce.hpp
+++ b/components/esp_modem/include/cxx_include/esp_modem_dce.hpp
@@ -34,7 +34,7 @@ namespace esp_modem {
  */
 class DCE_Mode {
 public:
-    DCE_Mode(): mode(modem_mode::COMMAND_MODE) {}
+    DCE_Mode(): mode(modem_mode::UNDEF) {}
     ~DCE_Mode() = default;
     bool set(DTE *dte, ModuleIf *module, Netif &netif, modem_mode m);
     modem_mode get();

--- a/components/esp_modem/include/cxx_include/esp_modem_dce_factory.hpp
+++ b/components/esp_modem/include/cxx_include/esp_modem_dce_factory.hpp
@@ -117,6 +117,7 @@ private:
 enum class ModemType {
     GenericModule,      /*!< Default generic module with the most common commands */
     SIM7600,            /*!< Derived from the GenericModule, specifics applied to SIM7600 model */
+    SIM7070,            /*!< Derived from the GenericModule, specifics applied to SIM7070 model */
     BG96,               /*!< Derived from the GenericModule, specifics applied to BG69 model */
     SIM800,             /*!< Derived from the GenericModule with specifics applied to SIM800 model */
 };
@@ -173,6 +174,8 @@ public:
             return build_shared_module<SIM800>(cfg, std::forward<Args>(args)...);
         case ModemType::SIM7600:
             return build_shared_module<SIM7600>(cfg, std::forward<Args>(args)...);
+        case ModemType::SIM7070:
+            return build_shared_module<SIM7070>(cfg, std::forward<Args>(args)...);
         case ModemType::BG96:
             return build_shared_module<BG96>(cfg, std::forward<Args>(args)...);
         case ModemType::GenericModule:
@@ -198,6 +201,8 @@ public:
             return build_unique<SIM800>(cfg, std::forward<Args>(args)...);
         case ModemType::SIM7600:
             return build_unique<SIM7600>(cfg, std::forward<Args>(args)...);
+        case ModemType::SIM7070:
+            return build_unique<SIM7070>(cfg, std::forward<Args>(args)...);
         case ModemType::BG96:
             return build_unique<BG96>(cfg, std::forward<Args>(args)...);
         case ModemType::GenericModule:
@@ -216,6 +221,8 @@ public:
             return build<SIM800>(cfg, std::forward<Args>(args)...);
         case ModemType::SIM7600:
             return build<SIM7600>(cfg, std::forward<Args>(args)...);
+        case ModemType::SIM7070:
+            return build<SIM7070>(cfg, std::forward<Args>(args)...);
         case ModemType::BG96:
             return build<BG96>(cfg, std::forward<Args>(args)...);
         case ModemType::GenericModule:

--- a/components/esp_modem/include/cxx_include/esp_modem_dce_factory.hpp
+++ b/components/esp_modem/include/cxx_include/esp_modem_dce_factory.hpp
@@ -118,6 +118,7 @@ enum class ModemType {
     GenericModule,      /*!< Default generic module with the most common commands */
     SIM7600,            /*!< Derived from the GenericModule, specifics applied to SIM7600 model */
     SIM7070,            /*!< Derived from the GenericModule, specifics applied to SIM7070 model */
+    SIM7000,            /*!< Derived from the GenericModule, specifics applied to SIM7000 model */
     BG96,               /*!< Derived from the GenericModule, specifics applied to BG69 model */
     SIM800,             /*!< Derived from the GenericModule with specifics applied to SIM800 model */
 };
@@ -176,6 +177,8 @@ public:
             return build_shared_module<SIM7600>(cfg, std::forward<Args>(args)...);
         case ModemType::SIM7070:
             return build_shared_module<SIM7070>(cfg, std::forward<Args>(args)...);
+        case ModemType::SIM7000:
+            return build_shared_module<SIM7000>(cfg, std::forward<Args>(args)...);
         case ModemType::BG96:
             return build_shared_module<BG96>(cfg, std::forward<Args>(args)...);
         case ModemType::GenericModule:
@@ -203,6 +206,8 @@ public:
             return build_unique<SIM7600>(cfg, std::forward<Args>(args)...);
         case ModemType::SIM7070:
             return build_unique<SIM7070>(cfg, std::forward<Args>(args)...);
+        case ModemType::SIM7000:
+            return build_unique<SIM7000>(cfg, std::forward<Args>(args)...);
         case ModemType::BG96:
             return build_unique<BG96>(cfg, std::forward<Args>(args)...);
         case ModemType::GenericModule:
@@ -223,6 +228,8 @@ public:
             return build<SIM7600>(cfg, std::forward<Args>(args)...);
         case ModemType::SIM7070:
             return build<SIM7070>(cfg, std::forward<Args>(args)...);
+        case ModemType::SIM7000:
+            return build<SIM7000>(cfg, std::forward<Args>(args)...);
         case ModemType::BG96:
             return build<BG96>(cfg, std::forward<Args>(args)...);
         case ModemType::GenericModule:

--- a/components/esp_modem/include/cxx_include/esp_modem_dce_module.hpp
+++ b/components/esp_modem/include/cxx_include/esp_modem_dce_module.hpp
@@ -121,6 +121,8 @@ class SIM7600: public GenericModule {
 public:
     command_result get_battery_status(int &voltage, int &bcs, int &bcl) override;
     command_result power_down() override;
+    command_result set_gnss_power_mode(int mode) override;
+    command_result set_network_bands(const std::string& mode, const int* bands, int size) override;
 };
 
 /**

--- a/components/esp_modem/include/cxx_include/esp_modem_dce_module.hpp
+++ b/components/esp_modem/include/cxx_include/esp_modem_dce_module.hpp
@@ -133,6 +133,15 @@ public:
 };
 
 /**
+ * @brief Specific definition of the SIM7000 module
+ */
+class SIM7000: public GenericModule {
+    using GenericModule::GenericModule;
+public:
+    command_result power_down() override;
+};
+
+/**
  * @brief Specific definition of the SIM800 module
  */
 class SIM800: public GenericModule {

--- a/components/esp_modem/include/cxx_include/esp_modem_dce_module.hpp
+++ b/components/esp_modem/include/cxx_include/esp_modem_dce_module.hpp
@@ -124,6 +124,15 @@ public:
 };
 
 /**
+ * @brief Specific definition of the SIM7070 module
+ */
+class SIM7070: public GenericModule {
+    using GenericModule::GenericModule;
+public:
+    command_result power_down() override;
+};
+
+/**
  * @brief Specific definition of the SIM800 module
  */
 class SIM800: public GenericModule {

--- a/components/esp_modem/include/esp_modem_c_api_types.h
+++ b/components/esp_modem/include/esp_modem_c_api_types.h
@@ -47,8 +47,9 @@ typedef enum esp_modem_dce_mode
 typedef enum esp_modem_dce_device
 {
     ESP_MODEM_DCE_GENETIC,  /**< The most generic device */
-    ESP_MODEM_DCE_SIM7070,
     ESP_MODEM_DCE_SIM7600,
+    ESP_MODEM_DCE_SIM7070,
+    ESP_MODEM_DCE_SIM7000,
     ESP_MODEM_DCE_BG96,
     ESP_MODEM_DCE_SIM800,
 } esp_modem_dce_device_t;

--- a/components/esp_modem/include/esp_modem_c_api_types.h
+++ b/components/esp_modem/include/esp_modem_c_api_types.h
@@ -47,6 +47,7 @@ typedef enum esp_modem_dce_mode
 typedef enum esp_modem_dce_device
 {
     ESP_MODEM_DCE_GENETIC,  /**< The most generic device */
+    ESP_MODEM_DCE_SIM7070,
     ESP_MODEM_DCE_SIM7600,
     ESP_MODEM_DCE_BG96,
     ESP_MODEM_DCE_SIM800,

--- a/components/esp_modem/include/generate/esp_modem_command_declare.inc
+++ b/components/esp_modem/include/generate/esp_modem_command_declare.inc
@@ -28,7 +28,7 @@
 #define BOOL_IN(param, name) const bool  _ARG(param, name)
 #define BOOL_OUT(param, name) bool&  _ARG(param, name)
 #define INT_OUT(param, name) int&  _ARG(param, name)
-#define LIST_IN(param, name) const int* _ARG(param, name)
+#define INTEGER_LIST_IN(param, name) const int* _ARG(param, name)
 
 #define STRUCT_OUT(struct_name, p1)  struct_name& p1
 #else
@@ -37,7 +37,7 @@
 #define BOOL_IN(param, name) const bool _ARG(param, name)
 #define BOOL_OUT(param, name) bool* _ARG(param, name)
 #define INT_OUT(param, name) int* _ARG(param, name)
-#define LIST_IN(param, name) const int* _ARG(param, name)
+#define INTEGER_LIST_IN(param, name) const int* _ARG(param, name)
 #define STRUCT_OUT(struct_name, p1)  struct struct_name* p1
 #endif
 
@@ -252,11 +252,6 @@ ESP_MODEM_DECLARE_DCE_COMMAND(get_radio_state, command_result, 1, INT_OUT(p1, st
 /**
  * @brief Set network mode
  * @param[in] mode preferred mode
- * -- SIM7xxx --
- * mode=2 - Automatic
- * mode=13 - GSM only
- * mode=38 - LTE only
- * mode=51 - GSM and LTE only
  * @return OK, FAIL or TIMEOUT
  */ \
 ESP_MODEM_DECLARE_DCE_COMMAND(set_network_mode, command_result, 1, INT_IN(p1, mode)) \
@@ -273,7 +268,7 @@ ESP_MODEM_DECLARE_DCE_COMMAND(set_preferred_mode, command_result, 1, INT_IN(p1, 
  * @param[in] mode CAT-M or NB-IoT
  * @return OK, FAIL or TIMEOUT
  */ \
-ESP_MODEM_DECLARE_DCE_COMMAND(set_network_bands, command_result, 3, STRING_IN(p1, mode), LIST_IN(p2, bands), INT_IN(p3, size)) \
+ESP_MODEM_DECLARE_DCE_COMMAND(set_network_bands, command_result, 3, STRING_IN(p1, mode), INTEGER_LIST_IN(p2, bands), INT_IN(p3, size)) \
     \
 /**
  * @brief Show network system mode

--- a/components/esp_modem/include/generate/esp_modem_command_declare.inc
+++ b/components/esp_modem/include/generate/esp_modem_command_declare.inc
@@ -28,6 +28,7 @@
 #define BOOL_IN(param, name) const bool  _ARG(param, name)
 #define BOOL_OUT(param, name) bool&  _ARG(param, name)
 #define INT_OUT(param, name) int&  _ARG(param, name)
+#define LIST_IN(param, name) const int* _ARG(param, name)
 
 #define STRUCT_OUT(struct_name, p1)  struct_name& p1
 #else
@@ -36,6 +37,7 @@
 #define BOOL_IN(param, name) const bool _ARG(param, name)
 #define BOOL_OUT(param, name) bool* _ARG(param, name)
 #define INT_OUT(param, name) int* _ARG(param, name)
+#define LIST_IN(param, name) const int* _ARG(param, name)
 #define STRUCT_OUT(struct_name, p1)  struct struct_name* p1
 #endif
 
@@ -200,7 +202,93 @@ ESP_MODEM_DECLARE_DCE_COMMAND(reset, command_result, 0) \
  * @param[in] baud Desired baud rate of the DTE
  * @return OK, FAIL or TIMEOUT
  */ \
-ESP_MODEM_DECLARE_DCE_COMMAND(set_baud, command_result, 1, INT_IN(p1, baud))
+ESP_MODEM_DECLARE_DCE_COMMAND(set_baud, command_result, 1, INT_IN(p1, baud)) \
+    \
+/**
+ * @brief Force an attempt to connect to a specific operator
+ * @param[in] mode mode of attempt
+ * mode=0 - automatic
+ * mode=1 - manual
+ * mode=2 - deregister
+ * mode=3 - set format for read operation
+ * mode=4 - manual with fallback to automatic
+ * @param[in] format what format the operator is given in
+ * format=0 - long format
+ * format=1 - short format
+ * format=2 - numeric
+ * @param[in] oper the operator to connect to
+ * @return OK, FAIL or TIMEOUT
+ */ \
+ESP_MODEM_DECLARE_DCE_COMMAND(set_operator, command_result, 3, INT_IN(p1, mode), INT_IN(p2, format), STRING_IN(p3, oper)) \
+    \
+/**
+ * @brief Attach or detach from the GPRS service
+ * @param[in] state 1-attach 0-detach
+ * @return OK, FAIL or TIMEOUT
+ */ \
+ESP_MODEM_DECLARE_DCE_COMMAND(set_network_attachment_state, command_result, 1, INT_IN(p1, state)) \
+    \
+/**
+ * @brief Get network attachment state
+ * @param[out] state 1-attached 0-detached
+ * @return OK, FAIL or TIMEOUT
+ */ \
+ESP_MODEM_DECLARE_DCE_COMMAND(get_network_attachment_state, command_result, 1, INT_OUT(p1, state)) \
+    \
+/**
+ * @brief What mode the radio should be set to
+ * @param[in] state state 1-full 0-minimum ...
+ * @return OK, FAIL or TIMEOUT
+ */ \
+ESP_MODEM_DECLARE_DCE_COMMAND(set_radio_state, command_result, 1, INT_IN(p1, state)) \
+    \
+/**
+ * @brief Get current radio state
+ * @param[out] state 1-full 0-minimum ...
+ * @return OK, FAIL or TIMEOUT
+ */ \
+ESP_MODEM_DECLARE_DCE_COMMAND(get_radio_state, command_result, 1, INT_OUT(p1, state)) \
+    \
+/**
+ * @brief Set network mode
+ * @param[in] mode preferred mode
+ * -- SIM7xxx --
+ * mode=2 - Automatic
+ * mode=13 - GSM only
+ * mode=38 - LTE only
+ * mode=51 - GSM and LTE only
+ * @return OK, FAIL or TIMEOUT
+ */ \
+ESP_MODEM_DECLARE_DCE_COMMAND(set_network_mode, command_result, 1, INT_IN(p1, mode)) \
+    \
+/**
+ * @brief Preferred network mode (CAT-M and/or NB-IoT)
+ * @param[in] mode preferred selection
+ * @return OK, FAIL or TIMEOUT
+ */ \
+ESP_MODEM_DECLARE_DCE_COMMAND(set_preferred_mode, command_result, 1, INT_IN(p1, mode)) \
+    \
+/**
+ * @brief Set network bands for CAT-M or NB-IoT
+ * @param[in] mode CAT-M or NB-IoT
+ * @return OK, FAIL or TIMEOUT
+ */ \
+ESP_MODEM_DECLARE_DCE_COMMAND(set_network_bands, command_result, 3, STRING_IN(p1, mode), LIST_IN(p2, bands), INT_IN(p3, size)) \
+    \
+/**
+ * @brief Show network system mode
+ * @param[out] mode current network mode
+ * @return OK, FAIL or TIMEOUT
+ */ \
+ESP_MODEM_DECLARE_DCE_COMMAND(get_network_system_mode, command_result, 1, INT_OUT(p1, mode)) \
+    \
+/**
+ * @brief GNSS power control
+ * @param[out] mode power mode (0 - off, 1 - on)
+ * @return OK, FAIL or TIMEOUT
+ */ \
+ESP_MODEM_DECLARE_DCE_COMMAND(set_gnss_power_mode, command_result, 1, INT_IN(p1, mode)) \
+    \
 
 
 #ifdef GENERATE_DOCS

--- a/components/esp_modem/src/esp_modem_api.cpp
+++ b/components/esp_modem/src/esp_modem_api.cpp
@@ -54,6 +54,11 @@ std::unique_ptr<DCE> create_SIM7600_dce(const dce_config *config, std::shared_pt
     return create_modem_dce(dce_factory::ModemType::SIM7600, config, std::move(dte), netif);
 }
 
+std::unique_ptr<DCE> create_SIM7070_dce(const dce_config *config, std::shared_ptr<DTE> dte, esp_netif_t *netif)
+{
+    return create_modem_dce(dce_factory::ModemType::SIM7070, config, std::move(dte), netif);
+}
+
 std::unique_ptr<DCE> create_SIM800_dce(const dce_config *config, std::shared_ptr<DTE> dte, esp_netif_t *netif)
 {
     return create_modem_dce(dce_factory::ModemType::SIM800, config, std::move(dte), netif);

--- a/components/esp_modem/src/esp_modem_api.cpp
+++ b/components/esp_modem/src/esp_modem_api.cpp
@@ -59,6 +59,11 @@ std::unique_ptr<DCE> create_SIM7070_dce(const dce_config *config, std::shared_pt
     return create_modem_dce(dce_factory::ModemType::SIM7070, config, std::move(dte), netif);
 }
 
+std::unique_ptr<DCE> create_SIM7000_dce(const dce_config *config, std::shared_ptr<DTE> dte, esp_netif_t *netif)
+{
+    return create_modem_dce(dce_factory::ModemType::SIM7000, config, std::move(dte), netif);
+}
+
 std::unique_ptr<DCE> create_SIM800_dce(const dce_config *config, std::shared_ptr<DTE> dte, esp_netif_t *netif)
 {
     return create_modem_dce(dce_factory::ModemType::SIM800, config, std::move(dte), netif);

--- a/components/esp_modem/src/esp_modem_c_api.cpp
+++ b/components/esp_modem/src/esp_modem_c_api.cpp
@@ -271,3 +271,100 @@ extern "C" esp_err_t esp_modem_power_down(esp_modem_dce_t *dce_wrap)
     }
     return command_response_to_esp_err(dce_wrap->dce->power_down());
 }
+
+extern "C" esp_err_t esp_modem_set_operator(esp_modem_dce_t *dce_wrap, int mode, int format, const char* oper)
+{
+    if (dce_wrap == nullptr || dce_wrap->dce == nullptr) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    std::string operator_str = std::string(oper);
+    return command_response_to_esp_err(dce_wrap->dce->set_operator(mode, format, operator_str));
+}
+
+extern "C" esp_err_t esp_modem_set_network_attachment_state(esp_modem_dce_t *dce_wrap, int state)
+{
+    if (dce_wrap == nullptr || dce_wrap->dce == nullptr) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    return command_response_to_esp_err(dce_wrap->dce->set_network_attachment_state(state));
+}
+
+extern "C" esp_err_t esp_modem_get_network_attachment_state(esp_modem_dce_t *dce_wrap, int *p_state)
+{
+    if (dce_wrap == nullptr || dce_wrap->dce == nullptr) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    int state;
+    auto ret = command_response_to_esp_err(dce_wrap->dce->get_network_attachment_state(state));
+    if (ret == ESP_OK) {
+        *p_state = state;
+    }
+    return ret;
+}
+
+extern "C" esp_err_t esp_modem_set_radio_state(esp_modem_dce_t *dce_wrap, int state)
+{
+    if (dce_wrap == nullptr || dce_wrap->dce == nullptr) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    return command_response_to_esp_err(dce_wrap->dce->set_radio_state(state));
+}
+
+extern "C" esp_err_t esp_modem_get_radio_state(esp_modem_dce_t *dce_wrap, int *p_state)
+{
+    if (dce_wrap == nullptr || dce_wrap->dce == nullptr) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    int state;
+    auto ret = command_response_to_esp_err(dce_wrap->dce->get_radio_state(state));
+    if (ret == ESP_OK) {
+        *p_state = state;
+    }
+    return ret;
+}
+
+extern "C" esp_err_t esp_modem_set_network_mode(esp_modem_dce_t *dce_wrap, int mode)
+{
+    if (dce_wrap == nullptr || dce_wrap->dce == nullptr) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    return command_response_to_esp_err(dce_wrap->dce->set_network_mode(mode));
+}
+
+extern "C" esp_err_t esp_modem_set_preferred_mode(esp_modem_dce_t *dce_wrap, int mode)
+{
+    if (dce_wrap == nullptr || dce_wrap->dce == nullptr) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    return command_response_to_esp_err(dce_wrap->dce->set_preferred_mode(mode));
+}
+
+extern "C" esp_err_t esp_modem_set_network_bands(esp_modem_dce_t *dce_wrap, const char* mode, const int* bands, int size)
+{
+    if (dce_wrap == nullptr || dce_wrap->dce == nullptr) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    std::string mode_str = std::string(mode);
+    return command_response_to_esp_err(dce_wrap->dce->set_network_bands(mode, bands, size));
+}
+
+extern "C" esp_err_t esp_modem_get_network_system_mode(esp_modem_dce_t *dce_wrap, int* p_mode)
+{
+    if (dce_wrap == nullptr || dce_wrap->dce == nullptr) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    int mode;
+    auto ret = command_response_to_esp_err(dce_wrap->dce->get_network_system_mode(mode));
+    if (ret == ESP_OK) {
+        *p_mode = mode;
+    }
+    return ret;
+}
+
+extern "C" esp_err_t esp_modem_set_gnss_power_mode(esp_modem_dce_t *dce_wrap, int mode)
+{
+    if (dce_wrap == nullptr || dce_wrap->dce == nullptr) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    return command_response_to_esp_err(dce_wrap->dce->set_gnss_power_mode(mode));
+}

--- a/components/esp_modem/src/esp_modem_c_api.cpp
+++ b/components/esp_modem/src/esp_modem_c_api.cpp
@@ -281,7 +281,7 @@ extern "C" esp_err_t esp_modem_set_operator(esp_modem_dce_t *dce_wrap, int mode,
     if (dce_wrap == nullptr || dce_wrap->dce == nullptr) {
         return ESP_ERR_INVALID_ARG;
     }
-    std::string operator_str = std::string(oper);
+    std::string operator_str(oper);
     return command_response_to_esp_err(dce_wrap->dce->set_operator(mode, format, operator_str));
 }
 
@@ -348,7 +348,7 @@ extern "C" esp_err_t esp_modem_set_network_bands(esp_modem_dce_t *dce_wrap, cons
     if (dce_wrap == nullptr || dce_wrap->dce == nullptr) {
         return ESP_ERR_INVALID_ARG;
     }
-    std::string mode_str = std::string(mode);
+    std::string mode_str(mode);
     return command_response_to_esp_err(dce_wrap->dce->set_network_bands(mode, bands, size));
 }
 

--- a/components/esp_modem/src/esp_modem_c_api.cpp
+++ b/components/esp_modem/src/esp_modem_c_api.cpp
@@ -59,6 +59,8 @@ static inline dce_factory::ModemType convert_modem_enum(esp_modem_dce_device_t m
     switch (module) {
     case ESP_MODEM_DCE_SIM7600:
         return esp_modem::dce_factory::ModemType::SIM7600;
+    case ESP_MODEM_DCE_SIM7070:
+        return esp_modem::dce_factory::ModemType::SIM7070;
     case ESP_MODEM_DCE_BG96:
         return esp_modem::dce_factory::ModemType::BG96;
     case ESP_MODEM_DCE_SIM800:

--- a/components/esp_modem/src/esp_modem_c_api.cpp
+++ b/components/esp_modem/src/esp_modem_c_api.cpp
@@ -61,6 +61,8 @@ static inline dce_factory::ModemType convert_modem_enum(esp_modem_dce_device_t m
         return esp_modem::dce_factory::ModemType::SIM7600;
     case ESP_MODEM_DCE_SIM7070:
         return esp_modem::dce_factory::ModemType::SIM7070;
+    case ESP_MODEM_DCE_SIM7000:
+        return esp_modem::dce_factory::ModemType::SIM7000;
     case ESP_MODEM_DCE_BG96:
         return esp_modem::dce_factory::ModemType::BG96;
     case ESP_MODEM_DCE_SIM800:

--- a/components/esp_modem/src/esp_modem_command_library.cpp
+++ b/components/esp_modem/src/esp_modem_command_library.cpp
@@ -482,7 +482,7 @@ command_result set_network_bands(CommandableIf *t, const std::string& mode, cons
 {
     ESP_LOGV(TAG, "%s", __func__ );
     std::string band_string = "";
-    for (int i = 0; i<size-1; i++){
+    for (int i = 0; i<size-1; ++i){
         band_string += std::to_string(bands[i]) + ",";
     }
     band_string += std::to_string(bands[size-1]);
@@ -493,7 +493,7 @@ command_result set_network_bands(CommandableIf *t, const std::string& mode, cons
 command_result set_network_bands_sim76xx(CommandableIf *t, const std::string& mode, const int* bands, int size)
 {
     ESP_LOGV(TAG, "%s", __func__ );
-    std::string any_mode = "0xFFFFFFFF7FFFFFFF";
+    //std::string any_mode = "0xFFFFFFFF7FFFFFFF";
     uint64_t band_bits = 0;
     for (int i = 0; i<size; ++i) {
         // OR-operation to add bands
@@ -501,8 +501,8 @@ command_result set_network_bands_sim76xx(CommandableIf *t, const std::string& mo
     }
     std::stringstream stream;
     stream << "0x" << std::setfill('0') << std::setw(16) << std::hex << band_bits;
-    std::string band_string = stream.str();
-    return generic_command_common(t, "AT+CNBP=" + any_mode + "," + band_string + "\r");
+    std::string band_string(stream.str());
+    return generic_command_common(t, "AT+CNBP=" + mode + "," + band_string + "\r");
 }
 
 command_result get_network_system_mode(CommandableIf *t, int &mode)

--- a/components/esp_modem/src/esp_modem_command_library.cpp
+++ b/components/esp_modem/src/esp_modem_command_library.cpp
@@ -18,6 +18,7 @@
 #include "cxx_include/esp_modem_dte.hpp"
 #include "cxx_include/esp_modem_dce_module.hpp"
 #include "cxx_include/esp_modem_command_library.hpp"
+#include <iomanip>
 
 namespace esp_modem::dce_commands {
 
@@ -489,6 +490,21 @@ command_result set_network_bands(CommandableIf *t, const std::string& mode, cons
     return generic_command_common(t, "AT+CBANDCFG=\"" + mode + "\"," + band_string + "\r");
 }
 
+command_result set_network_bands_sim76xx(CommandableIf *t, const std::string& mode, const int* bands, int size)
+{
+    ESP_LOGV(TAG, "%s", __func__ );
+    std::string any_mode = "0xFFFFFFFF7FFFFFFF";
+    uint64_t band_bits = 0;
+    for (int i = 0; i<size; ++i) {
+        // OR-operation to add bands
+        band_bits |= 1 << bands[i];
+    }
+    std::stringstream stream;
+    stream << "0x" << std::setfill('0') << std::setw(16) << std::hex << band_bits;
+    std::string band_string = stream.str();
+    return generic_command_common(t, "AT+CNBP=" + any_mode + "," + band_string + "\r");
+}
+
 command_result get_network_system_mode(CommandableIf *t, int &mode)
 {
     ESP_LOGV(TAG, "%s", __func__ );
@@ -515,6 +531,12 @@ command_result set_gnss_power_mode(CommandableIf *t, int mode)
 {
     ESP_LOGV(TAG, "%s", __func__ );
     return generic_command_common(t, "AT+CGNSPWR=" + std::to_string(mode) + "\r");
+}
+
+command_result set_gnss_power_mode_sim76xx(CommandableIf *t, int mode)
+{
+    ESP_LOGV(TAG, "%s", __func__ );
+    return generic_command_common(t, "AT+CGPS=" + std::to_string(mode) + "\r");
 }
 
 } // esp_modem::dce_commands

--- a/components/esp_modem/src/esp_modem_command_library.cpp
+++ b/components/esp_modem/src/esp_modem_command_library.cpp
@@ -121,13 +121,13 @@ command_result power_down(CommandableIf *t)
     return generic_command(t, "AT+QPOWD=1\r", "POWERED DOWN", "ERROR", 1000);
 }
 
-command_result power_down_sim7600(CommandableIf *t)
+command_result power_down_sim76xx(CommandableIf *t)
 {
     ESP_LOGV(TAG, "%s", __func__ );
     return generic_command_common(t, "AT+CPOF\r", 1000);
 }
 
-command_result power_down_sim7070(CommandableIf *t)
+command_result power_down_sim70xx(CommandableIf *t)
 {
     ESP_LOGV(TAG, "%s", __func__ );
     return generic_command(t, "AT+CPOWD=1\r", "POWER DOWN", "ERROR", 1000);

--- a/components/esp_modem/src/esp_modem_command_library.cpp
+++ b/components/esp_modem/src/esp_modem_command_library.cpp
@@ -121,10 +121,16 @@ command_result power_down(CommandableIf *t)
     return generic_command(t, "AT+QPOWD=1\r", "POWERED DOWN", "ERROR", 1000);
 }
 
-command_result power_down_sim7xxx(CommandableIf *t)
+command_result power_down_sim7600(CommandableIf *t)
 {
     ESP_LOGV(TAG, "%s", __func__ );
     return generic_command_common(t, "AT+CPOF\r", 1000);
+}
+
+command_result power_down_sim7070(CommandableIf *t)
+{
+    ESP_LOGV(TAG, "%s", __func__ );
+    return generic_command(t, "AT+CPOWD=1\r", "POWER DOWN", "ERROR", 1000);
 }
 
 command_result power_down_sim8xx(CommandableIf *t)

--- a/components/esp_modem/src/esp_modem_command_library.cpp
+++ b/components/esp_modem/src/esp_modem_command_library.cpp
@@ -490,10 +490,11 @@ command_result set_network_bands(CommandableIf *t, const std::string& mode, cons
     return generic_command_common(t, "AT+CBANDCFG=\"" + mode + "\"," + band_string + "\r");
 }
 
+// mode is expected to be 64bit string (in hex)
+// any_mode = "0xFFFFFFFF7FFFFFFF";
 command_result set_network_bands_sim76xx(CommandableIf *t, const std::string& mode, const int* bands, int size)
 {
     ESP_LOGV(TAG, "%s", __func__ );
-    //std::string any_mode = "0xFFFFFFFF7FFFFFFF";
     uint64_t band_bits = 0;
     for (int i = 0; i<size; ++i) {
         // OR-operation to add bands

--- a/components/esp_modem/src/esp_modem_command_library.cpp
+++ b/components/esp_modem/src/esp_modem_command_library.cpp
@@ -399,4 +399,116 @@ command_result get_signal_quality(CommandableIf *t, int &rssi, int &ber)
     return command_result::OK;
 }
 
+command_result set_operator(CommandableIf *t, int mode, int format, const std::string& oper)
+{
+    ESP_LOGV(TAG, "%s", __func__ );
+    return generic_command_common(t, "AT+COPS=" + std::to_string(mode) + "," + std::to_string(format) + ",\"" + oper + "\"\r", 90000);
+}
+
+command_result set_network_attachment_state(CommandableIf *t, int state)
+{
+    ESP_LOGV(TAG, "%s", __func__ );
+    return generic_command_common(t, "AT+CGATT=" + std::to_string(state) + "\r");
+}
+
+command_result get_network_attachment_state(CommandableIf *t, int &state)
+{
+    ESP_LOGV(TAG, "%s", __func__ );
+    std::string_view out;
+    auto ret = generic_get_string(t, "AT+CGATT?\r", out);
+    if (ret != command_result::OK) {
+        return ret;
+    }
+    constexpr std::string_view pattern = "+CGATT: ";
+    constexpr int pos = pattern.size();
+    if (out.find(pattern) == std::string::npos) {
+        return command_result::FAIL;
+    }
+
+    if (std::from_chars(out.data() + pos, out.data() + out.size(), state).ec == std::errc::invalid_argument) {
+        return command_result::FAIL;
+    }
+
+    return command_result::OK;
+}
+
+command_result set_radio_state(CommandableIf *t, int state)
+{
+    ESP_LOGV(TAG, "%s", __func__ );
+    return generic_command_common(t, "AT+CFUN=" + std::to_string(state) + "\r");
+}
+
+command_result get_radio_state(CommandableIf *t, int &state)
+{
+    ESP_LOGV(TAG, "%s", __func__ );
+    std::string_view out;
+    auto ret = generic_get_string(t, "AT+CFUN?\r", out);
+    if (ret != command_result::OK) {
+        return ret;
+    }
+    constexpr std::string_view pattern = "+CFUN: ";
+    constexpr int pos = pattern.size();
+    if (out.find(pattern) == std::string::npos) {
+        return command_result::FAIL;
+    }
+
+    if (std::from_chars(out.data() + pos, out.data() + out.size(), state).ec == std::errc::invalid_argument) {
+        return command_result::FAIL;
+    }
+
+    return command_result::OK;
+}
+
+command_result set_network_mode(CommandableIf *t, int mode)
+{
+    ESP_LOGV(TAG, "%s", __func__ );
+    return generic_command_common(t, "AT+CNMP=" + std::to_string(mode) + "\r");
+}
+
+command_result set_preferred_mode(CommandableIf *t, int mode)
+{
+    ESP_LOGV(TAG, "%s", __func__ );
+    return generic_command_common(t, "AT+CMNB=" + std::to_string(mode) + "\r");
+}
+
+command_result set_network_bands(CommandableIf *t, const std::string& mode, const int* bands, int size)
+{
+    ESP_LOGV(TAG, "%s", __func__ );
+    std::string band_string = "";
+    for (int i = 0; i<size-1; i++){
+        band_string += std::to_string(bands[i]) + ",";
+    }
+    band_string += std::to_string(bands[size-1]);
+    
+    return generic_command_common(t, "AT+CBANDCFG=\"" + mode + "\"," + band_string + "\r");
+}
+
+command_result get_network_system_mode(CommandableIf *t, int &mode)
+{
+    ESP_LOGV(TAG, "%s", __func__ );
+    std::string_view out;
+    auto ret = generic_get_string(t, "AT+CNSMOD?\r", out);
+    if (ret != command_result::OK) {
+        return ret;
+    }
+
+    constexpr std::string_view pattern = "+CNSMOD: ";
+    int mode_pos = out.find(",") + 1; // Skip "<n>,"
+    if (out.find(pattern) == std::string::npos) {
+        return command_result::FAIL;
+    }
+
+    if (std::from_chars(out.data() + mode_pos, out.data() + out.size(), mode).ec == std::errc::invalid_argument) {
+        return command_result::FAIL;
+    }
+
+    return command_result::OK;
+}
+
+command_result set_gnss_power_mode(CommandableIf *t, int mode)
+{
+    ESP_LOGV(TAG, "%s", __func__ );
+    return generic_command_common(t, "AT+CGNSPWR=" + std::to_string(mode) + "\r");
+}
+
 } // esp_modem::dce_commands

--- a/components/esp_modem/src/esp_modem_modules.cpp
+++ b/components/esp_modem/src/esp_modem_modules.cpp
@@ -57,12 +57,17 @@ command_result SIM7600::get_battery_status(int &voltage, int &bcs, int &bcl)
 
 command_result SIM7600::power_down()
 {
-    return dce_commands::power_down_sim7600(dte.get());
+    return dce_commands::power_down_sim76xx(dte.get());
 }
 
 command_result SIM7070::power_down()
 {
-    return dce_commands::power_down_sim7070(dte.get());
+    return dce_commands::power_down_sim70xx(dte.get());
+}
+
+command_result SIM7000::power_down()
+{
+    return dce_commands::power_down_sim70xx(dte.get());
 }
 
 command_result SIM800::power_down()

--- a/components/esp_modem/src/esp_modem_modules.cpp
+++ b/components/esp_modem/src/esp_modem_modules.cpp
@@ -57,7 +57,12 @@ command_result SIM7600::get_battery_status(int &voltage, int &bcs, int &bcl)
 
 command_result SIM7600::power_down()
 {
-    return dce_commands::power_down_sim7xxx(dte.get());
+    return dce_commands::power_down_sim7600(dte.get());
+}
+
+command_result SIM7070::power_down()
+{
+    return dce_commands::power_down_sim7070(dte.get());
 }
 
 command_result SIM800::power_down()

--- a/components/esp_modem/src/esp_modem_modules.cpp
+++ b/components/esp_modem/src/esp_modem_modules.cpp
@@ -60,6 +60,16 @@ command_result SIM7600::power_down()
     return dce_commands::power_down_sim76xx(dte.get());
 }
 
+command_result SIM7600::set_network_bands(const std::string& mode, const int* bands, int size)
+{
+    return dce_commands::set_network_bands_sim76xx(dte.get(), mode, bands, size);
+}
+
+command_result SIM7600::power_down()
+{
+    return dce_commands::power_down_sim76xx(dte.get());
+}
+
 command_result SIM7070::power_down()
 {
     return dce_commands::power_down_sim70xx(dte.get());

--- a/components/esp_modem/src/esp_modem_modules.cpp
+++ b/components/esp_modem/src/esp_modem_modules.cpp
@@ -55,14 +55,14 @@ command_result SIM7600::get_battery_status(int &voltage, int &bcs, int &bcl)
     return dce_commands::get_battery_status_sim7xxx(dte.get(), voltage, bcs, bcl);
 }
 
-command_result SIM7600::power_down()
-{
-    return dce_commands::power_down_sim76xx(dte.get());
-}
-
 command_result SIM7600::set_network_bands(const std::string& mode, const int* bands, int size)
 {
     return dce_commands::set_network_bands_sim76xx(dte.get(), mode, bands, size);
+}
+
+command_result SIM7600::set_gnss_power_mode(int mode)
+{
+    return dce_commands::set_gnss_power_mode_sim76xx(dte.get(), mode);
 }
 
 command_result SIM7600::power_down()

--- a/components/esp_modem/test/host_test/main/test_modem.cpp
+++ b/components/esp_modem/test/host_test/main/test_modem.cpp
@@ -128,6 +128,7 @@ TEST_CASE("DCE modes", "[esp_modem]")
     auto dce = create_SIM7600_dce(&dce_config, dte, &netif);
     CHECK(dce != nullptr);
 
+    CHECK(dce->set_mode(esp_modem::modem_mode::COMMAND_MODE) == true);
     CHECK(dce->set_mode(esp_modem::modem_mode::COMMAND_MODE) == false);
     CHECK(dce->set_mode(esp_modem::modem_mode::DATA_MODE) == true);
     CHECK(dce->set_mode(esp_modem::modem_mode::COMMAND_MODE) == true);


### PR DESCRIPTION
## Changes
- Added lists to esp_modem_command_declare.inc
- Extended command library to include many commonly used AT commands (using simcom modules as a base)
- Added SIM7070, SIM7000 and extended SIM7600 classes
  - Tested both C and C++ APIs
- Changed initial modem_mode to be set to UNDEF
  - In case of mcu restart without modem restart, which could make the modem be stuck in data mode