### PR TITLE
Fix LoadProhibited after failed CMUX initialization

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
     hooks:
       - id: eradicate
   - repo: https://github.com/espressif/check-copyright/
-    rev: v1.0.1
+    rev: v1.0.3
     hooks:
       - id: check-copyright
         args: ['--ignore', 'ci/check_copyright_ignore.txt', '--config', 'ci/check_copyright_config.yaml']

--- a/components/esp_modem/include/cxx_include/esp_modem_dte.hpp
+++ b/components/esp_modem/include/cxx_include/esp_modem_dte.hpp
@@ -125,7 +125,8 @@ private:
     static const size_t GOT_LINE = SignalGroup::bit0;       /*!< Bit indicating response available */
 
     [[nodiscard]] bool setup_cmux();                        /*!< Internal setup of CMUX mode */
-    [[nodiscard]] bool exit_cmux();                         /*!< Exit of CMUX mode */
+    [[nodiscard]] bool exit_cmux();                         /*!< Exit of CMUX mode and cleanup  */
+    void exit_cmux_internal();                              /*!< Cleanup CMUX */
 
     Lock internal_lock{};                                   /*!< Locks DTE operations */
     unique_buffer buffer;                                   /*!< DTE buffer */


### PR DESCRIPTION
Fixes https://github.com/espressif/esp-protocols/issues/339 (After unsuccessful CMUX initialization, incoming UART data will cause panic.)


Also, I was forced to bump the check-copyright version because I could not run precomit_hooks. The core issue was https://github.com/espressif/check-copyright/pull/10
