### PR TITLE
Update issue template with correct docs links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -8,7 +8,7 @@ body:
       label: Answers checklist.
       description: Before submitting a new issue, please follow the checklist and try to find the answer.
       options:
-        - label: I have read the documentation for [esp-protocols components](https://espressif.github.io/esp-protocols/) and the issue is not addressed there.
+        - label: I have read the documentation for esp-protocols [components](https://github.com/espressif/esp-protocols#readme) and the issue is not addressed there.
           required: true
         - label: I have updated my esp-protocols branch (master or release) to the latest version and checked that the issue is present there.
           required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
-  - name: esp-protocols documentation
-    url: https://espressif.github.io/esp-protocols/
+  - name: esp-protocols documentation links
+    url: https://github.com/espressif/esp-protocols#readme
     about: Documenation for esp-protocols components.
   - name: ESP-IDF Programming Guide
     url: https://docs.espressif.com/projects/esp-idf/en/latest/

--- a/.github/ISSUE_TEMPLATE/other-issue.yml
+++ b/.github/ISSUE_TEMPLATE/other-issue.yml
@@ -7,7 +7,7 @@ body:
       label: Answers checklist.
       description: Before submitting a new issue, please follow the checklist and try to find the answer.
       options:
-        - label: I have read the documentation for [esp-protocols components](https://espressif.github.io/esp-protocols/) and the issue is not addressed there.
+        - label: I have read the documentation for esp-protocols [components](https://github.com/espressif/esp-protocols#readme) and the issue is not addressed there.
           required: true
         - label: I have updated my esp-protocols branch (master or release) to the latest version and checked that the issue is present there.
           required: true


### PR DESCRIPTION
Just updating docs links. Decided to give a common link to the README, rather that listing all the components and docs.