### PR TITLE
fix(modem): Update vfs terminal; Removed designated init

### DIFF
--- a/.github/workflows/modem__build-host-tests.yml
+++ b/.github/workflows/modem__build-host-tests.yml
@@ -64,7 +64,7 @@ jobs:
       COMP_DIR: esp-protocols/components/esp_modem
     steps:
       - name: Checkout esp-protocols
-        uses: actions/checkout@master
+        uses: actions/checkout@v3
         with:
           path: esp-protocols
 

--- a/components/esp_modem/include/vfs_resource/vfs_create.hpp
+++ b/components/esp_modem/include/vfs_resource/vfs_create.hpp
@@ -14,7 +14,7 @@
             .stop_bits = UART_STOP_BITS_1,          \
             .parity = UART_PARITY_DISABLE,          \
             .flow_control = ESP_MODEM_FLOW_CONTROL_NONE,\
-            .source_clk = UART_SCLK_APB,            \
+            .source_clk = ESP_MODEM_DEFAULT_UART_CLK,   \
             .baud_rate = 115200,                    \
             .tx_io_num = 25,                        \
             .rx_io_num = 26,                        \

--- a/components/esp_modem/src/esp_modem_netif.cpp
+++ b/components/esp_modem/src/esp_modem_netif.cpp
@@ -49,9 +49,9 @@ esp_err_t Netif::esp_modem_post_attach(esp_netif_t *esp_netif, void *args)
     ESP_ERROR_CHECK(esp_netif_set_driver_config(esp_netif, &driver_ifconfig));
     // check if PPP error events are enabled, if not, do enable the error occurred/state changed
     // to notify the modem layer when switching modes
-    esp_netif_ppp_config_t ppp_config = { .ppp_phase_event_enabled = true,    // assuming phase enabled, as earlier IDFs
-                                          .ppp_error_event_enabled = false
-                                        }; // don't provide cfg getters so we enable both events
+    esp_netif_ppp_config_t ppp_config = { };
+    ppp_config.ppp_phase_event_enabled = true;    // assuming phase enabled, as earlier IDFs
+    ppp_config.ppp_error_event_enabled = false;   // don't provide cfg getters so we enable both events
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 4, 0)
     esp_netif_ppp_get_params(esp_netif, &ppp_config);
 #endif // ESP-IDF >= v4.4

--- a/components/esp_modem/src/esp_modem_term_fs.cpp
+++ b/components/esp_modem/src/esp_modem_term_fs.cpp
@@ -122,9 +122,7 @@ void FdTerminal::task()
         } else {
             if (FD_ISSET(f.fd, &rfds)) {
                 if (on_read_priv) {
-                    if (on_read_priv(nullptr, 0)) {
-                        on_read_priv = nullptr;
-                    }
+                    on_read_priv(nullptr, 0);
                 }
             }
         }


### PR DESCRIPTION
## Fix netif to set PPP config in C++ way
    
    If the config struct contains more items (or more items will be added in
    future) this init will not compile cleanly

## Fix netif to set PPP config in C++ way
    
    If the config struct contains more items (or more items will be added in
    future) this init will not compile cleanly
