### PR TITLE
bump(websocket): 1.1.0 -> 1.2.0

### DIFF
--- a/components/esp_websocket_client/.cz.yaml
+++ b/components/esp_websocket_client/.cz.yaml
@@ -3,6 +3,6 @@ commitizen:
   bump_message: 'bump(websocket): $current_version -> $new_version'
   pre_bump_hooks: python ../../ci/changelog.py esp_websocket_client
   tag_format: websocket-v$version
-  version: 1.1.0
+  version: 1.2.0
   version_files:
   - idf_component.yml

--- a/components/esp_websocket_client/CHANGELOG.md
+++ b/components/esp_websocket_client/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [1.2.0](https://github.com/espressif/esp-protocols/commits/websocket-v1.2.0)
+
+### Features
+
+- Added new API `esp_websocket_client_append_header` ([39e9725](https://github.com/espressif/esp-protocols/commit/39e9725))
+- Added new APIs to support fragmented messages transmission ([fae80e2](https://github.com/espressif/esp-protocols/commit/fae80e2))
+
+### Bug Fixes
+
+- reference protocol_examples_common from IDF ([025ede1](https://github.com/espressif/esp-protocols/commit/025ede1))
+- specify override_path in example manifests ([d5e7898](https://github.com/espressif/esp-protocols/commit/d5e7898))
+- Return status code correctly on esp_websocket_client_send_with_opcode ([ac8f1de](https://github.com/espressif/esp-protocols/commit/ac8f1de))
+- Fix pytest exclusion, gitignore, and changelog checks ([2696221](https://github.com/espressif/esp-protocols/commit/2696221))
+
 ## [1.1.0](https://github.com/espressif/esp-protocols/commits/websocket-v1.1.0)
 
 ### Features

--- a/components/esp_websocket_client/idf_component.yml
+++ b/components/esp_websocket_client/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.1.0"
+version: "1.2.0"
 description: WebSocket protocol client for ESP-IDF
 url: https://github.com/espressif/esp-protocols/tree/master/components/esp_websocket_client
 dependencies:


### PR DESCRIPTION
1.2.0
Features
- Added new API `esp_websocket_client_append_header` (39e9725)
- Added new APIs to support fragmented messages transmission (fae80e2) 
`esp_websocket_client_send_text_partial` 
`esp_websocket_client_send_bin_partial`
 `esp_websocket_client_send_cont_mgs` 
 `esp_websocket_client_send_fin` 
 `esp_websocket_client_send_with_exact_opcode` 

Bug Fixes
- reference protocol_examples_common from IDF (025ede1)
- specify override_path in example manifests (d5e7898)
- Return status code correctly on esp_websocket_client_send_with_opcode (ac8f1de)
- Fix pytest exclusion, gitignore, and changelog checks (2696221)