### PR TITLE
ci(common): Add support to bump component versions automatically

### DIFF
--- a/.github/workflows/publish-docs-component.yml
+++ b/.github/workflows/publish-docs-component.yml
@@ -13,8 +13,34 @@ env:
   DOCS_DEPLOY_PATH : ${{ secrets.DOCS_DEPLOY_PATH }}
 
 jobs:
+  bump_version:
+    if: "!startsWith(github.event.head_commit.message, 'bump')"
+    runs-on: ubuntu-latest
+    name: "Bump version and create changelog with commitizen"
+    steps:
+      - name: Check out
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          token: "${{ secrets.GITHUB_TOKEN }}"
+      - id: cz
+        name: Create bump and changelog
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: ./ci/bump
+      - name: Release
+        if: env.CURRENT_TAG != ''
+        uses: softprops/action-gh-release@v1
+        with:
+          body_path: "release_notes.md"
+          tag_name: ${{ env.CURRENT_TAG }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   docs_build:
     name: Docs-Build-And-Upload
+    needs: bump_version
     runs-on: ubuntu-latest
     # Skip running on forks since it won't have access to secrets
     if: github.repository == 'espressif/esp-protocols'

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+release_notes.md

--- a/ci/bump
+++ b/ci/bump
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -e
+
+if ! git show -s | grep -q '@bot bump '; then
+    echo "@bot: No bump command in the current (merge) commit, not updating..."
+    exit 0;
+fi
+
+echo "Checking all components:"
+for comp in asio modem websocket mdns mqtt_cxx; do
+    BUMP_CMD=`git show -s | grep "@bot bump ${comp}"` || true
+    if [ ! -z "${BUMP_CMD}" ]; then
+        BUMP_ARGS=${BUMP_CMD##*bump ${comp} }
+        echo "Bumping version number of component ${comp} (${BUMP_ARGS})"
+        git config --global --add safe.directory "*"
+        git config --local user.name "github-actions[bot]"
+        git config --local user.email "github-actions[bot]@users.noreply.github.com"
+        git config --local pull.rebase true
+
+        pip install commitizen sh
+
+        cd components/${comp}
+        cz bump ${BUMP_ARGS}
+
+        CURRENT_TAG=`git describe --exact-match --tags`
+        echo "CURRENT_TAG=${CURRENT_TAG}" >> "$GITHUB_ENV"
+
+        GITHUB_DOMAIN=${GITHUB_SERVER_URL#*//}
+        CURRENT_BRANCH="$(git branch --show-current)"
+        REPO="https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@${GITHUB_DOMAIN}/${GITHUB_REPOSITORY}.git"
+        git pull "$REPO" "$CURRENT_BRANCH"
+        git push "$REPO" "HEAD:${CURRENT_BRANCH}" --tags
+        echo "component ${comp} updated to ${CURRENT_TAG}"
+        exit 0
+    fi
+done

--- a/ci/changelog.py
+++ b/ci/changelog.py
@@ -93,6 +93,10 @@ def main():
         updated_changelog.write(orig_items)
     git.add(filename)
 
+    # write the current changelog entry to local release-notes file
+    with open(os.path.join(root_path, 'release_notes.md'), 'w') as release_notes:
+        release_notes.write(changelog)
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
If configured using "@bot bump" command in the PR Merge commit

### TODO:

* [ ] Update `CONTRIBUTING.md`
* [ ] Test and skip running on forks (no access to secrets)