### PR TITLE
esp_modem: Ignore format warnings (IDFGH-7760)

### DIFF
--- a/components/esp_modem/CMakeLists.txt
+++ b/components/esp_modem/CMakeLists.txt
@@ -44,3 +44,5 @@ if(${target} STREQUAL "linux")
     # This is needed for ESP_LOGx() macros, as integer formats differ on ESP32(..) and x64
     set_target_properties(${COMPONENT_LIB} PROPERTIES COMPILE_FLAGS -Wno-format)
 endif()
+
+target_compile_options(${COMPONENT_LIB} PRIVATE "-Wno-format")

--- a/components/esp_modem/examples/modem_console/main/CMakeLists.txt
+++ b/components/esp_modem/examples/modem_console/main/CMakeLists.txt
@@ -4,3 +4,4 @@ idf_component_register(SRCS "modem_console_main.cpp"
                             "ping_handle.c"
                        REQUIRES console esp_http_client nvs_flash esp_modem esp_modem_usb_dte
                        INCLUDE_DIRS ".")
+target_compile_options(${COMPONENT_LIB} PRIVATE "-Wno-format")

--- a/components/esp_modem/examples/pppos_client/main/CMakeLists.txt
+++ b/components/esp_modem/examples/pppos_client/main/CMakeLists.txt
@@ -1,2 +1,3 @@
 idf_component_register(SRCS "pppos_client_main.c"
                        INCLUDE_DIRS ".")
+target_compile_options(${COMPONENT_LIB} PRIVATE "-Wno-format")

--- a/components/esp_modem/idf_component.yml
+++ b/components/esp_modem/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.1.17"
+version: "0.1.18"
 description: esp modem
 url: https://github.com/espressif/esp-protocols/tree/master/components/esp_modem
 dependencies:


### PR DESCRIPTION
This is the first step to fix IDF's format warnings.

IDF has globally enabled compiler option `-Wno-format`. The fix will be in three steps:
1. add `-Wno-format` to affected components
2. disable the global option  `-Wno-format`
3. fix format warnings for each component