### PR TITLE
mdns: allow for adding a delegated host with no address (IDFGH-10246)

### DIFF
--- a/components/mdns/mdns.c
+++ b/components/mdns/mdns.c
@@ -5577,7 +5577,7 @@ esp_err_t mdns_delegate_hostname_add(const char *hostname, const mdns_ip_addr_t 
     if (!_mdns_server) {
         return ESP_ERR_INVALID_STATE;
     }
-    if (_str_null_or_empty(hostname) || strlen(hostname) > (MDNS_NAME_BUF_LEN - 1) || address_list == NULL) {
+    if (_str_null_or_empty(hostname) || strlen(hostname) > (MDNS_NAME_BUF_LEN - 1)) {
         return ESP_ERR_INVALID_ARG;
     }
     char *new_hostname = strndup(hostname, MDNS_NAME_BUF_LEN - 1);


### PR DESCRIPTION
Allow mdns to add a delegated host with no address.