### PR TITLE
mdns: Fix add_service() to report error if no hostname has been set

### DIFF
--- a/components/mdns/mdns.c
+++ b/components/mdns/mdns.c
@@ -232,7 +232,7 @@ static char * _mdns_mangle_name(char* in) {
 static bool _mdns_service_match(const mdns_service_t * srv, const char * service, const char * proto,
                                 const char * hostname)
 {
-    if (!service || !proto) {
+    if (!service || !proto || !srv->hostname) {
         return false;
     }
     return !strcasecmp(srv->service, service) && !strcasecmp(srv->proto, proto) &&
@@ -4558,7 +4558,8 @@ static void _mdns_remap_self_service_hostname(const char * old_hostname, const c
     mdns_srv_item_t * service = _mdns_server->services;
 
     while (service) {
-        if (strcmp(service->service->hostname, old_hostname) == 0) {
+        if (service->service->hostname &&
+            strcmp(service->service->hostname, old_hostname) == 0) {
             free((char *)service->service->hostname);
             service->service->hostname = strdup(new_hostname);
         }
@@ -5430,7 +5431,7 @@ esp_err_t mdns_instance_name_set(const char * instance)
 esp_err_t mdns_service_add_for_host(const char * instance, const char * service, const char * proto, const char * hostname,
                                     uint16_t port, mdns_txt_item_t txt[], size_t num_items)
 {
-    if (!_mdns_server || _str_null_or_empty(service) || _str_null_or_empty(proto) || !port) {
+    if (!_mdns_server || _str_null_or_empty(service) || _str_null_or_empty(proto) || !port || !hostname) {
         return ESP_ERR_INVALID_ARG;
     }
 


### PR DESCRIPTION
* Returns error if we try to add a service without setting hostname
* Reported here: https://www.esp32.com/viewtopic.php?f=13&t=28981