### PR TITLE
fix(modem): Refactor of DTE callbacks (and other fixes)

### DIFF
--- a/components/esp_modem/Kconfig
+++ b/components/esp_modem/Kconfig
@@ -16,6 +16,17 @@ menu "esp-modem"
             in command mode might come fragmented in rare cases so might need to retry
             AT commands.
 
+    config ESP_MODEM_USE_INFLATABLE_BUFFER_IF_NEEDED
+        bool "Use inflatable buffer in DCE"
+        default n
+        help
+            If enabled we will process the ongoing AT command by growing the current
+            buffer (if we've run out the preconfigured buffer).
+            If disabled, we simply report a failure.
+            Use this if additional allocation is not a problem and you need to reliably process
+            all commands, usually with sporadically longer responses than the configured buffer.
+            Could be also used to defragment AT replies in CMUX mode if CMUX_DEFRAGMENT_PAYLOAD=n
+
     config ESP_MODEM_CMUX_DELAY_AFTER_DLCI_SETUP
         int "Delay in ms to wait before creating another virtual terminal"
         default 0

--- a/components/esp_modem/examples/simple_cmux_client/main/simple_cmux_client_main.cpp
+++ b/components/esp_modem/examples/simple_cmux_client/main/simple_cmux_client_main.cpp
@@ -175,6 +175,9 @@ extern "C" void app_main(void)
 #endif
     assert(dce);
 
+    /* Try to connect to the network and publish an mqtt topic */
+    StatusHandler handler;
+
     if (dte_config.uart_config.flow_control == ESP_MODEM_FLOW_CONTROL_HW) {
         if (command_result::OK != dce->set_flow_control(2, 2)) {
             ESP_LOGE(TAG, "Failed to set the set_flow_control mode");
@@ -215,8 +218,6 @@ extern "C" void app_main(void)
     }
 #endif
 
-    /* Try to connect to the network and publish an mqtt topic */
-    StatusHandler handler;
     if (!handler.wait_for(StatusHandler::IP_Event, 60000)) {
         ESP_LOGE(TAG, "Cannot get IP within specified timeout... exiting");
         return;

--- a/components/esp_modem/include/cxx_include/esp_modem_dce_factory.hpp
+++ b/components/esp_modem/include/cxx_include/esp_modem_dce_factory.hpp
@@ -236,6 +236,14 @@ public:
         return nullptr;
     }
 
+    template <typename T_Module>
+    static std::unique_ptr<DCE> create_unique_dce_from(const esp_modem::dce_config *config,
+            std::shared_ptr<esp_modem::DTE> dte,
+            esp_netif_t *netif)
+    {
+        return build_generic_DCE<T_Module, DCE, std::unique_ptr<DCE>>(config, std::move(dte), netif);
+    }
+
 private:
     ModemType m;
 

--- a/components/esp_modem/include/cxx_include/esp_modem_netif.hpp
+++ b/components/esp_modem/include/cxx_include/esp_modem_netif.hpp
@@ -54,8 +54,9 @@ public:
      */
     void stop();
 
-private:
     void receive(uint8_t *data, size_t len);
+
+private:
 
     static esp_err_t esp_modem_dte_transmit(void *h, void *buffer, size_t len);
 

--- a/components/esp_modem/src/esp_modem_dce.cpp
+++ b/components/esp_modem/src/esp_modem_dce.cpp
@@ -39,6 +39,7 @@ static bool exit_data(DTE &dte, ModuleIf &device, Netif &netif)
     });
     netif.wait_until_ppp_exits();
     if (!signal->wait(1, 2000)) {
+        dte.set_read_cb(nullptr);
         if (!device.set_mode(modem_mode::COMMAND_MODE)) {
             return false;
         }

--- a/components/esp_modem/src/esp_modem_dce.cpp
+++ b/components/esp_modem/src/esp_modem_dce.cpp
@@ -21,10 +21,17 @@ static bool exit_data(DTE &dte, ModuleIf &device, Netif &netif)
     netif.stop();
     auto signal = std::make_shared<SignalGroup>();
     std::weak_ptr<SignalGroup> weak_signal = signal;
-    dte.set_read_cb([weak_signal](uint8_t *data, size_t len) -> bool {
+    dte.set_read_cb([&netif, weak_signal](uint8_t *data, size_t len) -> bool {
+        // post the transitioning data to the network layers if it contains PPP SOF marker
+        if (memchr(data, 0x7E, len))
+        {
+            ESP_LOG_BUFFER_HEXDUMP("esp-modem: debug_data (PPP)", data, len, ESP_LOG_DEBUG);
+            netif.receive(data, len);
+        }
+        // treat the transitioning data as a textual message if it contains a newline char
         if (memchr(data, '\n', len))
         {
-            ESP_LOG_BUFFER_HEXDUMP("esp-modem: debug_data", data, len, ESP_LOG_DEBUG);
+            ESP_LOG_BUFFER_HEXDUMP("esp-modem: debug_data (CMD)", data, len, ESP_LOG_DEBUG);
             const auto pass = std::list<std::string_view>({"NO CARRIER", "DISCONNECTED"});
             std::string_view response((char *) data, len);
             for (auto &it : pass)

--- a/components/esp_modem/src/esp_modem_netif.cpp
+++ b/components/esp_modem/src/esp_modem_netif.cpp
@@ -65,9 +65,7 @@ esp_err_t Netif::esp_modem_post_attach(esp_netif_t *esp_netif, void *args)
 
 void Netif::receive(uint8_t *data, size_t len)
 {
-    if (signal.is_any(PPP_STARTED)) {
-        esp_netif_receive(driver.base.netif, data, len, nullptr);
-    }
+    esp_netif_receive(driver.base.netif, data, len, nullptr);
 }
 
 Netif::Netif(std::shared_ptr<DTE> e, esp_netif_t *ppp_netif) :
@@ -89,8 +87,8 @@ void Netif::start()
         receive(data, len);
         return true;
     });
-    esp_netif_action_start(driver.base.netif, nullptr, 0, nullptr);
     signal.set(PPP_STARTED);
+    esp_netif_action_start(driver.base.netif, nullptr, 0, nullptr);
 }
 
 void Netif::stop()

--- a/components/esp_modem/src/esp_modem_uart.cpp
+++ b/components/esp_modem/src/esp_modem_uart.cpp
@@ -64,7 +64,6 @@ public:
 
     void set_read_cb(std::function<bool(uint8_t *data, size_t len)> f) override
     {
-        ESP_MODEM_THROW_IF_FALSE(signal.wait(TASK_PARAMS, 1000), "Failed to set UART task params");
         on_read = std::move(f);
     }
 
@@ -91,7 +90,6 @@ private:
     static const size_t TASK_INIT = BIT0;
     static const size_t TASK_START = BIT1;
     static const size_t TASK_STOP = BIT2;
-    static const size_t TASK_PARAMS = BIT3;
 
     QueueHandle_t event_queue;
     uart_resource uart;
@@ -118,9 +116,7 @@ void UartTerminal::task()
         return; // exits to the static method where the task gets deleted
     }
     while (signal.is_any(TASK_START)) {
-        signal.set(TASK_PARAMS);
         if (get_event(event, 100)) {
-            signal.clear(TASK_PARAMS);
             switch (event.type) {
             case UART_DATA:
                 uart_get_buffered_data_len(uart.port, &len);


### PR DESCRIPTION
* Simplifies network switching
* Implements inflatable buffer in CMUX and CMD mode
* Sets the ground for URC handling in the library
* Fixes potential data races (adding an extra mutex)

## TODO

- [x] Cleanup, naming
- [x] Make inflatable buffer configurable
- [x] Simplify Term and Netif -- no need for event flags anymore
