### PR TITLE
bump(console): 1.0.2 -> 1.1.0

### DIFF
--- a/components/console_simple_init/.cz.yaml
+++ b/components/console_simple_init/.cz.yaml
@@ -3,6 +3,6 @@ commitizen:
   bump_message: 'bump(console): $current_version -> $new_version'
   pre_bump_hooks: python ../../ci/changelog.py console_simple_init
   tag_format: console_simple_init-v$version
-  version: 1.0.2
+  version: 1.1.0
   version_files:
   - idf_component.yml

--- a/components/console_simple_init/CHANGELOG.md
+++ b/components/console_simple_init/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.1.0](https://github.com/espressif/esp-protocols/commits/console_simple_init-v1.1.0)
+
+### Features
+
+- Added runtime component registration support in console_simple_init ([057873c1](https://github.com/espressif/esp-protocols/commit/057873c1))
+
 ## [1.0.2](https://github.com/espressif/esp-protocols/commits/console_simple_init-v1.0.2)
 
 ### Bug Fixes

--- a/components/console_simple_init/idf_component.yml
+++ b/components/console_simple_init/idf_component.yml
@@ -1,4 +1,4 @@
-version: 1.0.2
+version: 1.1.0
 description: The component provides helper functions for easy initialization and start of esp console.
 url: https://github.com/espressif/esp-protocols/tree/master/components/console_simple_init
 dependencies:


### PR DESCRIPTION
1.1.0
Features
- Added runtime component registration support in console_simple_init (057873c1)