### PR TITLE
fix(esp_modem): Correction of switching to CMUX mode

### DIFF
--- a/components/esp_modem/src/esp_modem_cmux.cpp
+++ b/components/esp_modem/src/esp_modem_cmux.cpp
@@ -103,7 +103,7 @@ struct CMux::CMuxFrame {
 
 void CMux::data_available(uint8_t *data, size_t len)
 {
-    if (data && type == 0xFF && len > 0 && dlci > 0) {
+    if (data && (type&FT_UIH) == FT_UIH && len > 0 && dlci > 0) { // valid payload on a virtual term
         int virtual_term = dlci - 1;
         if (virtual_term < MAX_TERMINALS_NUM && read_cb[virtual_term]) {
             // Post partial data (or defragment to post on CMUX footer)

--- a/components/esp_modem/src/esp_modem_dce.cpp
+++ b/components/esp_modem/src/esp_modem_dce.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <unistd.h>
+
 #include "cxx_include/esp_modem_dte.hpp"
 #include "cxx_include/esp_modem_dce.hpp"
 #include "esp_log.h"
@@ -63,7 +65,9 @@ bool DCE_Mode::set(DTE *dte, ModuleIf *device, Netif &netif, modem_mode m)
         if (mode == modem_mode::DATA_MODE || mode == modem_mode::CMUX_MODE) {
             return false;
         }
-        device->set_mode(modem_mode::CMUX_MODE);
+        device->set_mode(modem_mode::CMUX_MODE);    // switch the device into CMUX mode
+        usleep(100'000);                            // some devices need a few ms to switch
+
         if (!dte->set_mode(modem_mode::CMUX_MODE)) {
             return false;
         }


### PR DESCRIPTION
* BG96 needs a small pause between CMUX command reception and actual use
of the CMUX mode
* Correct CMUX payload reception to check FT_UIH message type (P/F flag
could be cleared or set)

Closes https://github.com/espressif/esp-protocols/issues/33