### PR TITLE
ignore format warnings

### DIFF
--- a/components/asio/CMakeLists.txt
+++ b/components/asio/CMakeLists.txt
@@ -27,6 +27,7 @@ idf_component_register(SRCS ${asio_sources}
                     INCLUDE_DIRS "asio/asio/include" "port/include"
                     PRIV_INCLUDE_DIRS ${asio_priv_includes}
                     REQUIRES lwip)
+target_compile_options(${COMPONENT_LIB} PRIVATE "-Wno-format")
 
 if(CONFIG_ASIO_SSL_SUPPORT)
     if(CONFIG_ASIO_USE_ESP_WOLFSSL)

--- a/components/esp_websocket_client/CMakeLists.txt
+++ b/components/esp_websocket_client/CMakeLists.txt
@@ -10,3 +10,4 @@ idf_component_register(SRCS "esp_websocket_client.c"
                     INCLUDE_DIRS "include"
                     REQUIRES lwip esp-tls tcp_transport http_parser
                     PRIV_REQUIRES esp_timer)
+target_compile_options(${COMPONENT_LIB} PRIVATE "-Wno-format")

--- a/components/esp_websocket_client/examples/main/CMakeLists.txt
+++ b/components/esp_websocket_client/examples/main/CMakeLists.txt
@@ -1,2 +1,3 @@
 idf_component_register(SRCS "websocket_example.c"
                     INCLUDE_DIRS ".")
+target_compile_options(${COMPONENT_LIB} PRIVATE "-Wno-format")

--- a/components/mdns/CMakeLists.txt
+++ b/components/mdns/CMakeLists.txt
@@ -20,6 +20,7 @@ idf_component_register(
         PRIV_INCLUDE_DIRS "private_include"
         REQUIRES ${dependencies}
         PRIV_REQUIRES ${private_dependencies})
+target_compile_options(${COMPONENT_LIB} PRIVATE "-Wno-format")
 
 if(CONFIG_ETH_ENABLED)
     idf_component_optional_requires(PRIVATE esp_eth)

--- a/components/mdns/examples/main/CMakeLists.txt
+++ b/components/mdns/examples/main/CMakeLists.txt
@@ -1,2 +1,3 @@
 idf_component_register(SRCS "mdns_example_main.c"
                     INCLUDE_DIRS ".")
+target_compile_options(${COMPONENT_LIB} PRIVATE "-Wno-format")


### PR DESCRIPTION
I found that some components were missed in https://github.com/espressif/esp-protocols/pull/73
This change fixes that