### PR TITLE
bump(websocket): 1.2.1 -> 1.2.2

### DIFF
--- a/components/esp_websocket_client/.cz.yaml
+++ b/components/esp_websocket_client/.cz.yaml
@@ -3,6 +3,6 @@ commitizen:
   bump_message: 'bump(websocket): $current_version -> $new_version'
   pre_bump_hooks: python ../../ci/changelog.py esp_websocket_client
   tag_format: websocket-v$version
-  version: 1.2.1
+  version: 1.2.2
   version_files:
   - idf_component.yml

--- a/components/esp_websocket_client/CHANGELOG.md
+++ b/components/esp_websocket_client/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.2.2](https://github.com/espressif/esp-protocols/commits/websocket-v1.2.2)
+
+### Bug Fixes
+
+- continuation after FIN in websocket client (#460) ([774d1c75e6](https://github.com/espressif/esp-protocols/commit/774d1c75e6))
+- Re-applie refs to common comps idf_component.yml ([9fe44a4504](https://github.com/espressif/esp-protocols/commit/9fe44a4504))
+
 ## [1.2.1](https://github.com/espressif/esp-protocols/commits/websocket-v1.2.1)
 
 ### Bug Fixes

--- a/components/esp_websocket_client/idf_component.yml
+++ b/components/esp_websocket_client/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.2.1"
+version: "1.2.2"
 description: WebSocket protocol client for ESP-IDF
 url: https://github.com/espressif/esp-protocols/tree/master/components/esp_websocket_client
 dependencies:


### PR DESCRIPTION
1.2.2
Bug Fixes
- continuation after FIN in websocket client (#460) (774d1c75e6)
- Re-applied refs to common comps idf_component.yml (9fe44a4504)