### PR TITLE
bump(mqtt_cxx): 0.2.0 -> 0.3.0

### DIFF
--- a/components/esp_mqtt_cxx/.cz.yaml
+++ b/components/esp_mqtt_cxx/.cz.yaml
@@ -3,6 +3,6 @@ commitizen:
   bump_message: 'bump(mqtt_cxx): $current_version -> $new_version'
   pre_bump_hooks: python ../../ci/changelog.py esp_mqtt_cxx
   tag_format: mqtt_cxx-v$version
-  version: 0.2.0
+  version: 0.3.0
   version_files:
   - idf_component.yml

--- a/components/esp_mqtt_cxx/CHANGELOG.md
+++ b/components/esp_mqtt_cxx/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.3.0](https://github.com/espressif/esp-protocols/commits/mqtt_cxx-v0.3.0)
+
+### Bug Fixes
+
+- Incorrect documentation link ([aa4e9d57](https://github.com/espressif/esp-protocols/commit/aa4e9d57))
+- reference protocol_examples_common from IDF ([e6c0538d](https://github.com/espressif/esp-protocols/commit/e6c0538d))
+- specify override_path in example manifest files ([fa005c63](https://github.com/espressif/esp-protocols/commit/fa005c63))
+
 ## [0.2.0](https://github.com/espressif/esp-protocols/commits/mqtt_cxx-v0.2.0)
 
 ### Features

--- a/components/esp_mqtt_cxx/idf_component.yml
+++ b/components/esp_mqtt_cxx/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.2.0"
+version: "0.3.0"
 description: C++ APIs for ESP-MQTT library
 url: https://github.com/espressif/esp-protocols/tree/master/components/esp_mqtt_cxx
 issues: https://github.com/espressif/esp-protocols/issues


### PR DESCRIPTION
0.3.0
Bug Fixes
- Incorrect documentation link (aa4e9d57)
- reference protocol_examples_common from IDF (e6c0538d)
- specify override_path in example manifest files (fa005c63)