### PR TITLE
mdns: bump the component version to 1.0.8

### DIFF
--- a/components/mdns/idf_component.yml
+++ b/components/mdns/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.7"
+version: "1.0.8"
 description: mDNS
 dependencies:
   idf:


### PR DESCRIPTION
to publish the latest component per recent fixes.