### PR TITLE
typo (IDFGH-7360)

### DIFF
--- a/components/esp_modem/examples/simple_cmux_client/main/simple_cmux_client_main.cpp
+++ b/components/esp_modem/examples/simple_cmux_client/main/simple_cmux_client_main.cpp
@@ -70,9 +70,9 @@ extern "C" void app_main(void)
 #if CONFIG_EXAMPLE_MODEM_DEVICE_BG96 == 1
     std::unique_ptr<DCE> dce = create_BG96_dce(&dce_config, dte, esp_netif);
 #elif CONFIG_EXAMPLE_MODEM_DEVICE_SIM800 == 1
-    std::unique_ptr<DCE> dce = create_SIM800_dce(&dce_config, uart_dte, esp_netif);
+    std::unique_ptr<DCE> dce = create_SIM800_dce(&dce_config, dte, esp_netif);
 #elif CONFIG_EXAMPLE_MODEM_DEVICE_SIM7600 == 1
-    std::unique_ptr<DCE> dce = create_SIM7600_dce(&dce_config, uart_dte, esp_netif);
+    std::unique_ptr<DCE> dce = create_SIM7600_dce(&dce_config, dte, esp_netif);
 #else
 #error "Unsupported device"
 #endif


### PR DESCRIPTION
there is a Typo in the Code. dte not uart_dte