### PR TITLE
fix(esp-modem): Add filename/line info to exception message

### DIFF
--- a/components/esp_modem/examples/linux_modem/main/modem_main.cpp
+++ b/components/esp_modem/examples/linux_modem/main/modem_main.cpp
@@ -61,7 +61,7 @@ int main()
 
     bool pin_ok = true;
     if (dce->read_pin(pin_ok) == command_result::OK && !pin_ok) {
-        throw_if_false(dce->set_pin(CONFIG_EXAMPLE_SIM_PIN) == command_result::OK, "Cannot set PIN!");
+        ESP_MODEM_THROW_IF_FALSE(dce->set_pin(CONFIG_EXAMPLE_SIM_PIN) == command_result::OK, "Cannot set PIN!");
         usleep(1000000);
     }
     std::string str;

--- a/components/esp_modem/examples/modem_console/components/esp_modem_usb_dte/esp_modem_usb.cpp
+++ b/components/esp_modem/examples/modem_console/components/esp_modem_usb_dte/esp_modem_usb.cpp
@@ -70,9 +70,9 @@ public:
                 .skip_phy_setup = false,
                 .intr_flags = ESP_INTR_FLAG_LEVEL1,
             };
-            throw_if_esp_fail(usb_host_install(&host_config), "USB Host install failed");
+            ESP_MODEM_THROW_IF_ERROR(usb_host_install(&host_config), "USB Host install failed");
             ESP_LOGD(TAG, "USB Host installed");
-            throw_if_false(pdTRUE == xTaskCreatePinnedToCore(usb_host_task, "usb_host", 4096, NULL, config->task_priority + 1, NULL, usb_config->xCoreID), "USB host task failed");
+            ESP_MODEM_THROW_IF_FALSE(pdTRUE == xTaskCreatePinnedToCore(usb_host_task, "usb_host", 4096, NULL, config->task_priority + 1, NULL, usb_config->xCoreID), "USB host task failed");
         }
 
         // Install CDC-ACM driver
@@ -95,11 +95,11 @@ public:
         };
 
         if (usb_config->cdc_compliant) {
-            throw_if_esp_fail(this->CdcAcmDevice::open(usb_config->vid, usb_config->pid,
+            ESP_MODEM_THROW_IF_ERROR(this->CdcAcmDevice::open(usb_config->vid, usb_config->pid,
                             usb_config->interface_idx, &esp_modem_cdc_acm_device_config),
                             "USB Device open failed");
         } else {
-            throw_if_esp_fail(this->CdcAcmDevice::open_vendor_specific(usb_config->vid, usb_config->pid,
+            ESP_MODEM_THROW_IF_ERROR(this->CdcAcmDevice::open_vendor_specific(usb_config->vid, usb_config->pid,
                             usb_config->interface_idx, &esp_modem_cdc_acm_device_config),
                             "USB Device open failed");
         }

--- a/components/esp_modem/examples/simple_cmux_client/main/simple_cmux_client_main.cpp
+++ b/components/esp_modem/examples/simple_cmux_client/main/simple_cmux_client_main.cpp
@@ -82,7 +82,7 @@ extern "C" void app_main(void)
 #if CONFIG_EXAMPLE_NEED_SIM_PIN == 1
     bool pin_ok = true;
     if (dce->read_pin(pin_ok) == command_result::OK && !pin_ok) {
-        throw_if_false(dce->set_pin(CONFIG_EXAMPLE_SIM_PIN) == command_result::OK, "Cannot set PIN!");
+        ESP_MODEM_THROW_IF_FALSE(dce->set_pin(CONFIG_EXAMPLE_SIM_PIN) == command_result::OK, "Cannot set PIN!");
         vTaskDelay(pdMS_TO_TICKS(1000)); // Need to wait for some time after unlocking the SIM
     }
 #endif

--- a/components/esp_modem/include/cxx_include/esp_modem_dce_factory.hpp
+++ b/components/esp_modem/include/cxx_include/esp_modem_dce_factory.hpp
@@ -69,12 +69,12 @@ class Creator {
 public:
     Creator(std::shared_ptr<DTE> dte, esp_netif_t *esp_netif): dte(std::move(dte)), device(nullptr), netif(esp_netif)
     {
-        throw_if_false(netif != nullptr, "Null netif");
+        ESP_MODEM_THROW_IF_FALSE(netif != nullptr, "Null netif");
     }
 
     Creator(std::shared_ptr<DTE> dte, esp_netif_t *esp_netif, std::shared_ptr<T_Module> dev): dte(std::move(dte)), device(std::move(dev)), netif(esp_netif)
     {
-        throw_if_false(netif != nullptr, "Null netif");
+        ESP_MODEM_THROW_IF_FALSE(netif != nullptr, "Null netif");
     }
 
     ~Creator()

--- a/components/esp_modem/include/cxx_include/esp_modem_exception.hpp
+++ b/components/esp_modem/include/cxx_include/esp_modem_exception.hpp
@@ -16,14 +16,21 @@
 
 #include <string>
 #include "esp_err.h"
+#include "esp_log.h"
+
+#ifndef __FILENAME__
+#define __FILENAME__    __FILE__
+#endif
+#define ESP_MODEM_THROW_IF_FALSE(...) esp_modem::throw_if_false(__FILENAME__, __LINE__, __VA_ARGS__)
+#define ESP_MODEM_THROW_IF_ERROR(...) esp_modem::throw_if_error(__FILENAME__, __LINE__, __VA_ARGS__)
 
 namespace esp_modem {
 
 #ifdef CONFIG_COMPILER_CXX_EXCEPTIONS
-#define THROW(exception) throw(exception)
+#define ESP_MODEM_THROW(exception) throw(exception)
+
 class esp_err_exception: virtual public std::exception {
 public:
-    explicit esp_err_exception(esp_err_t err): esp_err(err) {}
     explicit esp_err_exception(std::string msg): esp_err(ESP_FAIL), message(std::move(msg)) {}
     explicit esp_err_exception(std::string msg, esp_err_t err): esp_err(err), message(std::move(msg)) {}
     virtual esp_err_t get_err_t()
@@ -31,7 +38,7 @@ public:
         return esp_err;
     }
     ~esp_err_exception() noexcept override = default;
-    virtual const char *what() const noexcept
+    [[nodiscard]] const char *what() const noexcept override
     {
         return message.c_str();
     }
@@ -39,28 +46,43 @@ private:
     esp_err_t esp_err;
     std::string message;
 };
+
 #else
-#define THROW(exception) abort()
+#define ESP_MODEM_THROW(exception) do { exception; abort(); } while(0)
+
+class esp_err_exception {
+    void print(std::string msg) { ESP_LOGE("ESP_MODEM_THROW", "%s\n", msg.c_str()); }
+public:
+    explicit esp_err_exception(std::string msg) { print(std::move(msg)); }
+    explicit esp_err_exception(std::string msg, esp_err_t err) { print(std::move(msg)); }
+};
+
 #endif
 
-static inline void throw_if_false(bool condition, std::string message)
+static inline std::string make_message(const std::string& filename, int line, const std::string& message = "ERROR")
+{
+    std::string text = filename + ":" + std::to_string(line) + " " + message;
+    return text;
+}
+
+static inline void throw_if_false(const std::string& filename, int line, bool condition, const std::string& message)
 {
     if (!condition) {
-        THROW(esp_err_exception(std::move(message)));
+        ESP_MODEM_THROW(esp_err_exception(make_message(filename, line, message)));
     }
 }
 
-static inline void throw_if_esp_fail(esp_err_t err, std::string message)
+static inline void throw_if_error(const std::string& filename, int line, esp_err_t err, const std::string& message)
 {
     if (err != ESP_OK) {
-        THROW(esp_err_exception(std::move(message), err));
+        ESP_MODEM_THROW(esp_err_exception(make_message(filename, line, message), err));
     }
 }
 
-static inline void throw_if_esp_fail(esp_err_t err)
+static inline void throw_if_error(const std::string& filename, int line, esp_err_t err)
 {
     if (err != ESP_OK) {
-        THROW(esp_err_exception(err));
+        ESP_MODEM_THROW(esp_err_exception(make_message(filename, line), err));
     }
 }
 

--- a/components/esp_modem/src/esp_modem_dte.cpp
+++ b/components/esp_modem/src/esp_modem_dte.cpp
@@ -56,7 +56,7 @@ command_result DTE::command(const std::string &command, got_line_cb got_line, ui
     command_term->write((uint8_t *)command.c_str(), command.length());
     auto got_lf = signal.wait(GOT_LINE, time_ms);
     if (got_lf && res == command_result::TIMEOUT) {
-        throw_if_esp_fail(ESP_ERR_INVALID_STATE);
+        ESP_MODEM_THROW_IF_ERROR(ESP_ERR_INVALID_STATE);
     }
     buffer.consumed = 0;
     command_term->set_read_cb(nullptr);

--- a/components/esp_modem/src/esp_modem_netif.cpp
+++ b/components/esp_modem/src/esp_modem_netif.cpp
@@ -82,11 +82,11 @@ Netif::Netif(std::shared_ptr<DTE> e, esp_netif_t *ppp_netif) :
     driver.base.netif = ppp_netif;
     driver.ppp = this;
     driver.base.post_attach = esp_modem_post_attach;
-    throw_if_esp_fail(esp_event_handler_register(NETIF_PPP_STATUS, ESP_EVENT_ANY_ID, &on_ppp_changed, (void *) this));
-    throw_if_esp_fail(esp_event_handler_register(IP_EVENT, IP_EVENT_PPP_GOT_IP, esp_netif_action_connected, ppp_netif));
-    throw_if_esp_fail(
+    ESP_MODEM_THROW_IF_ERROR(esp_event_handler_register(NETIF_PPP_STATUS, ESP_EVENT_ANY_ID, &on_ppp_changed, (void *) this));
+    ESP_MODEM_THROW_IF_ERROR(esp_event_handler_register(IP_EVENT, IP_EVENT_PPP_GOT_IP, esp_netif_action_connected, ppp_netif));
+    ESP_MODEM_THROW_IF_ERROR(
         esp_event_handler_register(IP_EVENT, IP_EVENT_PPP_LOST_IP, esp_netif_action_disconnected, ppp_netif));
-    throw_if_esp_fail(esp_netif_attach(ppp_netif, &driver));
+    ESP_MODEM_THROW_IF_ERROR(esp_netif_attach(ppp_netif, &driver));
 }
 
 void Netif::start()

--- a/components/esp_modem/src/esp_modem_primitives_freertos.cpp
+++ b/components/esp_modem/src/esp_modem_primitives_freertos.cpp
@@ -28,7 +28,7 @@ void Lock::unlock()
 Lock::Lock(): m(nullptr)
 {
     m = xSemaphoreCreateRecursiveMutex();
-    throw_if_false(m != nullptr, "create signal event group failed");
+    ESP_MODEM_THROW_IF_FALSE(m != nullptr, "create signal event group failed");
 }
 
 Lock::~Lock()
@@ -45,7 +45,7 @@ void Lock::lock()
 SignalGroup::SignalGroup(): event_group(nullptr)
 {
     event_group = xEventGroupCreate();
-    throw_if_false(event_group != nullptr, "create signal event group failed");
+    ESP_MODEM_THROW_IF_FALSE(event_group != nullptr, "create signal event group failed");
 }
 
 void SignalGroup::set(uint32_t bits)
@@ -86,7 +86,7 @@ Task::Task(size_t stack_size, size_t priority, void *task_param, TaskFunction_t 
     : task_handle(nullptr)
 {
     BaseType_t ret = xTaskCreate(task_function, "vfs_task", stack_size, task_param, priority, &task_handle);
-    throw_if_false(ret == pdTRUE, "create vfs task failed");
+    ESP_MODEM_THROW_IF_FALSE(ret == pdTRUE, "create vfs task failed");
 }
 
 Task::~Task()

--- a/components/esp_modem/src/esp_modem_term_uart.cpp
+++ b/components/esp_modem/src/esp_modem_term_uart.cpp
@@ -40,7 +40,7 @@ uart_resource::uart_resource(const esp_modem_uart_term_config *config, QueueHand
                             : UART_HW_FLOWCTRL_DISABLE;
     uart_config.source_clk = config->source_clk;
 
-    throw_if_esp_fail(uart_param_config(config->port_num, &uart_config), "config uart parameter failed");
+    ESP_MODEM_THROW_IF_ERROR(uart_param_config(config->port_num, &uart_config), "config uart parameter failed");
 
     if (config->flow_control == ESP_MODEM_FLOW_CONTROL_HW) {
         res = uart_set_pin(config->port_num, config->tx_io_num, config->rx_io_num,
@@ -49,24 +49,24 @@ uart_resource::uart_resource(const esp_modem_uart_term_config *config, QueueHand
         res = uart_set_pin(config->port_num, config->tx_io_num, config->rx_io_num,
                            UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE);
     }
-    throw_if_esp_fail(res, "config uart gpio failed");
+    ESP_MODEM_THROW_IF_ERROR(res, "config uart gpio failed");
     /* Set flow control threshold */
     if (config->flow_control == ESP_MODEM_FLOW_CONTROL_HW) {
         res = uart_set_hw_flow_ctrl(config->port_num, UART_HW_FLOWCTRL_CTS_RTS, UART_FIFO_LEN - 8);
     } else if (config->flow_control == ESP_MODEM_FLOW_CONTROL_SW) {
         res = uart_set_sw_flow_ctrl(config->port_num, true, 8, UART_FIFO_LEN - 8);
     }
-    throw_if_esp_fail(res, "config uart flow control failed");
+    ESP_MODEM_THROW_IF_ERROR(res, "config uart flow control failed");
 
     /* Install UART driver and get event queue used inside driver */
     res = uart_driver_install(config->port_num,
                               config->rx_buffer_size, config->tx_buffer_size,
                               config->event_queue_size, config->event_queue_size ?  event_queue : nullptr,
                               0);
-    throw_if_esp_fail(res, "install uart driver failed");
-    throw_if_esp_fail(uart_set_rx_timeout(config->port_num, 1), "set rx timeout failed");
+    ESP_MODEM_THROW_IF_ERROR(res, "install uart driver failed");
+    ESP_MODEM_THROW_IF_ERROR(uart_set_rx_timeout(config->port_num, 1), "set rx timeout failed");
 
-    throw_if_esp_fail(uart_set_rx_full_threshold(config->port_num, 64), "config rx full threshold failed");
+    ESP_MODEM_THROW_IF_ERROR(uart_set_rx_full_threshold(config->port_num, 64), "config rx full threshold failed");
 
     /* mark UART as initialized */
     port = config->port_num;

--- a/components/esp_modem/src/esp_modem_uart.cpp
+++ b/components/esp_modem/src/esp_modem_uart.cpp
@@ -33,7 +33,7 @@ struct uart_task {
         task_handle(nullptr)
     {
         BaseType_t ret = xTaskCreate(task_function, "uart_task", stack_size, task_param, priority, &task_handle);
-        throw_if_false(ret == pdTRUE, "create uart event task failed");
+        ESP_MODEM_THROW_IF_FALSE(ret == pdTRUE, "create uart event task failed");
     }
 
     ~uart_task()

--- a/components/esp_modem/src/esp_modem_uart_linux.cpp
+++ b/components/esp_modem/src/esp_modem_uart_linux.cpp
@@ -27,7 +27,7 @@ uart_resource::uart_resource(const esp_modem_uart_term_config *config, QueueHand
 {
     ESP_LOGD(TAG, "Creating uart resource" );
     struct termios tty = {};
-    throw_if_false(tcgetattr(fd, &tty) == 0, "Failed to tcgetattr()");
+    ESP_MODEM_THROW_IF_FALSE(tcgetattr(fd, &tty) == 0, "Failed to tcgetattr()");
 
     tty.c_cflag &= ~PARENB;
     tty.c_cflag &= ~CSTOPB;

--- a/components/esp_modem/src/esp_modem_vfs_socket_creator.cpp
+++ b/components/esp_modem/src/esp_modem_vfs_socket_creator.cpp
@@ -91,7 +91,7 @@ bool vfs_create_socket(struct esp_modem_vfs_socket_creator *config, struct esp_m
     }
     TRY_CATCH_OR_DO(
         int fd = -1;
-        esp_modem::throw_if_esp_fail(hostname_to_fd(config->host_name, config->port, &fd));
+        ESP_MODEM_THROW_IF_ERROR(hostname_to_fd(config->host_name, config->port, &fd));
 
         // Set the FD to non-blocking mode
         int flags = fcntl(fd, F_GETFL, nullptr) | O_NONBLOCK;

--- a/components/esp_modem/src/esp_modem_vfs_uart_creator.cpp
+++ b/components/esp_modem/src/esp_modem_vfs_uart_creator.cpp
@@ -48,7 +48,7 @@ bool vfs_create_uart(struct esp_modem_vfs_uart_creator *config, struct esp_modem
     }
     TRY_CATCH_OR_DO(
         int fd = open(config->dev_name, O_RDWR);
-        esp_modem::throw_if_false(fd >= 0, "Cannot open the fd");
+        ESP_MODEM_THROW_IF_FALSE(fd >= 0, "Cannot open the fd");
 
         created_config->resource = new esp_modem_vfs_resource(&config->uart, fd);
         created_config->fd = fd;


### PR DESCRIPTION
This is useful if exceptions are enabled, but caught internally on C++ API boundary

Closes https://github.com/espressif/esp-protocols/issues/74