### PR TITLE
mdns: append all ipv6 address in mdns answer (IDFGH-9646)

### DIFF
--- a/components/mdns/private_include/mdns_private.h
+++ b/components/mdns/private_include/mdns_private.h
@@ -33,6 +33,12 @@
 #endif
 #define MDNS_MAX_PREDEF_INTERFACES (CONFIG_MDNS_PREDEF_NETIF_STA + CONFIG_MDNS_PREDEF_NETIF_AP + CONFIG_MDNS_PREDEF_NETIF_ETH)
 
+#ifdef CONFIG_LWIP_IPV6_NUM_ADDRESSES
+#define NETIF_IPV6_MAX_NUMS CONFIG_LWIP_IPV6_NUM_ADDRESSES
+#else
+#define NETIF_IPV6_MAX_NUMS 3
+#endif
+
 /** Number of configured interfaces */
 #if MDNS_MAX_PREDEF_INTERFACES > CONFIG_MDNS_MAX_INTERFACES
 #warning Number of configured interfaces is less then number of predefined interfaces. Please update CONFIG_MDNS_MAX_INTERFACES.

--- a/components/mdns/tests/host_test/components/esp_netif_linux/esp_netif_linux.c
+++ b/components/mdns/tests/host_test/components/esp_netif_linux/esp_netif_linux.c
@@ -64,6 +64,29 @@ esp_err_t esp_netif_dhcpc_get_status(esp_netif_t *esp_netif, esp_netif_dhcp_stat
     return ESP_OK;
 }
 
+int esp_netif_get_all_ip6(esp_netif_t *esp_netif, esp_ip6_addr_t if_ip6[])
+{
+    if (esp_netif == NULL) {
+        return 0;
+    }
+    struct ifaddrs *addrs, *tmp;
+    int addr_count = 0;
+    getifaddrs(&addrs);
+    tmp = addrs;
+
+    while (tmp) {
+        if (tmp->ifa_addr && tmp->ifa_addr->sa_family == AF_INET6) {
+            struct sockaddr_in6 *pAddr = (struct sockaddr_in6 *)tmp->ifa_addr;
+            if (strcmp(esp_netif->if_desc, tmp->ifa_name) == 0) {
+                memcpy(&if_ip6[addr_count++], &pAddr->sin6_addr, 4 * 4);
+            }
+        }
+        tmp = tmp->ifa_next;
+    }
+
+    freeifaddrs(addrs);
+    return addr_count;
+}
 
 esp_err_t esp_netif_get_ip6_linklocal(esp_netif_t *esp_netif, esp_ip6_addr_t *if_ip6)
 {


### PR DESCRIPTION
**Description:** When the netif interface with link-local and many routable addresses, If a device query a mDNS service in local network, the ESP-device with mDNS feature responses the query with the link-local address AAAA resource record only in reponsed message.
**Requirement:** The address queries response message should include all ipv6 address accord to the RFC 6762's 6.2 section.
**Related Issue:** IDFGH-9637

