### PR TITLE
fix(mdns): ignore authoritative flag on reception (IDFGH-7891)

### DIFF
--- a/components/mdns/mdns.c
+++ b/components/mdns/mdns.c
@@ -3499,7 +3499,7 @@ void mdns_parse_packet(mdns_rx_packet_t * packet)
                     service = _mdns_get_service_item(name->service, name->proto, NULL);
                 }
             } else {
-                if (!parsed_packet->authoritative || record_type == MDNS_NS) {
+                if (!header.flags.qr || record_type == MDNS_NS) {
                     //skip this record
                     continue;
                 }


### PR DESCRIPTION
According to [RFC 6762](https://datatracker.ietf.org/doc/html/rfc6762#section-18.4):

   In response messages for Multicast domains, the Authoritative Answer
   bit MUST be set to one (not setting this bit would imply there's some
   other place where "better" information may be found) and MUST be
   ignored on reception.

The PR removes the check on the AA bit.