### PR TITLE
feat(websocket): Optimize memory size for websocket client init (IDFGH-7357)

### DIFF
--- a/components/esp_websocket_client/Kconfig
+++ b/components/esp_websocket_client/Kconfig
@@ -1,0 +1,10 @@
+menu "ESP WebSocket client"
+
+    config ESP_WS_CLIENT_ENABLE_DYNAMIC_BUFFER
+        bool "Enable websocket client dynamic buffer for send and receive data"
+        default n
+        help
+            Enable this option will reallocated buffer when send or receive data and free them when end of use.
+            This can save about 2 KB memory when no websocket data send and receive.
+
+endmenu


### PR DESCRIPTION
- Remove the unused transport. For example, if the connection is Websocket over TCP, we only need ws and tcp transport, no need wss and ssl transport.
- Make the tx buffer and rx buffer malloc dynamic.

This can save about 3 KB memory when no data send and receive.