### PR TITLE
fix(modem): TLS example: Add restore session support in mbedtls wrapper

### DIFF
--- a/components/esp_modem/examples/modem_tcp_client/components/extra_tcp_transports/include/mbedtls_wrap.hpp
+++ b/components/esp_modem/examples/modem_tcp_client/components/extra_tcp_transports/include/mbedtls_wrap.hpp
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <utility>
+#include <memory>
 #include <span>
 #include "mbedtls/ssl.h"
 #include "mbedtls/entropy.h"
@@ -22,6 +23,7 @@ public:
     Tls();
     virtual ~Tls();
     bool init(is_server server, do_verify verify);
+    bool deinit();
     int handshake();
     int write(const unsigned char *buf, size_t len);
     int read(unsigned char *buf, size_t len);
@@ -41,6 +43,11 @@ protected:
     mbedtls_entropy_context entropy_{};
     virtual void delay() {}
 
+    bool set_session();
+    bool get_session();
+    void reset_session();
+    bool is_session_loaded();
+
 private:
     static void print_error(const char *function, int error_code);
     static int bio_write(void *ctx, const unsigned char *buf, size_t len);
@@ -48,5 +55,21 @@ private:
     int mbedtls_pk_parse_key( mbedtls_pk_context *ctx,
                               const unsigned char *key, size_t keylen,
                               const unsigned char *pwd, size_t pwdlen);
+    struct unique_session {
+        unique_session()
+        {
+            ::mbedtls_ssl_session_init(&s);
+        }
+        ~unique_session()
+        {
+            ::mbedtls_ssl_session_free(&s);
+        }
+        mbedtls_ssl_session *ptr()
+        {
+            return &s;
+        }
+        mbedtls_ssl_session s;
+    };
+    std::unique_ptr<unique_session> session_;
 
 };


### PR DESCRIPTION
Reusable component in modem_tcp_client example implements a simple mbedtls wrapper. This update add support for mbedtls deinit() and for saving and resotoring TLS session.