### PR TITLE
Prevent crash when hostname is null (IDFGH-8356)

### DIFF
--- a/components/mdns/mdns.c
+++ b/components/mdns/mdns.c
@@ -2801,7 +2801,8 @@ static int _mdns_check_aaaa_collision(esp_ip6_addr_t * ip, mdns_if_t tcpip_if)
 
 static bool _hostname_is_ours(const char * hostname)
 {
-    if (strcasecmp(hostname, _mdns_server->hostname) == 0) {
+    if (!_str_null_or_empty(_mdns_server->hostname) &&
+        strcasecmp(hostname, _mdns_server->hostname) == 0) {
         return true;
     }
     mdns_host_item_t * host = _mdns_host_list;


### PR DESCRIPTION
Check whether `_mdns_server->hostname` is `_str_null_or_empty` before `strcasecmp`.