### PR TITLE
Add esp_tls option to skip server verification (IDFGH-7794)

### DIFF
--- a/components/esp_websocket_client/esp_websocket_client.c
+++ b/components/esp_websocket_client/esp_websocket_client.c
@@ -82,13 +82,14 @@ typedef struct {
     int                         pingpong_timeout_sec;
     size_t                      ping_interval_sec;
     const char                  *cert;
-    size_t                      cert_len;                
+    size_t                      cert_len;
     const char                  *client_cert;
     size_t                      client_cert_len;
     const char                  *client_key;
     size_t                      client_key_len;
     bool                        use_global_ca_store;
     bool                        skip_cert_common_name_check;
+    bool                        skip_server_verification;
     esp_err_t                   (*crt_bundle_attach)(void *conf);
 } websocket_config_storage_t;
 
@@ -431,6 +432,9 @@ static esp_err_t esp_websocket_client_create_transport(esp_websocket_client_hand
         if (client->config->skip_cert_common_name_check) {
             esp_transport_ssl_skip_common_name_check(ssl);
         }
+        if (client->config->skip_server_verification) {
+            esp_transport_ssl_skip_server_verification(ssl);
+        }
 
         esp_transport_handle_t wss = esp_transport_ws_init(ssl);
         ESP_WS_CLIENT_MEM_CHECK(TAG, wss, return ESP_ERR_NO_MEM);
@@ -505,6 +509,7 @@ esp_websocket_client_handle_t esp_websocket_client_init(const esp_websocket_clie
     client->config->client_key = config->client_key;
     client->config->client_key_len = config->client_key_len;
     client->config->skip_cert_common_name_check = config->skip_cert_common_name_check;
+    client->config->skip_server_verification = config->skip_server_verification;
     client->config->crt_bundle_attach = config->crt_bundle_attach;
 
     if (config->uri) {

--- a/components/esp_websocket_client/include/esp_websocket_client.h
+++ b/components/esp_websocket_client/include/esp_websocket_client.h
@@ -90,6 +90,7 @@ typedef struct {
     bool                        use_global_ca_store;        /*!< Use a global ca_store for all the connections in which this bool is set. */
     esp_err_t (*crt_bundle_attach)(void *conf);             /*!< Function pointer to esp_crt_bundle_attach. Enables the use of certification bundle for server verification, MBEDTLS_CERTIFICATE_BUNDLE must be enabled in menuconfig. Include esp_crt_bundle.h, and use `esp_crt_bundle_attach` here to include bundled CA certificates. */
     bool                        skip_cert_common_name_check;/*!< Skip any validation of server certificate CN field */
+    bool                        skip_server_verification;   /*!< Skip server verification completely. Should only be used for debugging */
     bool                        keep_alive_enable;          /*!< Enable keep-alive timeout */
     int                         keep_alive_idle;            /*!< Keep-alive idle time. Default is 5 (second) */
     int                         keep_alive_interval;        /*!< Keep-alive interval time. Default is 5 (second) */


### PR DESCRIPTION
I added a tls option to skip server verification completely for debugging purposes without turning on the dangerous compile time flag `CONFIG_ESP_TLS_SKIP_SERVER_CERT_VERIFY`.

This pull request needs another pull request of mine be merged first:
https://github.com/espressif/esp-idf/pull/9147