### PR TITLE
Allow to customize uart source_clk (IDFGH-7659)

### DIFF
--- a/components/esp_modem/include/esp_modem_config.h
+++ b/components/esp_modem/include/esp_modem_config.h
@@ -50,7 +50,8 @@ struct esp_modem_uart_term_config {
     uart_stop_bits_t stop_bits;     /*!< Stop bits of UART */
     uart_parity_t parity;           /*!< Parity type */
     esp_modem_flow_ctrl_t flow_control; /*!< Flow control type */
-    int baud_rate;             /*!< Communication baud rate */
+    uart_sclk_t source_clk;         /*!< UART source clock selection */
+    int baud_rate;                  /*!< Communication baud rate */
     int tx_io_num;                  /*!< TXD Pin Number */
     int rx_io_num;                  /*!< RXD Pin Number */
     int rts_io_num;                 /*!< RTS Pin Number */
@@ -107,6 +108,7 @@ struct esp_modem_dte_config {
             .stop_bits = UART_STOP_BITS_1,          \
             .parity = UART_PARITY_DISABLE,          \
             .flow_control = ESP_MODEM_FLOW_CONTROL_NONE,\
+            .source_clk = UART_SCLK_APB,            \
             .baud_rate = 115200,                    \
             .tx_io_num = 25,                        \
             .rx_io_num = 26,                        \

--- a/components/esp_modem/include/vfs_resource/vfs_create.hpp
+++ b/components/esp_modem/include/vfs_resource/vfs_create.hpp
@@ -22,6 +22,7 @@
             .stop_bits = UART_STOP_BITS_1,          \
             .parity = UART_PARITY_DISABLE,          \
             .flow_control = ESP_MODEM_FLOW_CONTROL_NONE,\
+            .source_clk = UART_SCLK_APB,            \
             .baud_rate = 115200,                    \
             .tx_io_num = 25,                        \
             .rx_io_num = 26,                        \

--- a/components/esp_modem/port/linux/esp_system_protocols_linux/include/driver/uart.h
+++ b/components/esp_modem/port/linux/esp_system_protocols_linux/include/driver/uart.h
@@ -18,3 +18,4 @@ typedef int uart_port_t;
 typedef int uart_word_length_t;
 typedef int uart_stop_bits_t;
 typedef int uart_parity_t;
+typedef int uart_sclk_t;

--- a/components/esp_modem/src/esp_modem_term_uart.cpp
+++ b/components/esp_modem/src/esp_modem_term_uart.cpp
@@ -38,7 +38,7 @@ uart_resource::uart_resource(const esp_modem_uart_term_config *config, QueueHand
     uart_config.stop_bits = config->stop_bits;
     uart_config.flow_ctrl = (config->flow_control == ESP_MODEM_FLOW_CONTROL_HW) ? UART_HW_FLOWCTRL_CTS_RTS
                             : UART_HW_FLOWCTRL_DISABLE;
-    uart_config.source_clk = UART_SCLK_APB;
+    uart_config.source_clk = config->source_clk;
 
     throw_if_esp_fail(uart_param_config(config->port_num, &uart_config), "config uart parameter failed");
 


### PR DESCRIPTION
This is for example needed when using an external crystal to select
UART_SCLK_XTAL, which fixes uart comm issue when using PM with light
sleep enabled.