### PR TITLE
Fix MDNS free host list (IDFGH-11116)

### DIFF
--- a/components/mdns/mdns.c
+++ b/components/mdns/mdns.c
@@ -2884,6 +2884,7 @@ static void free_delegated_hostnames(void)
         host = host->next;
         free(item);
     }
+    _mdns_host_list = NULL;
 }
 
 static bool _mdns_delegate_hostname_remove(const char *hostname)


### PR DESCRIPTION
Without this, any use of `_mdns_host_list` risks crashing due to use of freed memory.