### PR TITLE
Add task_name config option (for websocket client) (IDFGH-9346)

### DIFF
--- a/components/esp_websocket_client/esp_websocket_client.c
+++ b/components/esp_websocket_client/esp_websocket_client.c
@@ -63,6 +63,7 @@ const static int CLOSE_FRAME_SENT_BIT = BIT1;   // Indicates that a close frame 
 ESP_EVENT_DEFINE_BASE(WEBSOCKET_EVENTS);
 
 typedef struct {
+    const char                 *task_name;
     int                         task_stack;
     int                         task_prio;
     char                        *uri;
@@ -235,6 +236,8 @@ static esp_err_t esp_websocket_client_set_config(esp_websocket_client_handle_t c
     if (cfg->task_prio <= 0) {
         cfg->task_prio = WEBSOCKET_TASK_PRIORITY;
     }
+
+    cfg->task_name = config->task_name;
 
     cfg->task_stack = config->task_stack;
     if (cfg->task_stack == 0) {
@@ -869,7 +872,8 @@ esp_err_t esp_websocket_client_start(esp_websocket_client_handle_t client)
         return ESP_FAIL;
     }
 
-    if (xTaskCreate(esp_websocket_client_task, "websocket_task", client->config->task_stack, client, client->config->task_prio, &client->task_handle) != pdTRUE) {
+    if (xTaskCreate(esp_websocket_client_task, client->config->task_name ? client->config->task_name : "websocket_task",
+                    client->config->task_stack, client, client->config->task_prio, &client->task_handle) != pdTRUE) {
         ESP_LOGE(TAG, "Error create websocket task");
         return ESP_FAIL;
     }

--- a/components/esp_websocket_client/include/esp_websocket_client.h
+++ b/components/esp_websocket_client/include/esp_websocket_client.h
@@ -74,6 +74,7 @@ typedef struct {
     bool                        disable_auto_reconnect;     /*!< Disable the automatic reconnect function when disconnected */
     void                        *user_context;              /*!< HTTP user data context */
     int                         task_prio;                  /*!< Websocket task priority */
+    const char                 *task_name;                  /*!< Websocket task name */
     int                         task_stack;                 /*!< Websocket task stack */
     int                         buffer_size;                /*!< Websocket buffer size */
     const char                  *cert_pem;                  /*!< Pointer to certificate data in PEM or DER format for server verify (with SSL), default is NULL, not required to verify the server. PEM-format must have a terminating NULL-character. DER-format requires the length to be passed in cert_len. */


### PR DESCRIPTION
I have had a stack overflow and could find out which of my many connected websocket clients was the cause, I started giving individual names to all of them using my patch.