### PR TITLE
fix(websocket): fix of websocket coverage report generation

### DIFF
--- a/.github/workflows/run-host-tests.yml
+++ b/.github/workflows/run-host-tests.yml
@@ -53,7 +53,7 @@ jobs:
         - name: Run Coverage
           shell: bash
           run: |
-            apt-get update && apt-get install -y gcc-8 g++-8 python3-pip rsync
+            apt-get update && apt-get install -y python3-pip rsync
             python -m pip install gcovr
             cd $GITHUB_WORKSPACE/${{inputs.component_path}}
             gcov `find . -name "*gcda"`


### PR DESCRIPTION
Due to docker package upgrade, gcc-8 package is not available. 
Updated gcovr tool to use the latest available one