### PR TITLE
fix(common): Re-applied refs to common comps idf_component.yml

### DIFF
--- a/components/asio/examples/asio_chat/CMakeLists.txt
+++ b/components/asio/examples/asio_chat/CMakeLists.txt
@@ -2,9 +2,5 @@
 # in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.16)
 
-# (Not part of the boilerplate)
-# This example uses an extra component for common functions such as Wi-Fi and Ethernet connection.
-set(EXTRA_COMPONENT_DIRS ../.. $ENV{IDF_PATH}/examples/common_components/protocol_examples_common)
-
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(asio_chat)

--- a/components/asio/examples/async_request/CMakeLists.txt
+++ b/components/asio/examples/async_request/CMakeLists.txt
@@ -2,9 +2,5 @@
 # in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.16)
 
-# (Not part of the boilerplate)
-# This example uses an extra component for common functions such as Wi-Fi and Ethernet connection.
-set(EXTRA_COMPONENT_DIRS $ENV{IDF_PATH}/examples/common_components/protocol_examples_common)
-
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(async_http_request)

--- a/components/asio/examples/async_request/main/idf_component.yml
+++ b/components/asio/examples/async_request/main/idf_component.yml
@@ -4,3 +4,5 @@ dependencies:
   espressif/asio:
     version: "^1.14.1"
     override_path: "../../../"
+  protocol_examples_common:
+    path: ${IDF_PATH}/examples/common_components/protocol_examples_common

--- a/components/asio/examples/socks4/CMakeLists.txt
+++ b/components/asio/examples/socks4/CMakeLists.txt
@@ -2,9 +2,5 @@
 # in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.16)
 
-# (Not part of the boilerplate)
-# This example uses an extra component for common functions such as Wi-Fi and Ethernet connection.
-set(EXTRA_COMPONENT_DIRS $ENV{IDF_PATH}/examples/common_components/protocol_examples_common)
-
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(asio_sock4)

--- a/components/asio/examples/socks4/main/idf_component.yml
+++ b/components/asio/examples/socks4/main/idf_component.yml
@@ -4,3 +4,5 @@ dependencies:
   espressif/asio:
     version: "^1.14.1"
     override_path: "../../../"
+  protocol_examples_common:
+    path: ${IDF_PATH}/examples/common_components/protocol_examples_common

--- a/components/asio/examples/ssl_client_server/CMakeLists.txt
+++ b/components/asio/examples/ssl_client_server/CMakeLists.txt
@@ -2,9 +2,6 @@
 # in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.16)
 
-# (Not part of the boilerplate)
-# This example uses an extra component for common functions such as Wi-Fi and Ethernet connection.
-set(EXTRA_COMPONENT_DIRS $ENV{IDF_PATH}/examples/common_components/protocol_examples_common)
 set(EXCLUDE_COMPONENTS openssl)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)

--- a/components/asio/examples/ssl_client_server/main/idf_component.yml
+++ b/components/asio/examples/ssl_client_server/main/idf_component.yml
@@ -4,3 +4,5 @@ dependencies:
   espressif/asio:
     version: "^1.14.1"
     override_path: "../../../"
+  protocol_examples_common:
+    path: ${IDF_PATH}/examples/common_components/protocol_examples_common

--- a/components/asio/examples/tcp_echo_server/CMakeLists.txt
+++ b/components/asio/examples/tcp_echo_server/CMakeLists.txt
@@ -2,9 +2,5 @@
 # in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.16)
 
-# (Not part of the boilerplate)
-# This example uses an extra component for common functions such as Wi-Fi and Ethernet connection.
-set(EXTRA_COMPONENT_DIRS $ENV{IDF_PATH}/examples/common_components/protocol_examples_common)
-
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(asio_tcp_echo_server)

--- a/components/asio/examples/tcp_echo_server/main/idf_component.yml
+++ b/components/asio/examples/tcp_echo_server/main/idf_component.yml
@@ -4,3 +4,5 @@ dependencies:
   espressif/asio:
     version: "^1.14.1"
     override_path: "../../../"
+  protocol_examples_common:
+    path: ${IDF_PATH}/examples/common_components/protocol_examples_common

--- a/components/asio/examples/udp_echo_server/CMakeLists.txt
+++ b/components/asio/examples/udp_echo_server/CMakeLists.txt
@@ -2,9 +2,5 @@
 # in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.16)
 
-# (Not part of the boilerplate)
-# This example uses an extra component for common functions such as Wi-Fi and Ethernet connection.
-set(EXTRA_COMPONENT_DIRS $ENV{IDF_PATH}/examples/common_components/protocol_examples_common)
-
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(asio_udp_echo_server)

--- a/components/asio/examples/udp_echo_server/main/idf_component.yml
+++ b/components/asio/examples/udp_echo_server/main/idf_component.yml
@@ -4,3 +4,5 @@ dependencies:
   espressif/asio:
     version: "^1.14.1"
     override_path: "../../../"
+  protocol_examples_common:
+    path: ${IDF_PATH}/examples/common_components/protocol_examples_common

--- a/components/esp_websocket_client/examples/linux/CMakeLists.txt
+++ b/components/esp_websocket_client/examples/linux/CMakeLists.txt
@@ -8,7 +8,6 @@ set(EXTRA_COMPONENT_DIRS
   "${common_component_dir}/linux_compat"
   "${common_component_dir}/linux_compat/freertos")
 
-list(APPEND EXTRA_COMPONENT_DIRS $ENV{IDF_PATH}/examples/common_components/protocol_examples_common)
 list(APPEND EXTRA_COMPONENT_DIRS $ENV{IDF_PATH}/examples/protocols/linux_stubs/esp_stubs)
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 

--- a/components/esp_websocket_client/examples/linux/main/idf_component.yml
+++ b/components/esp_websocket_client/examples/linux/main/idf_component.yml
@@ -1,8 +1,3 @@
 dependencies:
-  ## Required IDF version
-  idf: ">=5.0"
-  espressif/asio:
-    version: "^1.14.1"
-    override_path: "../../../"
   protocol_examples_common:
     path: ${IDF_PATH}/examples/common_components/protocol_examples_common

--- a/components/esp_websocket_client/examples/target/CMakeLists.txt
+++ b/components/esp_websocket_client/examples/target/CMakeLists.txt
@@ -2,8 +2,5 @@
 # in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.5)
 
-# This example uses an extra component for common functions such as Wi-Fi and Ethernet connection.
-list(APPEND EXTRA_COMPONENT_DIRS $ENV{IDF_PATH}/examples/common_components/protocol_examples_common)
-
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(websocket_example)

--- a/components/esp_websocket_client/examples/target/main/idf_component.yml
+++ b/components/esp_websocket_client/examples/target/main/idf_component.yml
@@ -4,3 +4,5 @@ dependencies:
   espressif/esp_websocket_client:
     version: "^1.0.0"
     override_path: "../../../"
+  protocol_examples_common:
+    path: ${IDF_PATH}/examples/common_components/protocol_examples_common


### PR DESCRIPTION
Re-applied the references to `idf_component.yml` after merging https://github.com/espressif/esp-protocols/pull/440 to publish websocket client

* This reverts commit 74fc228cdfa6de07892118210505661f9d4ae837. 
* This reverts commit b176d3abbb741a8b77ae564cc93cfad72b440f94.
* This reverts commit f9e0281a04b7370ad4ba9c0b9cdf590bbf4475f6.