### PR TITLE
esp_modem: Update examples for USB v1.1

### DIFF
--- a/components/esp_modem/examples/modem_console/main/Kconfig.projbuild
+++ b/components/esp_modem/examples/modem_console/main/Kconfig.projbuild
@@ -16,17 +16,18 @@ menu "Example Configuration"
     endchoice
 
     choice EXAMPLE_MODEM_DEVICE
-        depends on EXAMPLE_SERIAL_CONFIG_UART
         prompt "Choose supported modem device (DCE)"
         default EXAMPLE_MODEM_DEVICE_BG96
         help
             Select modem device connected to the ESP DTE.
         config EXAMPLE_MODEM_DEVICE_SHINY
+            depends on EXAMPLE_SERIAL_CONFIG_UART
             bool "SHINY"
             help
                 SHINY is a GSM/GPRS module.
                 It supports SHINY.
         config EXAMPLE_MODEM_DEVICE_SIM800
+            depends on EXAMPLE_SERIAL_CONFIG_UART
             bool "SIM800"
             help
                 SIMCom SIM800L is a GSM/GPRS module.
@@ -36,10 +37,12 @@ menu "Example Configuration"
             help
                 Quectel BG96 is a series of LTE Cat M1/Cat NB1/EGPRS module.
         config EXAMPLE_MODEM_DEVICE_SIM7000
+            depends on EXAMPLE_SERIAL_CONFIG_UART
             bool "SIM7000"
             help
                 SIM7000 is a Multi-Band LTE-FDD and GSM/GPRS/EDGE module.
         config EXAMPLE_MODEM_DEVICE_SIM7070
+            depends on EXAMPLE_SERIAL_CONFIG_UART
             bool "SIM7070"
             help
                 SIM7070 is Multi-Band CAT M and NB IoT module.
@@ -47,6 +50,11 @@ menu "Example Configuration"
             bool "SIM7600"
             help
                 SIM7600 is a Multi-Band LTE-TDD/LTE-FDD/HSPA+ and GSM/GPRS/EDGE module.
+        config EXAMPLE_MODEM_DEVICE_A7670
+            depends on EXAMPLE_SERIAL_CONFIG_USB
+            bool "A7670"
+            help
+                A7670X is Multi-Band LTE-FDD/LTE-TDD/GSM/GPRS/EDGE module.
     endchoice
 
     config EXAMPLE_MODEM_PPP_APN

--- a/components/esp_modem/examples/modem_console/main/idf_component.yml
+++ b/components/esp_modem/examples/modem_console/main/idf_component.yml
@@ -6,7 +6,7 @@ dependencies:
     version: "^0.1.20"
     override_path: "../../../"
   espressif/esp_modem_usb_dte:
-    version: "^1.0.0"
+    version: "^1.1.0"
     rules:
       - if: "idf_version >=4.4"
       - if: "target in [esp32s2, esp32s3]"

--- a/components/esp_modem/examples/pppos_client/main/Kconfig.projbuild
+++ b/components/esp_modem/examples/pppos_client/main/Kconfig.projbuild
@@ -15,12 +15,12 @@ menu "Example Configuration"
     endchoice
 
     choice EXAMPLE_MODEM_DEVICE
-        depends on EXAMPLE_SERIAL_CONFIG_UART
         prompt "Choose supported modem device (DCE)"
         default EXAMPLE_MODEM_DEVICE_BG96
         help
             Select modem device connected to the ESP DTE.
         config EXAMPLE_MODEM_DEVICE_SIM800
+            depends on EXAMPLE_SERIAL_CONFIG_UART
             bool "SIM800"
             help
                 SIMCom SIM800L is a GSM/GPRS module.
@@ -30,10 +30,12 @@ menu "Example Configuration"
             help
                 Quectel BG96 is a series of LTE Cat M1/Cat NB1/EGPRS module.
         config EXAMPLE_MODEM_DEVICE_SIM7000
+            depends on EXAMPLE_SERIAL_CONFIG_UART
             bool "SIM7000"
             help
                 SIM7000 is a Multi-Band LTE-FDD and GSM/GPRS/EDGE module.
         config EXAMPLE_MODEM_DEVICE_SIM7070
+            depends on EXAMPLE_SERIAL_CONFIG_UART
             bool "SIM7070"
             help
                 SIM7070 is Multi-Band CAT M and NB IoT module.
@@ -41,6 +43,11 @@ menu "Example Configuration"
             bool "SIM7600"
             help
                 SIM7600 is a Multi-Band LTE-TDD/LTE-FDD/HSPA+ and GSM/GPRS/EDGE module.
+        config EXAMPLE_MODEM_DEVICE_A7670
+            depends on EXAMPLE_SERIAL_CONFIG_USB
+            bool "A7670"
+            help
+                A7670X is Multi-Band LTE-FDD/LTE-TDD/GSM/GPRS/EDGE module.
     endchoice
 
     config EXAMPLE_MODEM_PPP_APN

--- a/components/esp_modem/examples/pppos_client/main/idf_component.yml
+++ b/components/esp_modem/examples/pppos_client/main/idf_component.yml
@@ -6,7 +6,7 @@ dependencies:
     version: "^0.1.23"
     override_path: "../../../"
   espressif/esp_modem_usb_dte:
-    version: "^1.0.0"
+    version: "^1.1.0"
     rules:
       - if: "idf_version >=4.4"
       - if: "target in [esp32s2, esp32s3]"

--- a/components/esp_modem/examples/pppos_client/main/pppos_client_main.c
+++ b/components/esp_modem/examples/pppos_client/main/pppos_client_main.c
@@ -208,14 +208,28 @@ void app_main(void)
 
 #elif defined(CONFIG_EXAMPLE_SERIAL_CONFIG_USB)
     while (1) {
+#if CONFIG_EXAMPLE_MODEM_DEVICE_BG96 == 1
         ESP_LOGI(TAG, "Initializing esp_modem for the BG96 module...");
-        struct esp_modem_usb_term_config usb_config = ESP_MODEM_DEFAULT_USB_CONFIG(0x2C7C, 0x0296, 2); // VID, PID and interface num of BG96 modem
+        struct esp_modem_usb_term_config usb_config = ESP_MODEM_BG96_USB_CONFIG();
+        esp_modem_dce_device_t usb_dev_type = ESP_MODEM_DCE_BG96;
+#elif CONFIG_EXAMPLE_MODEM_DEVICE_SIM7600 == 1
+        ESP_LOGI(TAG, "Initializing esp_modem for the SIM7600 module...");
+        struct esp_modem_usb_term_config usb_config = ESP_MODEM_SIM7600_USB_CONFIG();
+        esp_modem_dce_device_t usb_dev_type = ESP_MODEM_DCE_SIM7600;
+#elif CONFIG_EXAMPLE_MODEM_DEVICE_A7670 == 1
+        ESP_LOGI(TAG, "Initializing esp_modem for the A7670 module...");
+        struct esp_modem_usb_term_config usb_config = ESP_MODEM_A7670_USB_CONFIG();
+        esp_modem_dce_device_t usb_dev_type = ESP_MODEM_DCE_SIM7600;
+#else
+#error USB modem not selected
+#endif
         const esp_modem_dte_config_t dte_usb_config = ESP_MODEM_DTE_DEFAULT_USB_CONFIG(usb_config);
         ESP_LOGI(TAG, "Waiting for USB device connection...");
-        esp_modem_dce_t *dce = esp_modem_new_dev_usb(ESP_MODEM_DCE_BG96, &dte_usb_config, &dce_config, esp_netif);
+        esp_modem_dce_t *dce = esp_modem_new_dev_usb(usb_dev_type, &dte_usb_config, &dce_config, esp_netif);
         assert(dce);
         esp_modem_set_error_cb(dce, usb_terminal_error_handler);
-        vTaskDelay(pdMS_TO_TICKS(1000)); // Although the DTE should be ready after USB enumeration, sometimes it fails to respond without this delay
+        ESP_LOGI(TAG, "Modem connected, waiting 10 seconds for boot...");
+        vTaskDelay(pdMS_TO_TICKS(10000)); // Give DTE some time to boot
 
 #else
 #error Invalid serial connection to modem.


### PR DESCRIPTION
Update esp_modem examples for new features in esp_modem_usb_dte v1.1

* Fix: modem_console: Take default apn name from Kconfig
* Use default USB configurations from esp_modem_usb_dte v1.1, including dual DTE SimCom A7670

### Related
* https://github.com/espressif/esp-protocols/issues/133
* https://github.com/espressif/esp-protocols/issues/200