### PR TITLE
asio: fix exampels build (IDFGH-7792)

### DIFF
--- a/.github/workflows/build_asio.yml
+++ b/.github/workflows/build_asio.yml
@@ -16,6 +16,7 @@ jobs:
       - name: Checkout esp-protocols
         uses: actions/checkout@v3
         with:
+          submodules: recursive
           path: esp-protocols
       - name: Build ${{ matrix.example }} with IDF-${{ matrix.idf_ver }} for ${{ matrix.idf_target }}
         env:

--- a/components/asio/examples/asio_chat/CMakeLists.txt
+++ b/components/asio/examples/asio_chat/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.16)
 
 # (Not part of the boilerplate)
 # This example uses an extra component for common functions such as Wi-Fi and Ethernet connection.
-set(EXTRA_COMPONENT_DIRS ../../../../common_components/protocol_examples_common)
+set(EXTRA_COMPONENT_DIRS ../.. ../../../../common_components/protocol_examples_common)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(asio_chat)

--- a/components/asio/examples/async_request/CMakeLists.txt
+++ b/components/asio/examples/async_request/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.16)
 
 # (Not part of the boilerplate)
 # This example uses an extra component for common functions such as Wi-Fi and Ethernet connection.
-set(EXTRA_COMPONENT_DIRS ../../../../common_components/protocol_examples_common)
+set(EXTRA_COMPONENT_DIRS ../../ ../../../../common_components/protocol_examples_common)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(async_http_request)

--- a/components/asio/examples/socks4/CMakeLists.txt
+++ b/components/asio/examples/socks4/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.16)
 
 # (Not part of the boilerplate)
 # This example uses an extra component for common functions such as Wi-Fi and Ethernet connection.
-set(EXTRA_COMPONENT_DIRS ../../../../common_components/protocol_examples_common)
+set(EXTRA_COMPONENT_DIRS ../.. ../../../../common_components/protocol_examples_common)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(asio_sock4)

--- a/components/asio/examples/ssl_client_server/CMakeLists.txt
+++ b/components/asio/examples/ssl_client_server/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.16)
 
 # (Not part of the boilerplate)
 # This example uses an extra component for common functions such as Wi-Fi and Ethernet connection.
-set(EXTRA_COMPONENT_DIRS ../../../../common_components/protocol_examples_common)
+set(EXTRA_COMPONENT_DIRS ../.. ../../../../common_components/protocol_examples_common)
 set(EXCLUDE_COMPONENTS openssl)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)

--- a/components/asio/examples/tcp_echo_server/CMakeLists.txt
+++ b/components/asio/examples/tcp_echo_server/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.16)
 
 # (Not part of the boilerplate)
 # This example uses an extra component for common functions such as Wi-Fi and Ethernet connection.
-set(EXTRA_COMPONENT_DIRS ../../../../common_components/protocol_examples_common)
+set(EXTRA_COMPONENT_DIRS ../.. ../../../../common_components/protocol_examples_common)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(asio_tcp_echo_server)

--- a/components/asio/examples/udp_echo_server/CMakeLists.txt
+++ b/components/asio/examples/udp_echo_server/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.16)
 
 # (Not part of the boilerplate)
 # This example uses an extra component for common functions such as Wi-Fi and Ethernet connection.
-set(EXTRA_COMPONENT_DIRS ../../../../common_components/protocol_examples_common)
+set(EXTRA_COMPONENT_DIRS ../../ ../../../../common_components/protocol_examples_common)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(asio_udp_echo_server)

--- a/components/mdns/tests/test_apps/CMakeLists.txt
+++ b/components/mdns/tests/test_apps/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.5)
 
 # (Not part of the boilerplate)
 # This example uses an extra component for common functions such as Wi-Fi and Ethernet connection.
-set(EXTRA_COMPONENT_DIRS "../../../../common_components/protocol_examples_common")
+set(EXTRA_COMPONENT_DIRS ../../ ../../../../common_components/protocol_examples_common)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 


### PR DESCRIPTION
Found that asio examples can't be built because can not find asio include files (https://github.com/espressif/esp-protocols/runs/7277980358?check_suite_focus=true)

This change fixes that