### PR TITLE
Temporarily revert IDF component references in examples

### DIFF
--- a/components/asio/examples/asio_chat/CMakeLists.txt
+++ b/components/asio/examples/asio_chat/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.16)
 
 # (Not part of the boilerplate)
 # This example uses an extra component for common functions such as Wi-Fi and Ethernet connection.
-set(EXTRA_COMPONENT_DIRS ../.. ../../../../common_components/protocol_examples_common)
+set(EXTRA_COMPONENT_DIRS ../.. $ENV{IDF_PATH}/examples/common_components/protocol_examples_common)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(asio_chat)

--- a/components/asio/examples/asio_chat/CMakeLists.txt
+++ b/components/asio/examples/asio_chat/CMakeLists.txt
@@ -2,5 +2,9 @@
 # in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.16)
 
+# (Not part of the boilerplate)
+# This example uses an extra component for common functions such as Wi-Fi and Ethernet connection.
+set(EXTRA_COMPONENT_DIRS ../.. ../../../../common_components/protocol_examples_common)
+
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(asio_chat)

--- a/components/asio/examples/asio_chat/main/idf_component.yml
+++ b/components/asio/examples/asio_chat/main/idf_component.yml
@@ -4,5 +4,3 @@ dependencies:
   espressif/asio:
     version: "^1.14.1"
     override_path: "../../../"
-  protocol_examples_common:
-    path: ${IDF_PATH}/examples/common_components/protocol_examples_common

--- a/components/asio/examples/async_request/CMakeLists.txt
+++ b/components/asio/examples/async_request/CMakeLists.txt
@@ -2,5 +2,9 @@
 # in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.16)
 
+# (Not part of the boilerplate)
+# This example uses an extra component for common functions such as Wi-Fi and Ethernet connection.
+set(EXTRA_COMPONENT_DIRS ../../../../common_components/protocol_examples_common)
+
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(async_http_request)

--- a/components/asio/examples/async_request/CMakeLists.txt
+++ b/components/asio/examples/async_request/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.16)
 
 # (Not part of the boilerplate)
 # This example uses an extra component for common functions such as Wi-Fi and Ethernet connection.
-set(EXTRA_COMPONENT_DIRS ../../../../common_components/protocol_examples_common)
+set(EXTRA_COMPONENT_DIRS $ENV{IDF_PATH}/examples/common_components/protocol_examples_common)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(async_http_request)

--- a/components/asio/examples/async_request/main/idf_component.yml
+++ b/components/asio/examples/async_request/main/idf_component.yml
@@ -4,5 +4,3 @@ dependencies:
   espressif/asio:
     version: "^1.14.1"
     override_path: "../../../"
-  protocol_examples_common:
-    path: ${IDF_PATH}/examples/common_components/protocol_examples_common

--- a/components/asio/examples/socks4/CMakeLists.txt
+++ b/components/asio/examples/socks4/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.16)
 
 # (Not part of the boilerplate)
 # This example uses an extra component for common functions such as Wi-Fi and Ethernet connection.
-set(EXTRA_COMPONENT_DIRS ../../../../common_components/protocol_examples_common)
+set(EXTRA_COMPONENT_DIRS $ENV{IDF_PATH}/examples/common_components/protocol_examples_common)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(asio_sock4)

--- a/components/asio/examples/socks4/CMakeLists.txt
+++ b/components/asio/examples/socks4/CMakeLists.txt
@@ -2,5 +2,9 @@
 # in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.16)
 
+# (Not part of the boilerplate)
+# This example uses an extra component for common functions such as Wi-Fi and Ethernet connection.
+set(EXTRA_COMPONENT_DIRS ../../../../common_components/protocol_examples_common)
+
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(asio_sock4)

--- a/components/asio/examples/socks4/main/idf_component.yml
+++ b/components/asio/examples/socks4/main/idf_component.yml
@@ -4,5 +4,3 @@ dependencies:
   espressif/asio:
     version: "^1.14.1"
     override_path: "../../../"
-  protocol_examples_common:
-    path: ${IDF_PATH}/examples/common_components/protocol_examples_common

--- a/components/asio/examples/ssl_client_server/CMakeLists.txt
+++ b/components/asio/examples/ssl_client_server/CMakeLists.txt
@@ -2,6 +2,9 @@
 # in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.16)
 
+# (Not part of the boilerplate)
+# This example uses an extra component for common functions such as Wi-Fi and Ethernet connection.
+set(EXTRA_COMPONENT_DIRS ../../../../common_components/protocol_examples_common)
 set(EXCLUDE_COMPONENTS openssl)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)

--- a/components/asio/examples/ssl_client_server/CMakeLists.txt
+++ b/components/asio/examples/ssl_client_server/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.16)
 
 # (Not part of the boilerplate)
 # This example uses an extra component for common functions such as Wi-Fi and Ethernet connection.
-set(EXTRA_COMPONENT_DIRS ../../../../common_components/protocol_examples_common)
+set(EXTRA_COMPONENT_DIRS $ENV{IDF_PATH}/examples/common_components/protocol_examples_common)
 set(EXCLUDE_COMPONENTS openssl)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)

--- a/components/asio/examples/ssl_client_server/main/idf_component.yml
+++ b/components/asio/examples/ssl_client_server/main/idf_component.yml
@@ -4,5 +4,3 @@ dependencies:
   espressif/asio:
     version: "^1.14.1"
     override_path: "../../../"
-  protocol_examples_common:
-    path: ${IDF_PATH}/examples/common_components/protocol_examples_common

--- a/components/asio/examples/tcp_echo_server/CMakeLists.txt
+++ b/components/asio/examples/tcp_echo_server/CMakeLists.txt
@@ -2,5 +2,9 @@
 # in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.16)
 
+# (Not part of the boilerplate)
+# This example uses an extra component for common functions such as Wi-Fi and Ethernet connection.
+set(EXTRA_COMPONENT_DIRS ../../../../common_components/protocol_examples_common)
+
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(asio_tcp_echo_server)

--- a/components/asio/examples/tcp_echo_server/CMakeLists.txt
+++ b/components/asio/examples/tcp_echo_server/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.16)
 
 # (Not part of the boilerplate)
 # This example uses an extra component for common functions such as Wi-Fi and Ethernet connection.
-set(EXTRA_COMPONENT_DIRS ../../../../common_components/protocol_examples_common)
+set(EXTRA_COMPONENT_DIRS $ENV{IDF_PATH}/examples/common_components/protocol_examples_common)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(asio_tcp_echo_server)

--- a/components/asio/examples/tcp_echo_server/main/idf_component.yml
+++ b/components/asio/examples/tcp_echo_server/main/idf_component.yml
@@ -4,5 +4,3 @@ dependencies:
   espressif/asio:
     version: "^1.14.1"
     override_path: "../../../"
-  protocol_examples_common:
-    path: ${IDF_PATH}/examples/common_components/protocol_examples_common

--- a/components/asio/examples/udp_echo_server/CMakeLists.txt
+++ b/components/asio/examples/udp_echo_server/CMakeLists.txt
@@ -2,5 +2,9 @@
 # in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.16)
 
+# (Not part of the boilerplate)
+# This example uses an extra component for common functions such as Wi-Fi and Ethernet connection.
+set(EXTRA_COMPONENT_DIRS ../../../../common_components/protocol_examples_common)
+
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(asio_udp_echo_server)

--- a/components/asio/examples/udp_echo_server/CMakeLists.txt
+++ b/components/asio/examples/udp_echo_server/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.16)
 
 # (Not part of the boilerplate)
 # This example uses an extra component for common functions such as Wi-Fi and Ethernet connection.
-set(EXTRA_COMPONENT_DIRS ../../../../common_components/protocol_examples_common)
+set(EXTRA_COMPONENT_DIRS $ENV{IDF_PATH}/examples/common_components/protocol_examples_common)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(asio_udp_echo_server)

--- a/components/asio/examples/udp_echo_server/main/idf_component.yml
+++ b/components/asio/examples/udp_echo_server/main/idf_component.yml
@@ -4,5 +4,3 @@ dependencies:
   espressif/asio:
     version: "^1.14.1"
     override_path: "../../../"
-  protocol_examples_common:
-    path: ${IDF_PATH}/examples/common_components/protocol_examples_common

--- a/components/esp_websocket_client/.cz.yaml
+++ b/components/esp_websocket_client/.cz.yaml
@@ -3,6 +3,6 @@ commitizen:
   bump_message: 'bump(websocket): $current_version -> $new_version'
   pre_bump_hooks: python ../../ci/changelog.py esp_websocket_client
   tag_format: websocket-v$version
-  version: 1.1.0
+  version: 1.2.0
   version_files:
   - idf_component.yml

--- a/components/esp_websocket_client/CHANGELOG.md
+++ b/components/esp_websocket_client/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [1.2.0](https://github.com/espressif/esp-protocols/commits/websocket-v1.2.0)
+
+### Features
+
+- Added new API `esp_websocket_client_append_header` ([39e9725](https://github.com/espressif/esp-protocols/commit/39e9725))
+- Added new APIs to support fragmented messages transmission ([fae80e2](https://github.com/espressif/esp-protocols/commit/fae80e2))
+
+### Bug Fixes
+
+- Reference common component from IDF ([74fc228](https://github.com/espressif/esp-protocols/commit/74fc228))
+- Revert referencing protocol_examples_common from IDF ([b176d3a](https://github.com/espressif/esp-protocols/commit/b176d3a))
+- reference protocol_examples_common from IDF ([025ede1](https://github.com/espressif/esp-protocols/commit/025ede1))
+- specify override_path in example manifests ([d5e7898](https://github.com/espressif/esp-protocols/commit/d5e7898))
+- Return status code correctly on esp_websocket_client_send_with_opcode ([ac8f1de](https://github.com/espressif/esp-protocols/commit/ac8f1de))
+- Fix pytest exclusion, gitignore, and changelog checks ([2696221](https://github.com/espressif/esp-protocols/commit/2696221))
+
 ## [1.1.0](https://github.com/espressif/esp-protocols/commits/websocket-v1.1.0)
 
 ### Features

--- a/components/esp_websocket_client/examples/linux/CMakeLists.txt
+++ b/components/esp_websocket_client/examples/linux/CMakeLists.txt
@@ -8,6 +8,7 @@ set(EXTRA_COMPONENT_DIRS
   "${common_component_dir}/linux_compat"
   "${common_component_dir}/linux_compat/freertos")
 
+list(APPEND EXTRA_COMPONENT_DIRS $ENV{IDF_PATH}/examples/common_components/protocol_examples_common)
 list(APPEND EXTRA_COMPONENT_DIRS $ENV{IDF_PATH}/examples/protocols/linux_stubs/esp_stubs)
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 

--- a/components/esp_websocket_client/examples/linux/main/idf_component.yml
+++ b/components/esp_websocket_client/examples/linux/main/idf_component.yml
@@ -1,3 +1,0 @@
-dependencies:
-  protocol_examples_common:
-    path: ${IDF_PATH}/examples/common_components/protocol_examples_common

--- a/components/esp_websocket_client/examples/target/CMakeLists.txt
+++ b/components/esp_websocket_client/examples/target/CMakeLists.txt
@@ -2,5 +2,8 @@
 # in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.5)
 
+# This example uses an extra component for common functions such as Wi-Fi and Ethernet connection.
+list(APPEND EXTRA_COMPONENT_DIRS "../../../../common_components/protocol_examples_common")
+
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(websocket_example)

--- a/components/esp_websocket_client/examples/target/CMakeLists.txt
+++ b/components/esp_websocket_client/examples/target/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.5)
 
 # This example uses an extra component for common functions such as Wi-Fi and Ethernet connection.
-list(APPEND EXTRA_COMPONENT_DIRS "../../../../common_components/protocol_examples_common")
+list(APPEND EXTRA_COMPONENT_DIRS $ENV{IDF_PATH}/examples/common_components/protocol_examples_common)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(websocket_example)

--- a/components/esp_websocket_client/examples/target/main/idf_component.yml
+++ b/components/esp_websocket_client/examples/target/main/idf_component.yml
@@ -4,5 +4,3 @@ dependencies:
   espressif/esp_websocket_client:
     version: "^1.0.0"
     override_path: "../../../"
-  protocol_examples_common:
-    path: ${IDF_PATH}/examples/common_components/protocol_examples_common

--- a/components/esp_websocket_client/idf_component.yml
+++ b/components/esp_websocket_client/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.1.0"
+version: "1.2.0"
 description: WebSocket protocol client for ESP-IDF
 url: https://github.com/espressif/esp-protocols/tree/master/components/esp_websocket_client
 dependencies:


### PR DESCRIPTION
In order to publish `v1.2.0` version of websocket client.

* This is needed as the local references in `idf_component.yml` are not supported yet
* This picks @gabsuren 's bump of ws client from https://github.com/espressif/esp-protocols/pull/437
