### PR TITLE
Added the missing definition for the esp_modem_set_baud function (IDFGH-9181)

### DIFF
--- a/components/esp_modem/src/esp_modem_c_api.cpp
+++ b/components/esp_modem/src/esp_modem_c_api.cpp
@@ -419,7 +419,7 @@ extern "C" esp_err_t esp_modem_command(esp_modem_dce_t *dce_wrap, const char *co
     }, timeout_ms));
 }
 
-extern "C" esp_err_t esp_modem_set_baud(esp_modem_dce_t* dce_wrap, int baud)
+extern "C" esp_err_t esp_modem_set_baud(esp_modem_dce_t *dce_wrap, int baud)
 {
-	return command_response_to_esp_err(dce_wrap->dce->set_baud(baud));
+    return command_response_to_esp_err(dce_wrap->dce->set_baud(baud));
 }

--- a/components/esp_modem/src/esp_modem_c_api.cpp
+++ b/components/esp_modem/src/esp_modem_c_api.cpp
@@ -418,3 +418,8 @@ extern "C" esp_err_t esp_modem_command(esp_modem_dce_t *dce_wrap, const char *co
         }
     }, timeout_ms));
 }
+
+extern "C" esp_err_t esp_modem_set_baud(esp_modem_dce_t* dce_wrap, int baud)
+{
+	return command_response_to_esp_err(dce_wrap->dce->set_baud(baud));
+}


### PR DESCRIPTION
This pull request should close #208

If I am not missing anything, it seems like the macro used to generate the C-API creates a signature for `esp_modem_set_baud ` function, but there is no definition for it available anywhere. I added a quick definition, which should solve the problem.

I've compiled some of the examples and used `esp_modem_set_baud` with success with this change.

Thank you for taking your time to review this pull request and have a great day!