### PR TITLE
esp_modem: Return true from on_data callback in data mode

### DIFF
--- a/components/esp_modem/idf_component.yml
+++ b/components/esp_modem/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.1.26"
+version: "0.1.27"
 description: esp modem
 url: https://github.com/espressif/esp-protocols/tree/master/components/esp_modem
 dependencies:

--- a/components/esp_modem/src/esp_modem_netif.cpp
+++ b/components/esp_modem/src/esp_modem_netif.cpp
@@ -87,7 +87,7 @@ void Netif::start()
 {
     ppp_dte->set_read_cb([this](uint8_t *data, size_t len) -> bool {
         receive(data, len);
-        return false;
+        return true;
     });
     esp_netif_action_start(driver.base.netif, nullptr, 0, nullptr);
     signal.set(PPP_STARTED);

--- a/components/esp_modem/src/esp_modem_netif_linux.cpp
+++ b/components/esp_modem/src/esp_modem_netif_linux.cpp
@@ -39,7 +39,7 @@ void Netif::start()
 {
     ppp_dte->set_read_cb([this](uint8_t *data, size_t len) -> bool {
         receive(data, len);
-        return false;
+        return true;
     });
     netif->transmit = esp_modem_dte_transmit;
     netif->ctx = (void *)this;

--- a/components/esp_modem/src/esp_modem_uart.cpp
+++ b/components/esp_modem/src/esp_modem_uart.cpp
@@ -125,9 +125,7 @@ void UartTerminal::task()
             case UART_DATA:
                 uart_get_buffered_data_len(uart.port, &len);
                 if (len && on_read) {
-                    if (on_read(nullptr, len)) {
-                        on_read = nullptr;
-                    }
+                    on_read(nullptr, len);
                 }
                 break;
             case UART_FIFO_OVF:


### PR DESCRIPTION
* The DTE's on_data callback should return false only if there is a problem with the received data.
* The updated UART Terminal implementation cannot longer clear its callback. It is DTE's responsibility to clear the callback.

As a result, the UART implementation ignores the returned value from on_data callback. However, this feature is important for USB DTE implementation that handles RX data differently.

PTAL @david-cermak 