### PR TITLE
Feature/websocket client errorhandling (IDFGH-8444)

### DIFF
--- a/components/esp_modem/examples/modem_console/main/Kconfig.projbuild
+++ b/components/esp_modem/examples/modem_console/main/Kconfig.projbuild
@@ -74,33 +74,6 @@ menu "Example Configuration"
         help
             Set to true for the PPP client to skip authentication
 
-    config EXAMPLE_SEND_MSG
-        bool "Short message (SMS)"
-        default n
-        help
-            Select this, the modem will send a short message before power off.
-
-    if EXAMPLE_SEND_MSG
-        config EXAMPLE_SEND_MSG_PEER_PHONE_NUMBER
-            string "Peer Phone Number (with area code)"
-            default "+8610086"
-            help
-                Enter the peer phone number that you want to send message to.
-    endif
-
-    config EXAMPLE_NEED_SIM_PIN
-        bool "SIM PIN needed"
-        default n
-        help
-            Enable to set SIM PIN before starting the example
-
-    config EXAMPLE_SIM_PIN
-        string "Set SIM PIN"
-        default "1234"
-        depends on EXAMPLE_NEED_SIM_PIN
-        help
-            Pin to unlock the SIM
-
     choice EXAMPLE_FLOW_CONTROL
         bool "Set preferred modem control flow"
         default EXAMPLE_FLOW_CONTROL_NONE

--- a/components/esp_websocket_client/esp_websocket_client.c
+++ b/components/esp_websocket_client/esp_websocket_client.c
@@ -104,7 +104,7 @@ typedef enum {
 struct esp_websocket_client {
     esp_event_loop_handle_t     event_handle;
     TaskHandle_t                task_handle;
-	esp_websocket_error_codes_t error_handle;
+    esp_websocket_error_codes_t error_handle;
     esp_transport_list_handle_t transport_list;
     esp_transport_handle_t      transport;
     websocket_config_storage_t *config;

--- a/components/esp_websocket_client/esp_websocket_client.c
+++ b/components/esp_websocket_client/esp_websocket_client.c
@@ -212,8 +212,7 @@ static esp_err_t esp_websocket_client_abort_connection(esp_websocket_client_hand
         ESP_LOGI(TAG, "Reconnect after %d ms", client->wait_timeout_ms);
     }
 
-    if (error_type == WEBSOCKET_ERROR_TYPE_TCP_TRANSPORT)
-    {
+    if (error_type == WEBSOCKET_ERROR_TYPE_TCP_TRANSPORT) {
         client->error_handle.esp_tls_last_esp_err =
             esp_tls_get_and_clear_last_error(esp_transport_get_error_handle(client->transport),
                                              &client->error_handle.esp_tls_stack_err,

--- a/components/esp_websocket_client/esp_websocket_client.c
+++ b/components/esp_websocket_client/esp_websocket_client.c
@@ -82,7 +82,7 @@ typedef struct {
     int                         pingpong_timeout_sec;
     size_t                      ping_interval_sec;
     const char                  *cert;
-    size_t                      cert_len;                
+    size_t                      cert_len;
     const char                  *client_cert;
     size_t                      client_cert_len;
     const char                  *client_key;
@@ -104,6 +104,7 @@ typedef enum {
 struct esp_websocket_client {
     esp_event_loop_handle_t     event_handle;
     TaskHandle_t                task_handle;
+	esp_websocket_error_codes_t error_handle;
     esp_transport_list_handle_t transport_list;
     esp_transport_handle_t      transport;
     websocket_config_storage_t *config;
@@ -189,6 +190,7 @@ static esp_err_t esp_websocket_client_dispatch_event(esp_websocket_client_handle
     event_data.op_code = client->last_opcode;
     event_data.payload_len = client->payload_len;
     event_data.payload_offset = client->payload_offset;
+    memcpy(&event_data.error_handle, &client->error_handle, sizeof(event_data.error_handle));
 
     if ((err = esp_event_post_to(client->event_handle,
                                  WEBSOCKET_EVENTS, event,
@@ -200,7 +202,7 @@ static esp_err_t esp_websocket_client_dispatch_event(esp_websocket_client_handle
     return esp_event_loop_run(client->event_handle, 0);
 }
 
-static esp_err_t esp_websocket_client_abort_connection(esp_websocket_client_handle_t client)
+static esp_err_t esp_websocket_client_abort_connection(esp_websocket_client_handle_t client, esp_websocket_error_type_t error_type)
 {
     ESP_WS_CLIENT_STATE_CHECK(TAG, client, return ESP_FAIL);
     esp_transport_close(client->transport);
@@ -209,6 +211,19 @@ static esp_err_t esp_websocket_client_abort_connection(esp_websocket_client_hand
         client->reconnect_tick_ms = _tick_get_ms();
         ESP_LOGI(TAG, "Reconnect after %d ms", client->wait_timeout_ms);
     }
+
+    if (error_type == WEBSOCKET_ERROR_TYPE_TCP_TRANSPORT)
+    {
+        client->error_handle.esp_tls_last_esp_err =
+            esp_tls_get_and_clear_last_error(esp_transport_get_error_handle(client->transport),
+                                             &client->error_handle.esp_tls_stack_err,
+                                             &client->error_handle.esp_tls_cert_verify_flags);
+        client->error_handle.esp_transport_sock_errno = esp_transport_get_errno(client->transport);
+    }
+
+    client->error_handle.error_type = error_type;
+    esp_websocket_client_dispatch_event(client, WEBSOCKET_EVENT_ERROR, NULL, 0);
+
     client->state = WEBSOCKET_STATE_WAIT_TIMEOUT;
     esp_websocket_client_dispatch_event(client, WEBSOCKET_EVENT_DISCONNECTED, NULL, 0);
     return ESP_OK;
@@ -647,6 +662,19 @@ esp_err_t esp_websocket_client_set_uri(esp_websocket_client_handle_t client, con
     return ESP_OK;
 }
 
+esp_err_t esp_websocket_client_set_headers(esp_websocket_client_handle_t client, const char *headers)
+{
+    if (client == NULL || headers == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    xSemaphoreTakeRecursive(client->lock, portMAX_DELAY);
+    esp_err_t ret = esp_transport_ws_set_headers(client->transport, headers);
+    xSemaphoreGiveRecursive(client->lock);
+
+    return ret;
+}
+
 static esp_err_t esp_websocket_client_recv(esp_websocket_client_handle_t client)
 {
     int rlen;
@@ -730,13 +758,23 @@ static void esp_websocket_client_task(void *pv)
                     client->run = false;
                     break;
                 }
+
+                esp_websocket_client_dispatch_event(client, WEBSOCKET_EVENT_BEFORE_CONNECT, NULL, 0);
+
                 int result = esp_transport_connect(client->transport,
                                                    client->config->host,
                                                    client->config->port,
                                                    client->config->network_timeout_ms);
                 if (result < 0) {
                     ESP_LOGE(TAG, "Error transport connect %i", result);
-                    esp_websocket_client_error_connection(client);
+
+                    int status = esp_transport_ws_get_http_status_code(client->transport);
+                    if (status > 0) {
+                        client->error_handle.esp_ws_handshake_status_code = status;
+                        esp_websocket_client_abort_connection(client, WEBSOCKET_ERROR_TYPE_HANDSHAKE);
+                    } else {
+                        esp_websocket_client_abort_connection(client, WEBSOCKET_ERROR_TYPE_TCP_TRANSPORT);
+                    }
                     break;
                 }
                 ESP_LOGD(TAG, "Transport connected to %s://%s:%d", client->config->scheme, client->config->host, client->config->port);
@@ -763,7 +801,7 @@ static void esp_websocket_client_task(void *pv)
                     if ( _tick_get_ms() - client->pingpong_tick_ms > client->config->pingpong_timeout_sec*1000 ) {
                         if (client->wait_for_pong_resp) {
                             ESP_LOGE(TAG, "Error, no PONG received for more than %d seconds after PING", client->config->pingpong_timeout_sec);
-                            esp_websocket_client_abort_connection(client);
+                            esp_websocket_client_abort_connection(client, WEBSOCKET_ERROR_TYPE_PONG_TIMEOUT);
                             break;
                         }
                     }
@@ -777,7 +815,7 @@ static void esp_websocket_client_task(void *pv)
 
                 if (esp_websocket_client_recv(client) == ESP_FAIL) {
                     ESP_LOGE(TAG, "Error receive data");
-                    esp_websocket_client_abort_connection(client);
+                    esp_websocket_client_abort_connection(client, WEBSOCKET_ERROR_TYPE_TCP_TRANSPORT);
                     break;
                 }
                 break;
@@ -810,7 +848,7 @@ static void esp_websocket_client_task(void *pv)
             read_select = esp_transport_poll_read(client->transport, 1000); //Poll every 1000ms
             if (read_select < 0) {
                 ESP_LOGE(TAG, "Network error: esp_transport_poll_read() returned %d, errno=%d", read_select, errno);
-                esp_websocket_client_abort_connection(client);
+                esp_websocket_client_abort_connection(client, WEBSOCKET_ERROR_TYPE_TCP_TRANSPORT);
             }
         } else if (WEBSOCKET_STATE_WAIT_TIMEOUT == client->state) {
             // waiting for reconnecting...
@@ -1005,7 +1043,7 @@ static int esp_websocket_client_send_with_opcode(esp_websocket_client_handle_t c
             ret = wlen;
             ESP_LOGE(TAG, "Network error: esp_transport_write() returned %d, errno=%d", ret, errno);
             esp_websocket_free_buf(client, true);
-            esp_websocket_client_abort_connection(client);
+            esp_websocket_client_abort_connection(client, WEBSOCKET_ERROR_TYPE_TCP_TRANSPORT);
             goto unlock_and_return;
         }
         current_opcode = 0;

--- a/components/esp_websocket_client/include/esp_websocket_client.h
+++ b/components/esp_websocket_client/include/esp_websocket_client.h
@@ -157,7 +157,7 @@ esp_err_t esp_websocket_client_set_uri(esp_websocket_client_handle_t client, con
  *             Must stop the WebSocket client before set headers if the client has been connected
  *
  * @param[in]  client  The client
- * @param[in]  uri     The uri
+ * @param headers  additional header strings each terminated with \r\n
  *
  * @return     esp_err_t
  */

--- a/components/esp_websocket_client/include/esp_websocket_client.h
+++ b/components/esp_websocket_client/include/esp_websocket_client.h
@@ -34,8 +34,34 @@ typedef enum {
     WEBSOCKET_EVENT_DISCONNECTED,   /*!< The connection has been disconnected */
     WEBSOCKET_EVENT_DATA,           /*!< When receiving data from the server, possibly multiple portions of the packet */
     WEBSOCKET_EVENT_CLOSED,         /*!< The connection has been closed cleanly */
+    WEBSOCKET_EVENT_BEFORE_CONNECT, /*!< The event occurs before connecting */
     WEBSOCKET_EVENT_MAX
 } esp_websocket_event_id_t;
+
+/**
+ * @brief Websocket connection error codes propagated via ERROR event
+ */
+typedef enum {
+    WEBSOCKET_ERROR_TYPE_NONE = 0,
+    WEBSOCKET_ERROR_TYPE_TCP_TRANSPORT,
+    WEBSOCKET_ERROR_TYPE_PONG_TIMEOUT,
+    WEBSOCKET_ERROR_TYPE_HANDSHAKE
+} esp_websocket_error_type_t;
+
+/**
+ * @brief Websocket error code structure to be passed as a contextual information into ERROR event
+ */
+typedef struct {
+    /* compatible portion of the struct corresponding to struct esp_tls_last_error */
+    esp_err_t esp_tls_last_esp_err;             /*!< last esp_err code reported from esp-tls component */
+    int       esp_tls_stack_err;                /*!< tls specific error code reported from underlying tls stack */
+    int       esp_tls_cert_verify_flags;        /*!< tls flags reported from underlying tls stack during certificate verification */
+    /* esp-websocket specific structure extension */
+    esp_websocket_error_type_t error_type;
+    int esp_ws_handshake_status_code;           /*!< http status code of the websocket upgrade handshake */
+    /* tcp_transport extension */
+    int       esp_transport_sock_errno;         /*!< errno from the underlying socket */
+} esp_websocket_error_codes_t;
 
 /**
  * @brief Websocket event data
@@ -49,6 +75,7 @@ typedef struct {
     void *user_context;                     /*!< user_data context, from esp_websocket_client_config_t user_data */
     int payload_len;                        /*!< Total payload length, payloads exceeding buffer will be posted through multiple events */
     int payload_offset;                     /*!< Actual offset for the data associated with this event */
+    esp_websocket_error_codes_t error_handle; /*!< esp-websocket error handle including esp-tls errors as well as internal websocket errors */
 } esp_websocket_event_data_t;
 
 /**
@@ -124,6 +151,17 @@ esp_websocket_client_handle_t esp_websocket_client_init(const esp_websocket_clie
  * @return     esp_err_t
  */
 esp_err_t esp_websocket_client_set_uri(esp_websocket_client_handle_t client, const char *uri);
+
+/**
+ * @brief      Set additional websocket headers for client, when performing this behavior, the headers will replace the old ones
+ *             Must stop the WebSocket client before set headers if the client has been connected
+ *
+ * @param[in]  client  The client
+ * @param[in]  uri     The uri
+ *
+ * @return     esp_err_t
+ */
+esp_err_t esp_websocket_client_set_headers(esp_websocket_client_handle_t client, const char *headers);
 
 /**
  * @brief      Open the WebSocket connection


### PR DESCRIPTION
see [this IDF 4.4 pull request](https://github.com/espressif/esp-idf/pull/9338) for more details

**NOTICE!!!**
These changes were implemented and tested with IDF 4.4. This pull request forwards all web-socket-client changes from the original pull request - except for the web-socket transport layer changes, since they are not part of this repository.

@gabsuren 
these depending changes have to be done separately on IDF 5.0