### PR TITLE
fix(modem): Fixed examples to show netif on ppp-changed event

### DIFF
--- a/components/esp_modem/examples/pppos_client/main/pppos_client_main.c
+++ b/components/esp_modem/examples/pppos_client/main/pppos_client_main.c
@@ -105,8 +105,8 @@ static void on_ppp_changed(void *arg, esp_event_base_t event_base,
     ESP_LOGI(TAG, "PPP state changed event %" PRIu32, event_id);
     if (event_id == NETIF_PPP_ERRORUSER) {
         /* User interrupted event from esp-netif */
-        esp_netif_t *netif = event_data;
-        ESP_LOGI(TAG, "User interrupted event from netif:%p", netif);
+        esp_netif_t **p_netif = event_data;
+        ESP_LOGI(TAG, "User interrupted event from netif:%p", *p_netif);
     }
 }
 

--- a/components/esp_modem/test/target/main/pppd_test.cpp
+++ b/components/esp_modem/test/target/main/pppd_test.cpp
@@ -64,8 +64,8 @@ static void on_ppp_changed(void *arg, esp_event_base_t event_base,
     ESP_LOGI(TAG, "PPP state changed event %" PRId32, event_id);
     if (event_id == NETIF_PPP_ERRORUSER) {
         /* User interrupted event from esp-netif */
-        esp_netif_t *netif = static_cast<esp_netif_t *>(event_data);
-        ESP_LOGI(TAG, "User interrupted event from netif:%p", netif);
+        auto p_netif = static_cast<esp_netif_t **>(event_data);
+        ESP_LOGI(TAG, "User interrupted event from netif:%p", *p_netif);
         xEventGroupSetBits(event_group, 2);
     }
 }


### PR DESCRIPTION
The event data is a pointer to netif, need to deference to correctly display the `esp_netif` handle.

https://github.com/espressif/esp-idf/blob/c8243465e45489835d645bf217a6929fd0c01b7f/components/esp_netif/lwip/esp_netif_lwip_ppp.c#L104