### PR TITLE
fix(modem): Fix AT client example to use custom AT processing

### DIFF
--- a/components/esp_modem/src/esp_modem_dte.cpp
+++ b/components/esp_modem/src/esp_modem_dte.cpp
@@ -313,6 +313,7 @@ void DTE::on_read(got_line_cb on_read_cb)
     if (on_read_cb == nullptr) {
         primary_term->set_read_cb(nullptr);
         internal_lock.unlock();
+        set_command_callbacks();
         return;
     }
     internal_lock.lock();


### PR DESCRIPTION
Need the callback reset upon removal of our custom AT command processing. This issue has been introduced in cb6e03ac when refactoring DTE callbacks.
