### PR TITLE
esp_modem: Expose set_error_cb method

### DIFF
--- a/components/esp_modem/CMakeLists.txt
+++ b/components/esp_modem/CMakeLists.txt
@@ -47,5 +47,3 @@ if(${target} STREQUAL "linux")
     # This is needed for ESP_LOGx() macros, as integer formats differ on ESP32(..) and x64
     set_target_properties(${COMPONENT_LIB} PROPERTIES COMPILE_FLAGS -Wno-format)
 endif()
-
-target_compile_options(${COMPONENT_LIB} PRIVATE "-Wno-format")

--- a/components/esp_modem/idf_component.yml
+++ b/components/esp_modem/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.1.19"
+version: "0.1.20"
 description: esp modem
 url: https://github.com/espressif/esp-protocols/tree/master/components/esp_modem
 dependencies:

--- a/components/esp_modem/include/cxx_include/esp_modem_dte.hpp
+++ b/components/esp_modem/include/cxx_include/esp_modem_dte.hpp
@@ -76,6 +76,12 @@ public:
     void set_read_cb(std::function<bool(uint8_t *data, size_t len)> f);
 
     /**
+     * @brief Sets DTE error callback
+     * @param f Function to be called on DTE error
+     */
+    void set_error_cb(std::function<void(terminal_error err)> f);
+
+    /**
      * @brief Sets the DTE to desired mode (Command/Data/Cmux)
      * @param m Desired operation mode
      * @return true on success

--- a/components/esp_modem/include/cxx_include/esp_modem_terminal.hpp
+++ b/components/esp_modem/include/cxx_include/esp_modem_terminal.hpp
@@ -41,6 +41,7 @@ enum class terminal_error {
     BUFFER_OVERFLOW,
     CHECKSUM_ERROR,
     UNEXPECTED_CONTROL_FLOW,
+    DEVICE_GONE,
 };
 
 /**

--- a/components/esp_modem/src/esp_modem_dte.cpp
+++ b/components/esp_modem/src/esp_modem_dte.cpp
@@ -155,6 +155,12 @@ void DTE::set_read_cb(std::function<bool(uint8_t *, size_t)> f)
     });
 }
 
+void DTE::set_error_cb(std::function<void(terminal_error err)> f)
+{
+    data_term->set_error_cb(f);
+    command_term->set_error_cb(f);
+}
+
 int DTE::read(uint8_t **d, size_t len)
 {
     auto data_to_read = std::min(len, buffer.size);

--- a/components/esp_modem/src/esp_modem_netif.cpp
+++ b/components/esp_modem/src/esp_modem_netif.cpp
@@ -14,6 +14,7 @@
 
 #include <memory>
 #include <utility>
+#include <inttypes.h>
 #include <esp_log.h>
 #include <esp_event.h>
 #include "cxx_include/esp_modem_netif.hpp"
@@ -28,7 +29,7 @@ void Netif::on_ppp_changed(void *arg, esp_event_base_t event_base,
 {
     auto *ppp = static_cast<Netif *>(arg);
     if (event_id < NETIF_PP_PHASE_OFFSET) {
-        ESP_LOGI("esp_modem_netif", "PPP state changed event %d", event_id);
+        ESP_LOGI("esp_modem_netif", "PPP state changed event %" PRId32, event_id);
         // only notify the modem on state/error events, ignoring phase transitions
         ppp->signal.set(PPP_EXIT);
     }


### PR DESCRIPTION
Allow user to register his DTE error handler. Errors from underlying terminals are forwarded to this DTE error handler.

@david-cermak Currently both `data_term` and `command_term` use the same error handler, is it OK?