### PR TITLE
bump(websocket): 1.0.0 -> 1.0.1

### DIFF
--- a/components/esp_websocket_client/.cz.yaml
+++ b/components/esp_websocket_client/.cz.yaml
@@ -1,0 +1,8 @@
+---
+commitizen:
+  bump_message: 'bump(websocket): $current_version -> $new_version'
+  pre_bump_hooks: python ../../ci/changelog.py esp_websocket_client
+  tag_format: websocket-v$version
+  version: 1.0.1
+  version_files:
+  - idf_component.yml

--- a/components/esp_websocket_client/CHANGELOG.md
+++ b/components/esp_websocket_client/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [1.0.1](https://github.com/espressif/esp-protocols/commits/websocket-v1.0.1)
+
+### Bug Fixes
+
+- esp_websocket_client client allow sending 0 byte packets ([b5177cb](https://github.com/espressif/esp-protocols/commit/b5177cb))
+- Cleaned up printf/format warnings (-Wno-format) ([e085826](https://github.com/espressif/esp-protocols/commit/e085826))
+- Added unit tests to CI + minor fix to pass it ([c974c14](https://github.com/espressif/esp-protocols/commit/c974c14))
+- Reintroduce missing CHANGELOGs ([200cbb3](https://github.com/espressif/esp-protocols/commit/200cbb3), [#235](https://github.com/espressif/esp-protocols/issues/235))
+
+### Updated
+
+- docs(common): updated component and example links ([f48d9b2](https://github.com/espressif/esp-protocols/commit/f48d9b2))
+- docs(common): improving documentation ([ca3fce0](https://github.com/espressif/esp-protocols/commit/ca3fce0))
+- Fix weird error message spacings ([8bb207e](https://github.com/espressif/esp-protocols/commit/8bb207e))
+
 ## [1.0.0](https://github.com/espressif/esp-protocols/commits/996fef7)
 
 ### Updated

--- a/components/esp_websocket_client/idf_component.yml
+++ b/components/esp_websocket_client/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.0"
+version: "1.0.1"
 description: esp websocket client
 url: https://github.com/espressif/esp-protocols/tree/master/components/esp_websocket_client
 dependencies:


### PR DESCRIPTION
1.0.1
Bug Fixes
- esp_websocket_client client allow sending 0 byte packets (b5177cb)
- Cleaned up printf/format warnings (-Wno-format) (e085826)
- Added unit tests to CI + minor fix to pass it (c974c14)
- Reintroduce missing CHANGELOGs (200cbb3) 
Updated
- docs(common): updated component and example links (f48d9b2)
- docs(common): improving documentation (ca3fce0)
- Fix weird error message spacings (8bb207e)