### PR TITLE
fix(modem): Fixed inconsistent state on data after OK

### DIFF
--- a/components/esp_modem/src/esp_modem_dte.cpp
+++ b/components/esp_modem/src/esp_modem_dte.cpp
@@ -347,6 +347,9 @@ void DTE::on_read(got_line_cb on_read_cb)
 
 bool DTE::command_cb::process_line(uint8_t *data, size_t consumed, size_t len)
 {
+    if (result != command_result::TIMEOUT) {
+        return false;   // this line has been processed already (got OK or FAIL previously)
+    }
     if (memchr(data + consumed, separator, len)) {
         result = got_line(data, consumed + len);
         if (result == command_result::OK || result == command_result::FAIL) {


### PR DESCRIPTION
If we received response in two chunks and the first one completed the command (result=OK or FAIL), and the second chunk preempts command processing, then we performed processing again rewriting the result back to TIMEOUT. This would invalidate the command, but also causes an exception: `ESP_MODEM_THROW_IF_ERROR(ESP_ERR_INVALID_STATE)`

Fixed by checking if the processing already finished in process_line().

Closes https://github.com/espressif/esp-protocols/issues/426