### PR TITLE
bump(mdns): 1.2.0 -> 1.3.0

### DIFF
--- a/components/mdns/.cz.yaml
+++ b/components/mdns/.cz.yaml
@@ -3,6 +3,6 @@ commitizen:
   bump_message: 'bump(mdns): $current_version -> $new_version'
   pre_bump_hooks: python ../../ci/changelog.py mdns
   tag_format: mdns-v$version
-  version: 1.2.0
+  version: 1.3.0
   version_files:
   - idf_component.yml

--- a/components/mdns/CHANGELOG.md
+++ b/components/mdns/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [1.3.0](https://github.com/espressif/esp-protocols/commits/mdns-v1.3.0)
+
+### Features
+
+- Allow setting length of mDNS action queue in menuconfig ([28cd898](https://github.com/espressif/esp-protocols/commit/28cd898))
+
+### Bug Fixes
+
+- added idf_component.yml for examples ([d273e10](https://github.com/espressif/esp-protocols/commit/d273e10))
+- added guard check for null pointer ([71bb461](https://github.com/espressif/esp-protocols/commit/71bb461))
+
 ## [1.2.0](https://github.com/espressif/esp-protocols/commits/mdns-v1.2.0)
 
 ### Features

--- a/components/mdns/idf_component.yml
+++ b/components/mdns/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.2.0"
+version: "1.3.0"
 description: mDNS
 url: https://github.com/espressif/esp-protocols/tree/master/components/mdns
 dependencies:


### PR DESCRIPTION
1.3.0
Features
- Allow setting length of mDNS action queue in menuconfig (28cd898) 

Bug Fixes
- added idf_component.yml for examples (d273e10)
- added guard check for null pointer (71bb461)