### PR TITLE
bump(asio): 1.28.0~0 -> 1.28.0~1

### DIFF
--- a/components/asio/.cz.yaml
+++ b/components/asio/.cz.yaml
@@ -2,6 +2,6 @@ commitizen:
   bump_message: 'bump(asio): $current_version -> $new_version'
   pre_bump_hooks: python ../../ci/changelog.py asio
   tag_format: asio-v$version
-  version: 1.28.0~0
+  version: 1.28.0~1
   version_files:
   - idf_component.yml

--- a/components/asio/CHANGELOG.md
+++ b/components/asio/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.28.0~1](https://github.com/espressif/esp-protocols/commits/asio-v1.28.0_1)
+
+- Updated only metadata, previous tag wasn't created.
+
 ## [1.28.0~0](https://github.com/espressif/esp-protocols/commits/asio-1.28.0~0)
 
 ### Features

--- a/components/asio/idf_component.yml
+++ b/components/asio/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.28.0~0"
+version: "1.28.0~1"
 description: ASIO
 url: https://github.com/espressif/esp-protocols/tree/master/components/asio
 dependencies:


### PR DESCRIPTION
Changes only metadata for component publishing

