### PR TITLE
fix(mdns): Run host test against v5.1 instead of latest IDF

### DIFF
--- a/.github/workflows/mdns__host-tests.yml
+++ b/.github/workflows/mdns__host-tests.yml
@@ -12,7 +12,7 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'mdns') || github.event_name == 'push'
     name: Host test
     runs-on: ubuntu-20.04
-    container: espressif/idf:latest
+    container: espressif/idf:release-v5.1
 
     steps:
       - name: Checkout esp-protocols


### PR DESCRIPTION
* Compilation of our current mDNS host test fails with latest IDF
   - IDF now supports FreeRTOS simulator
* Use v5.1 to run the test
* Next step is to use FreeRTOS simulator with latest IDF (TODO in a followup PR)