### PR TITLE
bump(websocket): 1.1.0 -> 1.2.0

### DIFF
--- a/components/esp_websocket_client/.cz.yaml
+++ b/components/esp_websocket_client/.cz.yaml
@@ -3,6 +3,6 @@ commitizen:
   bump_message: 'bump(websocket): $current_version -> $new_version'
   pre_bump_hooks: python ../../ci/changelog.py esp_websocket_client
   tag_format: websocket-v$version
-  version: 1.1.0
+  version: 1.2.0
   version_files:
   - idf_component.yml

--- a/components/esp_websocket_client/idf_component.yml
+++ b/components/esp_websocket_client/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.1.0"
+version: "1.2.0"
 description: WebSocket protocol client for ESP-IDF
 url: https://github.com/espressif/esp-protocols/tree/master/components/esp_websocket_client
 dependencies:


### PR DESCRIPTION
1.2.0
Features
- Added new API `esp_websocket_client_append_header` (39e972544f)
- Added new APIs to support fragmented messages transmission (fae80e2f3f) 
`esp_websocket_client_send_text_partial`, 
`esp_websocket_client_send_bin_partial` 
`esp_websocket_client_send_cont_mgs` 
`esp_websocket_client_send_fin` 
`esp_websocket_client_send_with_exact_opcode`

Bug Fixes
- Return status code correctly on esp_websocket_client_send_with_opcode (ac8f1de187)
- Fix pytest exclusion, gitignore, and changelog checks (269622170e)