### PR TITLE
components/mdns: use semaphore instead of task notification bits (IDFGH-9380) (IDFGH-9388)

### DIFF
--- a/components/mdns/private_include/mdns_private.h
+++ b/components/mdns/private_include/mdns_private.h
@@ -380,6 +380,7 @@ typedef struct mdns_server_s {
     mdns_srv_item_t *services;
     SemaphoreHandle_t lock;
     QueueHandle_t action_queue;
+    SemaphoreHandle_t action_sema;
     mdns_tx_packet_t *tx_queue_head;
     mdns_search_once_t *search_once;
     esp_timer_handle_t timer_handle;
@@ -390,7 +391,6 @@ typedef struct {
     union {
         struct {
             char *hostname;
-            TaskHandle_t calling_task;
         } hostname_set;
         char *instance;
         struct {


### PR DESCRIPTION
PR for https://github.com/espressif/esp-idf/issues/10754

Component should not alter the task notification bits of the calling task.