### PR TITLE
Fix mdns build failed when disable LWIP_IPV6 (IDFGH-8237)

### DIFF
--- a/components/mdns/mdns_networking_lwip.c
+++ b/components/mdns/mdns_networking_lwip.c
@@ -339,8 +339,13 @@ size_t _mdns_udp_pcb_write(mdns_if_t tcpip_if, mdns_ip_protocol_t ip_protocol, c
     memcpy((uint8_t *)pbt->payload, data, len);
 
     ip_addr_t ip_add_copy;
+#if CONFIG_LWIP_IPV6
     ip_add_copy.type = ip->type;
     memcpy(&(ip_add_copy.u_addr),&(ip->u_addr),sizeof(ip_add_copy.u_addr));
+#else
+    ip_add_copy.addr = ip->u_addr.ip4.addr;
+#endif
+    
 
     mdns_api_call_t msg = {
         .tcpip_if = tcpip_if,


### PR DESCRIPTION
Fix mdns build failed when disable LWIP_IPV6. This fix is for https://github.com/espressif/esp-protocols/pull/81