### PR TITLE
bump(mqtt_cxx): 0.1.0 -> 0.2.0

### DIFF
--- a/components/esp_mqtt_cxx/.cz.yaml
+++ b/components/esp_mqtt_cxx/.cz.yaml
@@ -1,0 +1,8 @@
+---
+commitizen:
+  bump_message: 'bump(mqtt_cxx): $current_version -> $new_version'
+  pre_bump_hooks: python ../../ci/changelog.py esp_mqtt_cxx
+  tag_format: mqtt_cxx-v$version
+  version: 0.2.0
+  version_files:
+  - idf_component.yml

--- a/components/esp_mqtt_cxx/CHANGELOG.md
+++ b/components/esp_mqtt_cxx/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [0.2.0](https://github.com/espressif/esp-protocols/commits/mqtt_cxx-v0.2.0)
+
+### Features
+
+- configure client authentication via certificate/key or secure element ([ee09ff4](https://github.com/espressif/esp-protocols/commit/ee09ff4))
+
+### Bug Fixes
+
+- removed Wno-format flag and fixed formatting warnings ([c48e442](https://github.com/espressif/esp-protocols/commit/c48e442))
+- Removes meaningless printf on subscribed handler (#358) ([bac742d](https://github.com/espressif/esp-protocols/commit/bac742d), [#356](https://github.com/espressif/esp-protocols/issues/356))
+- Removes unused type for configuration ([839c79d](https://github.com/espressif/esp-protocols/commit/839c79d))
+- added idf_component.yml for examples ([d273e10](https://github.com/espressif/esp-protocols/commit/d273e10))
+- Reintroduce missing CHANGELOGs ([200cbb3](https://github.com/espressif/esp-protocols/commit/200cbb3), [#235](https://github.com/espressif/esp-protocols/issues/235))
+
+### Updated
+
+- docs(common): updated component and example links ([f48d9b2](https://github.com/espressif/esp-protocols/commit/f48d9b2))
+- docs(esp_mqtt_cxx): updated documentation and deployment file ([a547ec8](https://github.com/espressif/esp-protocols/commit/a547ec8))
+- docs(common): improving documentation ([ca3fce0](https://github.com/espressif/esp-protocols/commit/ca3fce0))
+- Add homepage URL and License to all components ([ef3f0ee](https://github.com/espressif/esp-protocols/commit/ef3f0ee))
+
 ## [0.1.0](https://github.com/espressif/esp-protocols/commits/1407dfc)
 
 ### Updated

--- a/components/esp_mqtt_cxx/idf_component.yml
+++ b/components/esp_mqtt_cxx/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.1.0"
+version: "0.2.0"
 description: esp mqtt cxx
 url: https://github.com/espressif/esp-protocols/tree/master/components/esp_mqtt_cxx
 dependencies:


### PR DESCRIPTION
0.2.0
Features
- configure client authentication via certificate/key or secure element (ee09ff4) Bug Fixes
- removed Wno-format flag and fixed formatting warnings (c48e442)
- Removes meaningless printf on subscribed handler (#358) (bac742d, #356)
- Removes unused type for configuration (839c79d)
- added idf_component.yml for examples (d273e10)
- Reintroduce missing CHANGELOGs (200cbb3, #235) Updated
- docs(common): updated component and example links (f48d9b2)
- docs(esp_mqtt_cxx): updated documentation and deployment file (a547ec8)
- docs(common): improving documentation (ca3fce0)
- Add homepage URL and License to all components (ef3f0ee)