### PR TITLE
bump(asio): 1.28.0~0 -> 1.28.2~0

### DIFF
--- a/components/asio/CHANGELOG.md
+++ b/components/asio/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [1.28.2~0](https://github.com/espressif/esp-protocols/commits/asio-1.28.2_0)
+
+### Bug Fixes
+
+- reference protocol_examples_common from IDF ([09abb18](https://github.com/espressif/esp-protocols/commit/09abb18))
+- specify override_path in example manifest files ([1d8923c](https://github.com/espressif/esp-protocols/commit/1d8923c))
+
+### Updated
+
+- docs(asio): Updates asio docs ([ce9337d](https://github.com/espressif/esp-protocols/commit/ce9337d))
+
 ## [1.28.0~0](https://github.com/espressif/esp-protocols/commits/asio-1.28.0~0)
 
 ### Features

--- a/components/asio/CONTRIBUTING.md
+++ b/components/asio/CONTRIBUTING.md
@@ -1,0 +1,40 @@
+# Information for Contributors
+
+Contributions in the form of pull requests, issue reports, and feature requests are welcome!
+
+## Updating ASIO
+
+ASIO is managed as a submodule, to updated the version first the [espressif](github.com/espressif/asio) ASIO fork must be updated.
+
+## Release process
+
+When releasing a new component version we have to:
+
+* Update the submodule reference
+* Update the version number
+* Update the changelog
+
+And the automation process takes care of the last steps:
+
+* Create the version tag in this repository
+* Deploy the component to component registry
+* Update the documentation
+
+This process needs to be manually handled for ASIO component since commitizen doesn't accept the versioning schema used.
+
+* Increment manually the version in the [manifest file](idf_component.yml)
+* Export environment variables for changelog generation:
+    - CZ_PRE_CURRENT_TAG_VERSION
+    - CZ_PRE_NEW_TAG_VERSION
+    - CZ_PRE_NEW_VERSION
+* Run `python ../../ci/changelog.py asio` from this directory to generate the change log
+* Check the updated `CHANGELOG.md`
+* Commit the changes with the adequated message format.
+    ```
+    bump(asio): $current_version -> $new_version
+
+    $Changelog for the version
+    ```
+* Create a PR
+
+Once the PR is merged, the CI job tags the merge commit, creates a new release, builds and deploys documentation and the new component to the component registry

--- a/components/asio/idf_component.yml
+++ b/components/asio/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.28.0~0"
+version: "1.28.2~0"
 description: Cross-platform C++ library for network and I/O programming
 url: https://github.com/espressif/esp-protocols/tree/master/components/asio
 issues: https://github.com/espressif/esp-protocols/issues


### PR DESCRIPTION
1.28.2~0

Bug Fixes
- reference protocol_examples_common from IDF ([09abb18](https://github.com/espressif/esp-protocols/commit/09abb18))
- specify override_path in example manifest files ([1d8923c](https://github.com/espressif/esp-protocols/commit/1d8923c))

Updated
- docs(asio): Updates asio docs ([ce9337d](https://github.com/espressif/esp-protocols/commit/ce9337d))