### PR TITLE
feat(mdns): Allow setting length of mDNS action queue in menuconfig

### DIFF
--- a/components/mdns/Kconfig
+++ b/components/mdns/Kconfig
@@ -27,6 +27,13 @@ menu "mDNS"
             higher than priorities of system tasks. Compile time warning/error
             would be emitted if the chosen task priority were too high.
 
+    config MDNS_ACTION_QUEUE_LEN
+        int "Maximum actions pending to the server"
+        range 8 64
+        default 16
+        help
+            Allows setting the length of mDNS action queue.
+
     config MDNS_TASK_STACK_SIZE
         int "mDNS task stack size"
         default 4096

--- a/components/mdns/private_include/mdns_private.h
+++ b/components/mdns/private_include/mdns_private.h
@@ -93,7 +93,7 @@
 #define MDNS_SERVICE_ADD_TIMEOUT_MS CONFIG_MDNS_SERVICE_ADD_TIMEOUT_MS
 
 #define MDNS_PACKET_QUEUE_LEN       16                      // Maximum packets that can be queued for parsing
-#define MDNS_ACTION_QUEUE_LEN       16                      // Maximum actions pending to the server
+#define MDNS_ACTION_QUEUE_LEN       CONFIG_MDNS_ACTION_QUEUE_LEN  // Maximum actions pending to the server
 #define MDNS_TXT_MAX_LEN            1024                    // Maximum string length of text data in TXT record
 #if defined(CONFIG_LWIP_IPV6) && defined(CONFIG_MDNS_RESPOND_REVERSE_QUERIES)
 #define MDNS_NAME_MAX_LEN           (64+4)                  // Need to account for IPv6 reverse queries (64 char address  + ".ip6" )

--- a/components/mdns/tests/test_afl_fuzz_host/sdkconfig.h
+++ b/components/mdns/tests/test_afl_fuzz_host/sdkconfig.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2022-2023 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Unlicense OR CC0-1.0
  */
@@ -290,6 +290,7 @@
 #define CONFIG_MDNS_MAX_SERVICES 25
 #define CONFIG_MDNS_MAX_INTERFACES 3
 #define CONFIG_MDNS_TASK_PRIORITY 1
+#define CONFIG_MDNS_ACTION_QUEUE_LEN 16
 #define CONFIG_MDNS_TASK_STACK_SIZE 4096
 #define CONFIG_MDNS_TASK_AFFINITY_CPU0 1
 #define CONFIG_MDNS_TASK_AFFINITY 0x0


### PR DESCRIPTION
Allow users to configure the length of mDNS action queue via menuconfig.