### PR TITLE
fix(websocket): Continue waiting for TCP connection to be closed (IDFGH-11965)

### DIFF
--- a/components/esp_websocket_client/esp_websocket_client.c
+++ b/components/esp_websocket_client/esp_websocket_client.c
@@ -1039,10 +1039,9 @@ static void esp_websocket_client_task(void *pv)
             ESP_LOGD(TAG, " Waiting for TCP connection to be closed by the server");
             int ret = esp_transport_ws_poll_connection_closed(client->transport, 1000);
             if (ret == 0) {
-                // still waiting
-                continue;
-            }
-            if (ret < 0) {
+                ESP_LOGW(TAG, "Did not get TCP close within expected delay");
+
+            } else if (ret < 0) {
                 ESP_LOGW(TAG, "Connection terminated while waiting for clean TCP close");
             }
             client->run = false;

--- a/components/esp_websocket_client/esp_websocket_client.c
+++ b/components/esp_websocket_client/esp_websocket_client.c
@@ -1040,7 +1040,7 @@ static void esp_websocket_client_task(void *pv)
             int ret = esp_transport_ws_poll_connection_closed(client->transport, 1000);
             if (ret == 0) {
                 // still waiting
-                break;
+                continue;
             }
             if (ret < 0) {
                 ESP_LOGW(TAG, "Connection terminated while waiting for clean TCP close");


### PR DESCRIPTION
An issue was observed where the websocket client did not send WEBSOCKET_EVENT_CLOSED after server closed the websocket.

An alternative solution to fix the issue would be  to remove the if instead. It could be more robust, but the existing comment seem to suggest that it was not the original intent.