### PR TITLE
protocol_examples_common: Updated to explicitly use esp-eth dependency if needed

### DIFF
--- a/common_components/protocol_examples_common/CMakeLists.txt
+++ b/common_components/protocol_examples_common/CMakeLists.txt
@@ -1,4 +1,4 @@
 idf_component_register(SRCS "connect.c" "stdin_out.c" "addr_from_stdin.c"
                     INCLUDE_DIRS "include"
-                    PRIV_REQUIRES esp_netif driver
+                    PRIV_REQUIRES esp_netif driver esp_eth
                     )

--- a/common_components/protocol_examples_common/include/protocol_examples_common.h
+++ b/common_components/protocol_examples_common/include/protocol_examples_common.h
@@ -15,6 +15,7 @@ extern "C" {
 
 #include "esp_err.h"
 #include "esp_netif.h"
+#include "esp_eth.h"
 
 #ifdef CONFIG_EXAMPLE_CONNECT_ETHERNET
 #define EXAMPLE_INTERFACE get_example_netif()


### PR DESCRIPTION
Updated to explicitly use esp-eth dependency if needed

* Original commit: espressif/esp-idf@5e19b9c9518ae253d82400ab24b86af8af832425