### PR TITLE
bump(modem): 1.0.1 -> 1.0.2

### DIFF
--- a/components/esp_modem/.cz.yaml
+++ b/components/esp_modem/.cz.yaml
@@ -3,6 +3,6 @@ commitizen:
   bump_message: 'bump(modem): $current_version -> $new_version'
   pre_bump_hooks: python ../../ci/changelog.py esp_modem
   tag_format: modem-v$version
-  version: 1.0.1
+  version: 1.0.2
   version_files:
   - idf_component.yml

--- a/components/esp_modem/CHANGELOG.md
+++ b/components/esp_modem/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [1.0.2](https://github.com/espressif/esp-protocols/commits/modem-v1.0.2)
+
+### Features
+
+- Add factory method for simple creation of custom DCEs ([4cf9e50](https://github.com/espressif/esp-protocols/commit/4cf9e50))
+- Support custom transport in AT TCP client example ([ae629ed](https://github.com/espressif/esp-protocols/commit/ae629ed))
+
+### Bug Fixes
+
+- Fix host test race with async read and d'structor ([c89d42f](https://github.com/espressif/esp-protocols/commit/c89d42f))
+- More error handling in cmux protocol ([8edbac6](https://github.com/espressif/esp-protocols/commit/8edbac6))
+- Fix netif to set PPP config in C++ way ([5287432](https://github.com/espressif/esp-protocols/commit/5287432))
+- Fix vfs terminal not to reset read_cb() automatically ([25a35e2](https://github.com/espressif/esp-protocols/commit/25a35e2))
+- Fix netif data race causing PPP startup delays ([c8c0507](https://github.com/espressif/esp-protocols/commit/c8c0507), [#308](https://github.com/espressif/esp-protocols/issues/308))
+- Added support for inflatable buffer ([cb6e03a](https://github.com/espressif/esp-protocols/commit/cb6e03a), [#272](https://github.com/espressif/esp-protocols/issues/272))
+- Fix LoadProhibited after failed CMUX initialization (IDFGH-10845) ([60c87dd](https://github.com/espressif/esp-protocols/commit/60c87dd))
+
 ## [1.0.1](https://github.com/espressif/esp-protocols/commits/modem-v1.0.1)
 
 ### Bug Fixes

--- a/components/esp_modem/idf_component.yml
+++ b/components/esp_modem/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.1"
+version: "1.0.2"
 description: esp modem
 url: https://github.com/espressif/esp-protocols/tree/master/components/esp_modem
 dependencies:


### PR DESCRIPTION
## v1.0.2

### Features

- Add factory method for simple creation of custom DCEs (4cf9e50)
- Support custom transport in AT TCP client example (ae629ed)

### Bug Fixes

- Fix host test race with async read and d'structor (c89d42f)
- More error handling in cmux protocol (8edbac6)
- Fix netif to set PPP config in C++ way (5287432)
- Fix vfs terminal not to reset read_cb() automatically (25a35e2)
- Fix netif data race causing PPP startup delays (c8c0507, #308)
- Added support for inflatable buffer (cb6e03a, #272)
- Fix LoadProhibited after failed CMUX initialization (IDFGH-10845) (60c87dd)