### PR TITLE
mDNS: Add an NSEC record for a host that has no address. (IDFGH-9966)

### DIFF
--- a/components/mdns/include/mdns.h
+++ b/components/mdns/include/mdns.h
@@ -97,6 +97,16 @@ typedef struct mdns_result_s {
     mdns_ip_addr_t *addr;                   /*!< linked list of IP addresses found */
 } mdns_result_t;
 
+/**
+ * @brief mDNS NSEC bitmap struct definition
+ *
+ */
+#define _MDNS_MAX_RR_BITMAP_VALUE   255
+typedef struct _mdns_bitmap {
+    uint16_t size;
+    uint64_t value[((_MDNS_MAX_RR_BITMAP_VALUE + 1) / sizeof(uint64_t) * 8)];
+} _mdns_bitmap_t;
+
 typedef void (*mdns_query_notify_t)(mdns_search_once_t *search);
 
 /**

--- a/components/mdns/private_include/mdns_private.h
+++ b/components/mdns/private_include/mdns_private.h
@@ -55,6 +55,7 @@
 #define MDNS_ANSWER_SRV_TTL         120
 #define MDNS_ANSWER_A_TTL           120
 #define MDNS_ANSWER_AAAA_TTL        120
+#define MDNS_ANSWER_NSEC_TTL        4500
 
 #define MDNS_FLAGS_QUERY_REPSONSE   0x8000
 #define MDNS_FLAGS_AUTHORITATIVE    0x0400
@@ -77,7 +78,7 @@
 #define MDNS_ANSWER_SRV             0x02
 #define MDNS_ANSWER_A               0x01
 #define MDNS_ANSWER_AAAA            0x10
-#define MDNS_ANSWER_NSEC            0x20
+#define MDNS_ANSWER_NSEC            0x2f
 #define MDNS_ANSWER_SDPTR           0x80
 #define MDNS_ANSWER_AAAA_SIZE       16
 


### PR DESCRIPTION
### Problem Description
- When a querier is querying for a AAAA record, and the host name in question has no associated IPv6 addresses.  In this case, the responding host knows it currently has exclusive ownership of that name, and it knows that it currently does not have any IPv6 addresses, so an explicit negative response is preferable to the querier having to retransmit its query multiple times.

###  Modification
- Allow to add the host which has no address.
- Add address detection to the host.
- Add NSEC record type. 

### Relate Issuse
[issue](https://github.com/espressif/esp-protocols/issues/258)