### PR TITLE
bugfix: mdns IPv6 address convert error (IDFGH-7772)

### DIFF
--- a/components/mdns/mdns_networking_lwip.c
+++ b/components/mdns/mdns_networking_lwip.c
@@ -338,11 +338,15 @@ size_t _mdns_udp_pcb_write(mdns_if_t tcpip_if, mdns_ip_protocol_t ip_protocol, c
     }
     memcpy((uint8_t *)pbt->payload, data, len);
 
+    ip_addr_t ip_add_copy;
+    ip_add_copy.type = ip->type;
+    memcpy(&(ip_add_copy.u_addr),&(ip->u_addr),sizeof(ip_add_copy.u_addr));
+
     mdns_api_call_t msg = {
         .tcpip_if = tcpip_if,
         .ip_protocol = ip_protocol,
         .pbt = pbt,
-        .ip = (ip_addr_t *)ip,
+        .ip = &ip_add_copy,
         .port = port
     };
     tcpip_api_call(_mdns_udp_pcb_write_api, &msg.call);


### PR DESCRIPTION
In [_mdns_udp_pcb_write()](https://github.com/espressif/esp-protocols/blob/417591b99ff9abae3265ff66a5e575f3c68f7491/components/mdns/mdns_networking_lwip.c#L333) function, it converts  [esp_ip_addr_t](https://github.com/espressif/esp-protocols/blob/38f6eb963a75e4f6ec2480a3630c09afb756ea61/components/esp_modem/port/linux/esp_netif_linux/include/esp_netif_ip_addr.h#L133) to [ip_addr_t,](https://github.com/espressif/esp-lwip/blob/2c9c531f0a7e0ee536db9de4f9dc54e453712087/src/include/lwip/ip_addr.h#L76) this results in a wrong ip_addr_t when the address is IPv6 and [LWIP_IPV6_SCOPES](https://github.com/espressif/esp-lwip/blob/2c9c531f0a7e0ee536db9de4f9dc54e453712087/src/include/lwip/ip6_addr.h#L61) is undefined. This is because zone attribute is optional in lwip [ip6_addr](https://github.com/espressif/esp-lwip/blob/2c9c531f0a7e0ee536db9de4f9dc54e453712087/src/include/lwip/ip6_addr.h#L62) but is essential in [esp_ip6_addr ](https://github.com/espressif/esp-protocols/blob/38f6eb963a75e4f6ec2480a3630c09afb756ea61/components/esp_modem/port/linux/esp_netif_linux/include/esp_netif_ip_addr.h#L114). In this fix, we manually convert esp_ip_addr_t to ip_addr_t.