### PR TITLE
esp_modem: Exit CMUX after end of example

### DIFF
--- a/components/esp_modem/examples/simple_cmux_client/main/Kconfig.projbuild
+++ b/components/esp_modem/examples/simple_cmux_client/main/Kconfig.projbuild
@@ -61,4 +61,10 @@ menu "Example Configuration"
         help
             HTTPS address of the update binary.
 
+    config EXAMPLE_CLOSE_CMUX_AT_END
+        bool "Close multiplexed mode at the end of the example"
+        default n
+        help
+            Close the multiplexed mode at the end of the example and rollback to command mode.
+
 endmenu

--- a/components/esp_modem/examples/simple_cmux_client/main/simple_cmux_client_main.cpp
+++ b/components/esp_modem/examples/simple_cmux_client/main/simple_cmux_client_main.cpp
@@ -164,4 +164,14 @@ extern "C" void app_main(void)
         return;
     }
 #endif // CONFIG_EXAMPLE_PERFORM_OTA
+
+    /* Close multiplexed command/data mode */
+#if CONFIG_EXAMPLE_CLOSE_CMUX_AT_END == 1
+    if (dce->set_mode(esp_modem::modem_mode::COMMAND_MODE)) {
+        std::cout << "Modem has correctly entered command mode" << std::endl;
+    } else {
+        ESP_LOGE(TAG, "Failed to configure desired mode... exiting");
+        return;
+    }
+#endif
 }

--- a/components/esp_modem/include/generate/esp_modem_command_declare.inc
+++ b/components/esp_modem/include/generate/esp_modem_command_declare.inc
@@ -47,6 +47,7 @@
  * @return OK, FAIL or TIMEOUT
  */ \
 ESP_MODEM_DECLARE_DCE_COMMAND(sync, command_result, 0) \
+    \
 /**
  * @brief Reads the operator name
  * @param[out] operator name
@@ -113,7 +114,7 @@ ESP_MODEM_DECLARE_DCE_COMMAND(sms_character_set, command_result, 0) \
 ESP_MODEM_DECLARE_DCE_COMMAND(send_sms, command_result, 2, STRING_IN(p1, number), STRING_IN(p2, message)) \
     \
 /**
- * @brief Resumes data mode (Switches back to th data mode, which was temporarily suspended)
+ * @brief Resumes data mode (Switches back to the data mode, which was temporarily suspended)
  * @return OK, FAIL or TIMEOUT
  */ \
 ESP_MODEM_DECLARE_DCE_COMMAND(resume_data_mode, command_result, 0) \


### PR DESCRIPTION
Exit CMUX mode at the end of the *simple_cmux_client* example (as describe in this [comment](https://github.com/espressif/esp-protocols/issues/37#issuecomment-1155727790)).
Here is also two minor fixes (formatting & spelling).