### PR TITLE
feat(mdns): Define explicit dependencies on esp-wifi

### DIFF
--- a/components/mdns/CMakeLists.txt
+++ b/components/mdns/CMakeLists.txt
@@ -10,7 +10,7 @@ if(${target} STREQUAL "linux")
     set(srcs "mdns.c" ${MDNS_NETWORKING})
 else()
     set(dependencies lwip console esp_netif)
-    set(private_dependencies esp_timer)
+    set(private_dependencies esp_timer esp_wifi)
     set(srcs "mdns.c" ${MDNS_NETWORKING} "mdns_console.c")
 endif()
 

--- a/components/mdns/idf_component.yml
+++ b/components/mdns/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.4"
+version: "1.0.5"
 description: mDNS
 dependencies:
   idf:

--- a/components/mdns/mdns.c
+++ b/components/mdns/mdns.c
@@ -20,6 +20,8 @@
 #if CONFIG_ETH_ENABLED
 #include "esp_eth.h"
 #endif
+#include "esp_wifi.h"
+
 
 #ifdef MDNS_ENABLE_DEBUG
 void mdns_debug_packet(const uint8_t * data, size_t len);


### PR DESCRIPTION
`mdns` depends on `esp-wifi`, but currently it's is transiently brought by `esp-netif` (Which doesn't have to depend on esp-wifi)