### PR TITLE
feat(websocket): allow users to attach CA bundle (IDFGH-7520)

### DIFF
--- a/components/esp_websocket_client/esp_websocket_client.c
+++ b/components/esp_websocket_client/esp_websocket_client.c
@@ -392,6 +392,15 @@ esp_websocket_client_handle_t esp_websocket_client_init(const esp_websocket_clie
             esp_transport_ssl_set_client_key_data_der(ssl, config->client_key, config->client_key_len);
         }
     }
+
+    if (config->crt_bundle_attach) {
+#ifdef CONFIG_MBEDTLS_CERTIFICATE_BUNDLE
+        esp_transport_ssl_crt_bundle_attach(ssl, config->crt_bundle_attach);
+#else //CONFIG_MBEDTLS_CERTIFICATE_BUNDLE
+        ESP_LOGE(TAG, "crt_bundle_attach configured but not enabled in menuconfig: Please enable MBEDTLS_CERTIFICATE_BUNDLE option");
+#endif
+    }
+
     if (config->skip_cert_common_name_check) {
         esp_transport_ssl_skip_common_name_check(ssl);
     }

--- a/components/esp_websocket_client/include/esp_websocket_client.h
+++ b/components/esp_websocket_client/include/esp_websocket_client.h
@@ -88,6 +88,7 @@ typedef struct {
     int                         pingpong_timeout_sec;       /*!< Period before connection is aborted due to no PONGs received */
     bool                        disable_pingpong_discon;    /*!< Disable auto-disconnect due to no PONG received within pingpong_timeout_sec */
     bool                        use_global_ca_store;        /*!< Use a global ca_store for all the connections in which this bool is set. */
+    esp_err_t (*crt_bundle_attach)(void *conf);             /*!< Function pointer to esp_crt_bundle_attach. Enables the use of certification bundle for server verification, MBEDTLS_CERTIFICATE_BUNDLE must be enabled in menuconfig. Include esp_crt_bundle.h, and use `esp_crt_bundle_attach` here to include bundled CA certificates. */
     bool                        skip_cert_common_name_check;/*!< Skip any validation of server certificate CN field */
     bool                        keep_alive_enable;          /*!< Enable keep-alive timeout */
     int                         keep_alive_idle;            /*!< Keep-alive idle time. Default is 5 (second) */


### PR DESCRIPTION
with esp_transport_ssl_crt_bundle_attach(), it is not necessary to
include a specific certificate. other protocol clients, such as
esp_http_client, do the same.

fixes #48