### PR TITLE
esp_modem: Dual DTE support

### DIFF
--- a/components/esp_modem/idf_component.yml
+++ b/components/esp_modem/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.1.27"
+version: "0.1.28"
 description: esp modem
 url: https://github.com/espressif/esp-protocols/tree/master/components/esp_modem
 dependencies:

--- a/components/esp_modem/include/cxx_include/esp_modem_dte.hpp
+++ b/components/esp_modem/include/cxx_include/esp_modem_dte.hpp
@@ -39,9 +39,12 @@ public:
      * @brief Creates a DTE instance from the terminal
      * @param config DTE config structure
      * @param t unique-ptr to Terminal
+     * @param s unique-ptr to secondary Terminal
      */
     explicit DTE(const esp_modem_dte_config *config, std::unique_ptr<Terminal> t);
     explicit DTE(std::unique_ptr<Terminal> t);
+    explicit DTE(const esp_modem_dte_config *config, std::unique_ptr<Terminal> t, std::unique_ptr<Terminal> s);
+    explicit DTE(std::unique_ptr<Terminal> t, std::unique_ptr<Terminal> s);
 
     ~DTE() = default;
 

--- a/components/esp_modem/include/cxx_include/esp_modem_types.hpp
+++ b/components/esp_modem/include/cxx_include/esp_modem_types.hpp
@@ -27,8 +27,9 @@ namespace esp_modem {
  */
 enum class modem_mode {
     UNDEF,
-    COMMAND_MODE, /*!< Command mode -- the modem is supposed to send AT commands in this mode  */
+    COMMAND_MODE, /*!< Command mode -- the modem is supposed to send AT commands in this mode */
     DATA_MODE,    /*!< Data mode -- the modem communicates with network interface on PPP protocol */
+    DUAL_MODE,    /*!< Dual mode -- the modem has two real terminals. Data and commands work at the same time */
     CMUX_MODE,    /*!< CMUX (Multiplex mode) -- Simplified CMUX mode, which creates two virtual terminals,
                    *  assigning one solely to command interface and the other  to the data mode */
     CMUX_MANUAL_MODE,    /*!< Enter CMUX mode manually -- just creates two virtual terminals */

--- a/components/esp_modem/src/esp_modem_dce.cpp
+++ b/components/esp_modem/src/esp_modem_dce.cpp
@@ -88,6 +88,7 @@ bool DCE_Mode::set_unsafe(DTE *dte, ModuleIf *device, Netif &netif, modem_mode m
 {
     switch (m) {
     case modem_mode::UNDEF:
+    case modem_mode::DUAL_MODE: // Only DTE can be in Dual mode
         break;
     case modem_mode::COMMAND_MODE:
         if (mode == modem_mode::COMMAND_MODE || mode >= modem_mode::CMUX_MANUAL_MODE) {


### PR DESCRIPTION
Modems can expose 2 terminals, which can be used simultaneously. One for AT commands, the other one for data.

* Added new DTE constructors that accept two instances of `Terminal` class
* Added new DTE state 'DUAL'

Tested with USB modem SimCom A7670E

@david-cermak PTAL