### PR TITLE
Fix deadly mdns crash (IDFGH-9800)

### DIFF
--- a/components/mdns/mdns.c
+++ b/components/mdns/mdns.c
@@ -1614,18 +1614,20 @@ static void _mdns_remove_scheduled_answer(mdns_if_t tcpip_if, mdns_ip_protocol_t
     while (q) {
         if (q->tcpip_if == tcpip_if && q->ip_protocol == ip_protocol && q->distributed) {
             mdns_out_answer_t *a = q->answers;
-            if (a->type == type && a->service == service->service) {
-                q->answers = q->answers->next;
-                free(a);
-            } else {
-                while (a->next) {
-                    if (a->next->type == type && a->next->service == service->service) {
-                        mdns_out_answer_t *b = a->next;
-                        a->next = b->next;
-                        free(b);
-                        break;
+            if (a) {
+                if (a->type == type && a->service == service->service) {
+                    q->answers = q->answers->next;
+                    free(a);
+                } else {
+                    while (a->next) {
+                        if (a->next->type == type && a->next->service == service->service) {
+                            mdns_out_answer_t *b = a->next;
+                            a->next = b->next;
+                            free(b);
+                            break;
+                        }
+                        a = a->next;
                     }
-                    a = a->next;
                 }
             }
         }


### PR DESCRIPTION
A customer had hundrets of thousands of recorded crashes in the mdns code because answers was a nullptr.

We are inserting all esp crashes in our sentry which has the stack already decoded and ordered by fimrware version, esp-idf version and customer serial number.

I know if I recorded a malicious packet and sent it to espressif I could get a bounty price but I do this for charity now :)
I was too lazy to build a remote packet sniffer for the esp as driving to the customers site was not possible.