### PR TITLE
feat(mdns): Make including mdns_console KConfig

### DIFF
--- a/components/mdns/CMakeLists.txt
+++ b/components/mdns/CMakeLists.txt
@@ -4,6 +4,12 @@ else()
     set(MDNS_NETWORKING "mdns_networking_lwip.c")
 endif()
 
+if(CONFIG_MDNS_ENABLE_CONSOLE_CLI)
+    set(MDNS_CONSOLE "mdns_console.c")
+else()
+    set(MDNS_CONSOLE "")
+endif()
+
 idf_build_get_property(target IDF_TARGET)
 if(${target} STREQUAL "linux")
     set(dependencies esp_netif_linux esp_timer esp_system)
@@ -11,7 +17,7 @@ if(${target} STREQUAL "linux")
 else()
     set(dependencies lwip console esp_netif)
     set(private_dependencies esp_timer esp_wifi)
-    set(srcs "mdns.c" ${MDNS_NETWORKING} "mdns_console.c")
+    set(srcs "mdns.c" ${MDNS_NETWORKING} ${MDNS_CONSOLE})
 endif()
 
 idf_component_register(

--- a/components/mdns/Kconfig
+++ b/components/mdns/Kconfig
@@ -100,6 +100,12 @@ menu "mDNS"
         help
             Enable for the library to log received and sent mDNS packets to stdout.
 
+    config MDNS_ENABLE_CONSOLE_CLI
+        bool "Enable Command Line Interface on device console"
+        default y
+        help
+            Enable for the console cli to be available on the device.
+
     config MDNS_RESPOND_REVERSE_QUERIES
         bool "Enable responding to IPv4 reverse queries"
         default n


### PR DESCRIPTION
The CLI that mdns_console offers is very useful for debugging and bootstrapping mDNS onto new projects, but some projects may not want console CLI in place to reduce binary size.

This gives a KConfig option to do so.