### PR TITLE
ci(common): Support for tagging and releasing in CI

### DIFF
--- a/.github/workflows/pre_commit_check.yml
+++ b/.github/workflows/pre_commit_check.yml
@@ -15,12 +15,14 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ github.base_ref }}
+          fetch-depth: 20
       - name: Fetch head and base refs
         # This is necessary for pre-commit to check the changes in the PR branch (and to set origin/HEAD and HEAD refs)
         run: |
           git fetch origin ${{ github.event.pull_request.head.sha }}:pr_ref
           git checkout pr_ref
           git remote set-head origin --auto
+          git merge-base origin/HEAD HEAD || ( echo "Your PR is far behind origin/HEAD, please rebase" && exit 1 )
       - name: Set up Python environment
         uses: actions/setup-python@master
         with:

--- a/.github/workflows/publish-docs-component.yml
+++ b/.github/workflows/publish-docs-component.yml
@@ -13,18 +13,36 @@ env:
   DOCS_DEPLOY_PATH : ${{ secrets.DOCS_DEPLOY_PATH }}
 
 jobs:
-  docs_build:
-    name: Docs-Build-And-Upload
+  publish:
+    name: Publish Tag, Release, Docs, Component
     runs-on: ubuntu-latest
     # Skip running on forks since it won't have access to secrets
     if: github.repository == 'espressif/esp-protocols'
     steps:
       - name: Checkout esp-protocols
-        uses: actions/checkout@master
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
           fetch-depth: 0
           submodules: recursive
+          token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Check for version update
+        shell: bash
+        run: ./ci/detect_component_bump
+      - name: Tag merge commit
+        if: env.BUMP_VERSION != ''
+        uses: anothrNick/github-tag-action@1.61.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CUSTOM_TAG: ${{ env.BUMP_TAG }}
+      - name: Create Release
+        if: env.BUMP_VERSION != ''
+        uses: softprops/action-gh-release@v1
+        with:
+          body_path: "release_notes.md"
+          tag_name: ${{ env.BUMP_TAG }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Generate docs
         shell: bash
         run: |

--- a/.github/workflows/publish-docs-component.yml
+++ b/.github/workflows/publish-docs-component.yml
@@ -43,27 +43,27 @@ jobs:
           tag_name: ${{ env.BUMP_TAG }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Generate docs
-        shell: bash
-        run: |
-            sudo apt-get update
-            sudo apt-get -y install doxygen clang python3-pip
-            python -m pip install breathe recommonmark esp-docs==1.4.1
-            cd $GITHUB_WORKSPACE/docs
-            ./generate_docs
-      - name: Deploying generated docs
-        if: always()
-        shell: bash
-        run: |
-            source $GITHUB_WORKSPACE/docs/utils.sh
-            add_doc_server_ssh_keys $DOCS_DEPLOY_KEY $DOCS_DEPLOY_SERVER $DOCS_DEPLOY_SERVER_USER
-            export GIT_VER=$(git describe --always)
-            export GITHUB_REF_NAME=latest
-            export DOCS_BUILD_DIR=$GITHUB_WORKSPACE/docs
-            deploy-docs
-      - name: Upload components to component service
-        uses: espressif/github-actions/upload_components@master
-        with:
-          directories: "components/esp_modem;components/esp_websocket_client;components/mdns;components/asio;components/esp_mqtt_cxx"
-          namespace: "espressif"
-          api_token: ${{ secrets.IDF_COMPONENT_API_TOKEN }}
+      # - name: Generate docs
+      #   shell: bash
+      #   run: |
+      #       sudo apt-get update
+      #       sudo apt-get -y install doxygen clang python3-pip
+      #       python -m pip install breathe recommonmark esp-docs==1.4.1
+      #       cd $GITHUB_WORKSPACE/docs
+      #       ./generate_docs
+      # - name: Deploying generated docs
+      #   if: always()
+      #   shell: bash
+      #   run: |
+      #       source $GITHUB_WORKSPACE/docs/utils.sh
+      #       add_doc_server_ssh_keys $DOCS_DEPLOY_KEY $DOCS_DEPLOY_SERVER $DOCS_DEPLOY_SERVER_USER
+      #       export GIT_VER=$(git describe --always)
+      #       export GITHUB_REF_NAME=latest
+      #       export DOCS_BUILD_DIR=$GITHUB_WORKSPACE/docs
+      #       deploy-docs
+      # - name: Upload components to component service
+      #   uses: espressif/github-actions/upload_components@master
+      #   with:
+      #     directories: "components/esp_modem;components/esp_websocket_client;components/mdns;components/asio;components/esp_mqtt_cxx"
+      #     namespace: "espressif"
+      #     api_token: ${{ secrets.IDF_COMPONENT_API_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,8 +24,8 @@ When releasing a new component version we have to:
 * Deploy the component to component registry
 * Update the documentation
 
-This process is not fully automated, the first three steps need to be performed manually by project maintainers running the `bump` command (from within this repository, rather than forks, to publish the release `tag`). Release procedure is as follows:
-* Create a branch in this repository (not from fork)
-* Run `cz bump [version]` (version number is optional, `cz` would automatically increment it if not present)
-* Check the updated `CHANGELOG.md`
-* Create and merge the branch to master
+This process is not fully automated, the first step needs to be performed manually by project maintainers running the `bump` command. Release procedure is as follows:
+* Run `ci/bump [component] [version]` (version number is optional, `cz` would automatically increment it if not present)
+* Check the updated `CHANGELOG.md` and the generated bump commit message
+* Create a PR
+Once the PR is merged, the CI job tags the merge commit, creates a new release, builds and deploys documentation and the new component to the component registry

--- a/ci/bump
+++ b/ci/bump
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+if [ -z "$1" ]; then
+    echo "Usage: bump component [version]"
+    exit 1;
+fi
+
+comp=$1; shift;
+
+cd components/${comp}
+if ! cz bump --dry-run; then
+    echo "Commitizen bump commad failed!"
+    exit 1;
+fi
+
+cz_bump_out=`cz bump --files-only "$@"`
+commit_title=`echo "${cz_bump_out}" | head -1`
+commit_body=`cat ../../release_notes.txt`
+
+git add -u .
+git commit -m $"${commit_title}
+
+${commit_body}"

--- a/ci/changelog.py
+++ b/ci/changelog.py
@@ -93,6 +93,13 @@ def main():
         updated_changelog.write(orig_items)
     git.add(filename)
 
+    # write the current changelog entry to a local text file (removing links, captions and extra newlines)
+    changelog = re.sub(r'\[([^\]]+)\]\([^\)]+\)', r'\1', changelog)
+    changelog = re.sub(r'\#\#[\#\s]*(.+)', r'\1', changelog)
+    changelog = re.sub(r'\n\n', '\n', changelog)
+    with open(os.path.join(root_path, 'release_notes.txt'), 'w') as release_notes:
+        release_notes.write(changelog)
+
 
 if __name__ == '__main__':
     main()

--- a/ci/detect_component_bump
+++ b/ci/detect_component_bump
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -e
+
+if ! git show -s | grep -q '^Merge'; then
+    echo "Not a merge commit"
+    exit 0;
+fi
+
+for comp in  `ls components`; do
+if git log -1 -m --name-only --pretty="" | grep -q components/${comp}/idf_component.yml; then
+    echo "${comp}: Component version has been updated"
+    version=`grep version: components/${comp}/.cz.yaml`
+    version=${version#*version: }
+
+    tag_format=`grep tag_format: components/${comp}/.cz.yaml`
+    tag_format=${tag_format#*tag_format: }
+
+    eval tag=$tag_format
+
+    # creates release notes from the last entry (between first two "## sections")
+    awk '/^## \[/{a++};{if(a==1){print}}' components/${comp}/CHANGELOG.md > release_notes.md
+
+    echo "BUMP_VERSION=${version}"
+    echo "BUMP_COMPONENT=${comp}"
+    echo "BUMP_TAG=${tag}"
+
+    # export the findings to github env, so it could be used in other jobs
+    echo "BUMP_VERSION=${version}" >> "$GITHUB_ENV"
+    echo "BUMP_COMPONENT=${comp}" >> "$GITHUB_ENV"
+    echo "BUMP_TAG=${tag}" >> "$GITHUB_ENV"
+
+    exit 0;
+fi
+done
+echo "No changes in component version file"


### PR DESCRIPTION
Alternative to https://github.com/espressif/esp-protocols/pull/276

* `bump` command needs to be executed manually
* tag will be created on master branch (on the Merge commit)
* release will be created
