### PR TITLE
fix(ci): Run pre-commit checker only on PRs

### DIFF
--- a/.github/workflows/pre_commit_check.yml
+++ b/.github/workflows/pre_commit_check.yml
@@ -1,9 +1,6 @@
 name: Check pre-commit rules
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
     types: [opened, reopened, synchronize]
 


### PR DESCRIPTION
Regression from  https://github.com/espressif/esp-protocols/pull/242, where I accidentally added `on: push` trigger for the job that's supposed to be run only on PRs.

Introduced in a089e0d6800ad20b090baa32ae033571f93bf198 