### PR TITLE
fix(esp-modem): On read/command callback fixes

### DIFF
--- a/components/esp_modem/include/cxx_include/esp_modem_dte.hpp
+++ b/components/esp_modem/include/cxx_include/esp_modem_dte.hpp
@@ -122,6 +122,7 @@ private:
     std::shared_ptr<Terminal> data_term;                    /*!< Secondary terminal for this DTE */
     modem_mode mode;                                        /*!< DTE operation mode */
     SignalGroup signal;                                     /*!< Event group used to signal request-response operations */
+    command_result result;                                  /*!< Command result of the currently exectuted command */
     std::function<bool(uint8_t *data, size_t len)> on_data; /*!< on data callback for current terminal */
 };
 

--- a/components/esp_modem/src/esp_modem_dte.cpp
+++ b/components/esp_modem/src/esp_modem_dte.cpp
@@ -35,9 +35,9 @@ DTE::DTE(std::unique_ptr<Terminal> terminal):
 command_result DTE::command(const std::string &command, got_line_cb got_line, uint32_t time_ms, const char separator)
 {
     Scoped<Lock> l(internal_lock);
-    command_result res = command_result::TIMEOUT;
+    result = command_result::TIMEOUT;
     signal.clear(GOT_LINE);
-    command_term->set_read_cb([&](uint8_t *data, size_t len) {
+    command_term->set_read_cb([this, got_line, separator](uint8_t *data, size_t len) {
         if (!data) {
             data = buffer.get();
             len = command_term->read(data + buffer.consumed, buffer.size - buffer.consumed);
@@ -45,8 +45,8 @@ command_result DTE::command(const std::string &command, got_line_cb got_line, ui
             buffer.consumed = 0; // if the underlying terminal contains data, we cannot fragment
         }
         if (memchr(data + buffer.consumed, separator, len)) {
-            res = got_line(data, buffer.consumed + len);
-            if (res == command_result::OK || res == command_result::FAIL) {
+            result = got_line(data, buffer.consumed + len);
+            if (result == command_result::OK || result == command_result::FAIL) {
                 signal.set(GOT_LINE);
                 return true;
             }
@@ -56,12 +56,12 @@ command_result DTE::command(const std::string &command, got_line_cb got_line, ui
     });
     command_term->write((uint8_t *)command.c_str(), command.length());
     auto got_lf = signal.wait(GOT_LINE, time_ms);
-    if (got_lf && res == command_result::TIMEOUT) {
+    if (got_lf && result == command_result::TIMEOUT) {
         ESP_MODEM_THROW_IF_ERROR(ESP_ERR_INVALID_STATE);
     }
     buffer.consumed = 0;
     command_term->set_read_cb(nullptr);
-    return res;
+    return result;
 }
 
 command_result DTE::command(const std::string &cmd, got_line_cb got_line, uint32_t time_ms)


### PR DESCRIPTION
* Made lambda to capture `std::function<>` by value (to control lifetime of the functor)
* Wait for a signal (*clear to update*) before modifying on-read callback