### PR TITLE
esp_modem: Allow C API extensions (IDFGH-8368)

### DIFF
--- a/components/esp_modem/idf_component.yml
+++ b/components/esp_modem/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.1.22"
+version: "0.1.23"
 description: esp modem
 url: https://github.com/espressif/esp-protocols/tree/master/components/esp_modem
 dependencies:

--- a/components/esp_modem/include/esp_modem_c_api_types.h
+++ b/components/esp_modem/include/esp_modem_c_api_types.h
@@ -61,6 +61,23 @@ typedef enum esp_modem_dce_device
 } esp_modem_dce_device_t;
 
 /**
+ * @brief Terminal errors
+ */
+typedef enum esp_modem_terminal_error
+{
+    ESP_MODEM_TERMINAL_BUFFER_OVERFLOW,
+    ESP_MODEM_TERMINAL_CHECKSUM_ERROR,
+    ESP_MODEM_TERMINAL_UNEXPECTED_CONTROL_FLOW,
+    ESP_MODEM_TERMINAL_DEVICE_GONE,
+    ESP_MODEM_TERMINAL_UNKNOWN_ERROR,
+} esp_modem_terminal_error_t;
+
+/**
+ * @brief Terminal error callback
+ */
+typedef void (*esp_modem_terminal_error_cbt)(esp_modem_terminal_error_t);
+
+/**
  * @brief Create a generic DCE handle for new modem API
  *
  * @param dte_config DTE configuration (UART config for now)
@@ -89,6 +106,15 @@ esp_modem_dce_t *esp_modem_new_dev(esp_modem_dce_device_t module, const esp_mode
  * @param dce DCE to destroy
  */
 void esp_modem_destroy(esp_modem_dce_t * dce);
+
+/**
+ * @brief Set DTE's error callback
+ * 
+ * @param dce Modem DCE handle
+ * @param[in] err_cb Error callback
+ * @return ESP_OK on success, ESP_FAIL on failure
+ */
+esp_err_t esp_modem_set_error_cb(esp_modem_dce_t * dce, esp_modem_terminal_error_cbt err_cb);
 
 /**
  * @brief Set operation mode for this DCE

--- a/components/esp_modem/include/esp_private/c_api_wrapper.hpp
+++ b/components/esp_modem/include/esp_private/c_api_wrapper.hpp
@@ -12,6 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/**
+ * @file c_api_wrapper.hpp
+ * @brief Collection of C API wrappers
+ * 
+ * This file is located in include/esp_private because it is not intended for users,
+ * but rather for esp_modem C extension developers.
+ * 
+ * The C extension API must provide a 'factory function' that returns initialized pointer to esp_modem_dce_wrap.
+ * Helper functions provided below, can be used for conversion between C++ enum classes and standard C enums.
+ */
+
 #pragma once
 
 #include "cxx_include/esp_modem_dce_factory.hpp"
@@ -23,6 +34,8 @@ struct esp_modem_dce_wrap { // need to mimic the polymorphic dispatch as CPP use
     enum class modem_wrap_dte_type { UART, VFS, USB } dte_type;
     dce_factory::ModemType modem_type;
     DCE *dce;
+    std::shared_ptr<DTE> dte;
+    esp_modem_dce_wrap() : dce(nullptr), dte(nullptr) {}
 };
 
 inline dce_factory::ModemType convert_modem_enum(esp_modem_dce_device_t module)
@@ -42,4 +55,33 @@ inline dce_factory::ModemType convert_modem_enum(esp_modem_dce_device_t module)
     case ESP_MODEM_DCE_GENETIC:
         return esp_modem::dce_factory::ModemType::GenericModule;
     }
+}
+
+inline esp_modem_terminal_error_t convert_terminal_error_enum(terminal_error err)
+{
+    switch (err) {
+    case terminal_error::BUFFER_OVERFLOW:
+        return ESP_MODEM_TERMINAL_BUFFER_OVERFLOW;
+    case terminal_error::CHECKSUM_ERROR:
+        return ESP_MODEM_TERMINAL_CHECKSUM_ERROR;
+    case terminal_error::UNEXPECTED_CONTROL_FLOW:
+        return ESP_MODEM_TERMINAL_UNEXPECTED_CONTROL_FLOW;
+    case terminal_error::DEVICE_GONE:
+        return ESP_MODEM_TERMINAL_DEVICE_GONE;
+    default:
+        return ESP_MODEM_TERMINAL_UNKNOWN_ERROR;
+    }
+}
+
+inline esp_err_t command_response_to_esp_err(command_result res)
+{
+    switch (res) {
+    case command_result::OK:
+        return ESP_OK;
+    case command_result::FAIL:
+        return ESP_FAIL;
+    case command_result::TIMEOUT:
+        return ESP_ERR_TIMEOUT;
+    }
+    return ESP_ERR_INVALID_ARG;
 }

--- a/components/esp_modem/include/esp_private/c_api_wrapper.hpp
+++ b/components/esp_modem/include/esp_private/c_api_wrapper.hpp
@@ -1,0 +1,45 @@
+// Copyright 2022 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "cxx_include/esp_modem_dce_factory.hpp"
+#include "esp_modem_c_api_types.h"
+
+using namespace esp_modem;
+
+struct esp_modem_dce_wrap { // need to mimic the polymorphic dispatch as CPP uses templated dispatch
+    enum class modem_wrap_dte_type { UART, VFS, USB } dte_type;
+    dce_factory::ModemType modem_type;
+    DCE *dce;
+};
+
+inline dce_factory::ModemType convert_modem_enum(esp_modem_dce_device_t module)
+{
+    switch (module) {
+    case ESP_MODEM_DCE_SIM7600:
+        return esp_modem::dce_factory::ModemType::SIM7600;
+    case ESP_MODEM_DCE_SIM7070:
+        return esp_modem::dce_factory::ModemType::SIM7070;
+    case ESP_MODEM_DCE_SIM7000:
+        return esp_modem::dce_factory::ModemType::SIM7000;
+    case ESP_MODEM_DCE_BG96:
+        return esp_modem::dce_factory::ModemType::BG96;
+    case ESP_MODEM_DCE_SIM800:
+        return esp_modem::dce_factory::ModemType::SIM800;
+    default:
+    case ESP_MODEM_DCE_GENETIC:
+        return esp_modem::dce_factory::ModemType::GenericModule;
+    }
+}

--- a/components/esp_modem/src/esp_modem_c_api.cpp
+++ b/components/esp_modem/src/esp_modem_c_api.cpp
@@ -21,6 +21,7 @@
 #include "esp_modem_c_api_types.h"
 #include "esp_modem_config.h"
 #include "exception_stub.hpp"
+#include "esp_private/c_api_wrapper.hpp"
 #include "cstring"
 
 #ifndef ESP_MODEM_C_API_STR_MAX
@@ -35,12 +36,6 @@ size_t strlcpy(char *dest, const char *src, size_t len);
 // C API definitions
 using namespace esp_modem;
 
-struct esp_modem_dce_wrap { // need to mimic the polymorphic dispatch as CPP uses templated dispatch
-    enum class modem_wrap_dte_type { UART, } dte_type;
-    dce_factory::ModemType modem_type;
-    DCE *dce;
-};
-
 static inline esp_err_t command_response_to_esp_err(command_result res)
 {
     switch (res) {
@@ -52,25 +47,6 @@ static inline esp_err_t command_response_to_esp_err(command_result res)
         return ESP_ERR_TIMEOUT;
     }
     return ESP_ERR_INVALID_ARG;
-}
-
-static inline dce_factory::ModemType convert_modem_enum(esp_modem_dce_device_t module)
-{
-    switch (module) {
-    case ESP_MODEM_DCE_SIM7600:
-        return esp_modem::dce_factory::ModemType::SIM7600;
-    case ESP_MODEM_DCE_SIM7070:
-        return esp_modem::dce_factory::ModemType::SIM7070;
-    case ESP_MODEM_DCE_SIM7000:
-        return esp_modem::dce_factory::ModemType::SIM7000;
-    case ESP_MODEM_DCE_BG96:
-        return esp_modem::dce_factory::ModemType::BG96;
-    case ESP_MODEM_DCE_SIM800:
-        return esp_modem::dce_factory::ModemType::SIM800;
-    default:
-    case ESP_MODEM_DCE_GENETIC:
-        return esp_modem::dce_factory::ModemType::GenericModule;
-    }
 }
 
 extern "C" esp_modem_dce_t *esp_modem_new_dev(esp_modem_dce_device_t module, const esp_modem_dte_config_t *dte_config, const esp_modem_dce_config_t *dce_config, esp_netif_t *netif)


### PR DESCRIPTION
**This PR focuses on C API of esp_modem**

## 1. Extensible C API
**The problem:** C++ API is easily expandable with different types of DTE (such as USB DTE). But C API offers only UART DTE in function `esp_modem_new_dev` with no way of extending this function in C.

**The solution:** Move definitions needed for extending C API to separate header file `include/esp_private/c_api_wrapper.h`. Developers of esp_modem extension can include this file with `#include "esp_private/c_api_wrapper.h"` and implement their own `esp_modem_new_dev_*` function.

## 2. Error callback in C
**The problem:** C API doesn't offer API to register error callback to Terminal errors.

Composition of esp_modem C wrapper `struct esp_modem_dce_wrap`:
struct esp_modem_dce_wrap -> DCE -> DTE -> Terminal -> error_callback_function

DTE is protected (inaccessible) member of DCE.

We cannot add the error_callback to DTE configuration structure, because its signature contains C++ enum class (`terminal_error`), thus it is not compatible with C.

**The solution:**
**TODO:**

- [ ] ~~Provide C functions to create DTE and DCE separately~~ This proved as suboptimal. We maintain lifetime of DCE and DTE through smart pointer. So we can't easily pass DTE to DCE.
- [x] Provide C function that will allow registering DTE error callback

Now we provide 
1. C enum type `esp_modem_terminal_error_t` that is a C version of `terminal_error` 
2. Conversion function between the two types `convert_terminal_error_enum` 
3. `esp_modem_set_error_cb(esp_modem_dce_t * dce, esp_modem_terminal_error_cbt err_cb)` for registering error callback from C

~~**This PR doesn't update the default UART implementation**.~~ UART can be extended with error handling too.
~~Disadvantage: User cannot change the error callback after initialization (we don't offer C alternative to C++ `DTE::set_error_cb`)~~