### PR TITLE
Remove meaningless print

### DIFF
--- a/components/esp_mqtt_cxx/esp_mqtt_cxx.cpp
+++ b/components/esp_mqtt_cxx/esp_mqtt_cxx.cpp
@@ -215,7 +215,6 @@ void Client::on_disconnected(esp_mqtt_event_handle_t const event)
 }
 void Client::on_subscribed(esp_mqtt_event_handle_t const event)
 {
-    printf("Subscribed to %.*s\r\n", event->topic_len, event->topic);
 }
 void Client::on_unsubscribed(esp_mqtt_event_handle_t const event)
 {


### PR DESCRIPTION
Information isn't available in the event, so the printf isn't meaningful and can be confusing to users. 