### PR TITLE
fix(esp_modem): Update ap2ppp example to recover network on disconnection

### DIFF
--- a/components/esp_modem/examples/ap_to_pppos/main/network_dce.c
+++ b/components/esp_modem/examples/ap_to_pppos/main/network_dce.c
@@ -47,12 +47,31 @@ void modem_deinit_network(void)
     }
 }
 
-void modem_start_network()
+bool modem_start_network()
 {
-    esp_modem_set_mode(dce, ESP_MODEM_MODE_DATA);
+    return esp_modem_set_mode(dce, ESP_MODEM_MODE_DATA) == ESP_OK;
 }
 
-void modem_stop_network()
+bool modem_stop_network()
 {
-    esp_modem_set_mode(dce, ESP_MODEM_MODE_COMMAND);
+    return esp_modem_set_mode(dce, ESP_MODEM_MODE_COMMAND);
+}
+
+bool modem_check_sync()
+{
+    return esp_modem_sync(dce) == ESP_OK;
+}
+
+void modem_reset()
+{
+    esp_modem_reset(dce);
+}
+
+bool modem_check_signal()
+{
+    int rssi, ber;
+    if (esp_modem_get_signal_quality(dce, &rssi, &ber) == ESP_OK) {
+        return rssi != 99 && rssi > 5;
+    }
+    return false;
 }

--- a/components/esp_modem/examples/ap_to_pppos/main/network_dce.cpp
+++ b/components/esp_modem/examples/ap_to_pppos/main/network_dce.cpp
@@ -79,6 +79,24 @@ public:
         }
     }
 
+    bool sync()
+    {
+        return dce_commands::sync(dte.get()) == command_result::OK;
+    }
+
+    void reset()
+    {
+        dce_commands::reset(dte.get());
+    }
+
+    bool check_signal()
+    {
+        int rssi, ber;
+        if (dce_commands::get_signal_quality(dte.get(), rssi, ber) != command_result::OK)
+            return false;
+        return rssi != 99 && rssi > 5;
+    }
+
     [[maybe_unused]] bool init_sim(const std::string &pin)
     {
         // switch to command mode (in case we were in PPP mode)
@@ -166,20 +184,35 @@ extern "C" esp_err_t modem_init_network(esp_netif_t *netif)
     return ESP_OK;
 }
 
-extern "C" void modem_start_network()
+extern "C" bool modem_start_network()
 {
-    dce->set_mode(esp_modem::modem_mode::DATA_MODE);
+    return dce->set_mode(esp_modem::modem_mode::DATA_MODE);
 }
 
-extern "C" void modem_stop_network()
+extern "C" bool modem_stop_network()
 {
-    dce->set_mode(esp_modem::modem_mode::COMMAND_MODE);
+    return dce->set_mode(esp_modem::modem_mode::COMMAND_MODE);
 }
 
 extern "C" void modem_deinit_network()
 {
     free(dce);
     dce = nullptr;
+}
+
+extern "C" bool modem_check_sync()
+{
+    return dce->get_module()->sync();
+}
+
+extern "C" void modem_reset()
+{
+    dce->get_module()->reset();
+}
+
+extern "C" bool modem_check_signal()
+{
+    return dce->get_module()->check_signal();
 }
 
 }

--- a/components/esp_modem/examples/ap_to_pppos/main/network_dce.h
+++ b/components/esp_modem/examples/ap_to_pppos/main/network_dce.h
@@ -31,13 +31,18 @@ void modem_deinit_network();
 /**
  * @brief Starts the PPP network
  */
-void modem_start_network();
+bool modem_start_network();
 
 /**
  * @brief Stops the PPP network
  */
-void modem_stop_network();
+bool modem_stop_network();
 
+bool modem_check_sync();
+
+void modem_reset();
+
+bool modem_check_signal();
 
 #ifdef __cplusplus
 }

--- a/components/esp_modem/src/esp_modem_c_api.cpp
+++ b/components/esp_modem/src/esp_modem_c_api.cpp
@@ -122,20 +122,15 @@ extern "C" esp_err_t esp_modem_set_mode(esp_modem_dce_t *dce_wrap, esp_modem_dce
         return ESP_ERR_INVALID_ARG;
     }
     if (mode == ESP_MODEM_MODE_DATA) {
-        dce_wrap->dce->set_data();
-    } else if (mode == ESP_MODEM_MODE_COMMAND) {
-        dce_wrap->dce->exit_data();
-    } else if (mode == ESP_MODEM_MODE_CMUX) {
-        if (dce_wrap->dce->set_mode(modem_mode::CMUX_MODE) &&
-            // automatically switch to data mode for the primary terminal
-            dce_wrap->dce->set_mode(modem_mode::DATA_MODE)) {
-            return ESP_OK;
-        }
-        return ESP_FAIL;
-    } else {
-        return ESP_ERR_NOT_SUPPORTED;
+        return dce_wrap->dce->set_mode(modem_mode::DATA_MODE) ? ESP_OK : ESP_FAIL;
     }
-    return ESP_OK;
+    if (mode == ESP_MODEM_MODE_COMMAND) {
+       return dce_wrap->dce->set_mode(modem_mode::COMMAND_MODE) ? ESP_OK : ESP_FAIL;
+    }
+    if (mode == ESP_MODEM_MODE_CMUX) {
+        return dce_wrap->dce->set_mode(modem_mode::CMUX_MODE) ? ESP_OK : ESP_FAIL;
+    }
+    return ESP_ERR_NOT_SUPPORTED;
 }
 
 extern "C" esp_err_t esp_modem_read_pin(esp_modem_dce_t *dce_wrap, bool *pin)
@@ -392,4 +387,9 @@ extern "C" esp_err_t esp_modem_set_gnss_power_mode(esp_modem_dce_t *dce_wrap, in
         return ESP_ERR_INVALID_ARG;
     }
     return command_response_to_esp_err(dce_wrap->dce->set_gnss_power_mode(mode));
+}
+
+extern "C" esp_err_t esp_modem_reset(esp_modem_dce_t *dce_wrap)
+{
+    return command_response_to_esp_err(dce_wrap->dce->reset());
 }

--- a/components/esp_modem/test/target/main/NetworkDCE.cpp
+++ b/components/esp_modem/test/target/main/NetworkDCE.cpp
@@ -87,7 +87,7 @@ esp_err_t modem_init_network(esp_netif_t *netif)
     return NetModule::init(netif);
 }
 
-void modem_start_network()
+esp_err_t modem_start_network()
 {
     NetModule::start();
 }


### PR DESCRIPTION
Update the example to use recover network based on
* Checking if modem replies
* Checking the signal quality (per some hard-coded values -- could be adjusted)
* Restarting the modem (using AT commands -- could use GPIO to hard reset)
* Timeouts if no connection