### PR TITLE
feat(console): Added component for iperf command

### DIFF
--- a/components/iperf/.cz.yaml
+++ b/components/iperf/.cz.yaml
@@ -1,0 +1,8 @@
+---
+commitizen:
+  bump_message: 'bump(console): $current_version -> $new_version'
+  pre_bump_hooks: python ../../ci/changelog.py iperf
+  tag_format: iperf-v$version
+  version: 1.0.3
+  version_files:
+  - idf_component.yml

--- a/components/iperf/CMakeLists.txt
+++ b/components/iperf/CMakeLists.txt
@@ -1,0 +1,8 @@
+idf_component_register(SRCS "iperf.c"
+                            "console_iperf.c"
+                    INCLUDE_DIRS "include"
+                    PRIV_REQUIRES esp_netif console esp_timer)
+
+if(CONFIG_IPERF_CMD_AUTO_REGISTRATION)
+    target_link_libraries(${COMPONENT_LIB} "-u console_cmd_iperf_register")
+endif()

--- a/components/iperf/Kconfig.projbuild
+++ b/components/iperf/Kconfig.projbuild
@@ -1,0 +1,37 @@
+menu "Iperf Configuration"
+
+    config IPERF_SOCKET_RX_TIMEOUT
+        int "iperf socket TCP/UDP rx timeout in seconds"
+        default 10
+        help
+            The value is used for iperf socket TCP/UDP rx timeout, iperf will be aborted
+            and socket will be closed and shutdown.
+
+    config IPERF_SOCKET_TCP_TX_TIMEOUT
+        int "iperf socket TCP tx timeout in seconds"
+        default 10
+        help
+            The value is used for iperf socket TCP tx timeout, iperf will be aborted
+            and socket will be closed and shutdown.
+
+    config IPERF_TRAFFIC_TASK_PRIORITY
+        int "iperf traffic task priority"
+        default 4
+        range 1 24
+        help
+            The value is used for iperf traffic task priority.
+
+    config IPERF_REPORT_TASK_PRIORITY
+        int "iperf result report task priority"
+        default 6
+        range 1 24
+        help
+            The value is used for iperf result report task priority.
+
+    config IPERF_CMD_AUTO_REGISTRATION
+        bool "Enable Console command iperf Auto-registration"
+        default y
+        help
+            Enabling this allows for the autoregistration of the iperf command.
+
+endmenu

--- a/components/iperf/LICENSE
+++ b/components/iperf/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/components/iperf/README.md
+++ b/components/iperf/README.md
@@ -1,0 +1,67 @@
+# iperf Component
+
+This component contains an implementation for iperf network performance tester.
+
+Note that it's incompatible with `iperf3`
+
+This component is used as part of the following ESP-IDF examples:
+- [esp_wifi](../../wifi/iperf).
+- [wifi_coexist](../../bluetooth/esp_ble_mesh/wifi_coexist).
+- [ethernet](../../ethernet/iperf)
+
+To learn more about how to use this component, please check API Documentation from header file [iperf.h](./include/iperf.h).
+
+
+# Console command iperf
+The component also provides a console where the 'iperf' command can be executed for any example project.
+
+
+## API
+
+### Steps to enable console in an example code:
+1. Add this component to your project using ```idf.py add-dependency``` command.
+2. In the main file of the example, add the following line:
+    ```c
+    #include "console_iperf.h"
+    ```
+3. Ensure esp-netif and NVS flash is initialized and default event loop is created in your app_main():
+    ```c
+    ESP_ERROR_CHECK(esp_netif_init());
+    ESP_ERROR_CHECK(esp_event_loop_create_default());
+    ```
+4. In your app_main() function, add the following line as the last line:
+    ```c
+    ESP_ERROR_CHECK(console_cmd_init());     // Initialize console
+
+    // Register all plugin command added to your project
+    ESP_ERROR_CHECK(console_cmd_all_register());
+
+    // To register only iperf command skip calling console_cmd_all_register()
+    ESP_ERROR_CHECK(console_cmd_iperf_register());
+
+    ESP_ERROR_CHECK(console_cmd_start());    // Start console
+    ```
+
+### Adding a plugin command or component:
+To add a plugin command or any component from IDF component manager into your project, simply include an entry within the `idf_component.yml` file.
+
+For more details refer [IDF Component Manager](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/tools/idf-component-manager.html)
+
+
+## Suported command:
+
+### iperf:
+```
+iperf  [-suVa] [-c <ip>] [-p <port>] [-l <length>] [-i <interval>] [-t <time>] [-b <bandwidth>]
+  Command to measure network performance, through TCP or UDP connections.
+  -c, --client=<ip>  run in client mode, connecting to <host>
+  -s, --server  run in server mode
+     -u, --udp  use UDP rather than TCP
+  -V, --ipv6_domain  use IPV6 address rather than IPV4
+  -p, --port=<port>  server port to listen on/connect to
+  -l, --len=<length>  set read/write buffer size
+  -i, --interval=<interval>  seconds between periodic bandwidth reports
+  -t, --time=<time>  time in seconds to transmit for (default 10 secs)
+  -b, --bandwidth=<bandwidth>  bandwidth to send at in Mbits/sec
+   -a, --abort  abort running iperf
+```

--- a/components/iperf/console_iperf.c
+++ b/components/iperf/console_iperf.c
@@ -1,0 +1,201 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <stdio.h>
+#include <string.h>
+#include <inttypes.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/event_groups.h"
+#include "sys/socket.h" // for INADDR_ANY
+#include "esp_netif.h"
+#include "esp_log.h"
+#include "esp_system.h"
+#include "esp_event.h"
+#include "esp_log.h"
+#include "esp_netif.h"
+#include "esp_netif_ppp.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/event_groups.h"
+
+#include "esp_console.h"
+#include "esp_event.h"
+#include "esp_bit_defs.h"
+#include "argtable3/argtable3.h"
+#include "sdkconfig.h"
+#include "iperf.h"
+#include "console_iperf.h"
+
+/* "iperf" command */
+
+/**
+ * Static registration of this plugin is achieved by defining the plugin description
+ * structure and placing it into .console_cmd_desc section.
+ * The name of the section and its placement is determined by linker.lf file in 'plugins' component.
+ */
+static const console_cmd_plugin_desc_t __attribute__((section(".console_cmd_desc"), used)) PLUGIN = {
+    .name = "console_cmd_iperf",
+    .plugin_regd_fn = &console_cmd_iperf_register
+};
+
+static const char *TAG = "console_iperf";
+
+static struct {
+    struct arg_str *ip;
+    struct arg_lit *server;
+    struct arg_lit *udp;
+    struct arg_lit *version;
+    struct arg_int *port;
+    struct arg_int *length;
+    struct arg_int *interval;
+    struct arg_int *time;
+    struct arg_int *bw_limit;
+    struct arg_lit *abort;
+    struct arg_end *end;
+} iperf_args;
+
+static int do_cmd_iperf(int argc, char **argv)
+{
+    int nerrors = arg_parse(argc, argv, (void **)&iperf_args);
+    /* ethernet iperf only support IPV4 address */
+    iperf_cfg_t cfg = {.type = IPERF_IP_TYPE_IPV4};
+
+    if (nerrors != 0) {
+        arg_print_errors(stderr, iperf_args.end, argv[0]);
+        return 0;
+    }
+
+    /* iperf -a */
+    if (iperf_args.abort->count != 0) {
+        iperf_stop();
+        return 0;
+    }
+
+    if (((iperf_args.ip->count == 0) && (iperf_args.server->count == 0)) ||
+            ((iperf_args.ip->count != 0) && (iperf_args.server->count != 0))) {
+        ESP_LOGE(__func__, "Wrong mode! ESP32 should run in client or server mode");
+        return 0;
+    }
+
+    /* iperf -s */
+    if (iperf_args.ip->count == 0) {
+        cfg.flag |= IPERF_FLAG_SERVER;
+    }
+    /* iperf -c SERVER_ADDRESS */
+    else {
+        cfg.destination_ip4 = esp_ip4addr_aton(iperf_args.ip->sval[0]);
+        cfg.flag |= IPERF_FLAG_CLIENT;
+    }
+
+    if (iperf_args.length->count == 0) {
+        cfg.len_send_buf = 0;
+    } else {
+        cfg.len_send_buf = iperf_args.length->ival[0];
+    }
+
+    cfg.source_ip4 = INADDR_ANY;
+
+    /* iperf -u */
+    if (iperf_args.udp->count == 0) {
+        cfg.flag |= IPERF_FLAG_TCP;
+    } else {
+        cfg.flag |= IPERF_FLAG_UDP;
+    }
+
+    /* iperf -p */
+    if (iperf_args.port->count == 0) {
+        cfg.sport = IPERF_DEFAULT_PORT;
+        cfg.dport = IPERF_DEFAULT_PORT;
+    } else {
+        if (cfg.flag & IPERF_FLAG_SERVER) {
+            cfg.sport = iperf_args.port->ival[0];
+            cfg.dport = IPERF_DEFAULT_PORT;
+        } else {
+            cfg.sport = IPERF_DEFAULT_PORT;
+            cfg.dport = iperf_args.port->ival[0];
+        }
+    }
+
+    /* iperf -i */
+    if (iperf_args.interval->count == 0) {
+        cfg.interval = IPERF_DEFAULT_INTERVAL;
+    } else {
+        cfg.interval = iperf_args.interval->ival[0];
+        if (cfg.interval <= 0) {
+            cfg.interval = IPERF_DEFAULT_INTERVAL;
+        }
+    }
+
+    /* iperf -t */
+    if (iperf_args.time->count == 0) {
+        cfg.time = IPERF_DEFAULT_TIME;
+    } else {
+        cfg.time = iperf_args.time->ival[0];
+        if (cfg.time <= cfg.interval) {
+            cfg.time = cfg.interval;
+        }
+    }
+
+    /* iperf -b */
+    if (iperf_args.bw_limit->count == 0) {
+        cfg.bw_lim = IPERF_DEFAULT_NO_BW_LIMIT;
+    } else {
+        cfg.bw_lim = iperf_args.bw_limit->ival[0];
+        if (cfg.bw_lim <= 0) {
+            cfg.bw_lim = IPERF_DEFAULT_NO_BW_LIMIT;
+        }
+    }
+
+    printf("mode=%s-%s sip=" IPSTR ":%" PRIu16 ", dip=%" PRIu32 ".%" PRIu32 ".%" PRIu32 ".%" PRIu32 ":%" PRIu16 ", interval=%" PRIu32 ", time=%" PRIu32 "\r\n",
+           cfg.flag & IPERF_FLAG_TCP ? "tcp" : "udp",
+           cfg.flag & IPERF_FLAG_SERVER ? "server" : "client",
+           (uint16_t) cfg.source_ip4 & 0xFF,
+           (uint16_t)(cfg.source_ip4 >> 8) & 0xFF,
+           (uint16_t)(cfg.source_ip4 >> 16) & 0xFF,
+           (uint16_t)(cfg.source_ip4 >> 24) & 0xFF,
+           cfg.sport,
+           cfg.destination_ip4 & 0xFF, (cfg.destination_ip4 >> 8) & 0xFF,
+           (cfg.destination_ip4 >> 16) & 0xFF, (cfg.destination_ip4 >> 24) & 0xFF, cfg.dport,
+           cfg.interval, cfg.time);
+
+    iperf_start(&cfg);
+    return 0;
+}
+
+/**
+ * @brief Registers the iperf command.
+ *
+ * @return
+ *          - esp_err_t
+ */
+esp_err_t console_cmd_iperf_register(void)
+{
+    iperf_args.ip = arg_str0("c", "client", "<ip>", "run in client mode, connecting to <host>");
+    iperf_args.server = arg_lit0("s", "server", "run in server mode");
+    iperf_args.udp = arg_lit0("u", "udp", "use UDP rather than TCP");
+    iperf_args.version = arg_lit0("V", "ipv6_domain", "use IPV6 address rather than IPV4");
+    iperf_args.port = arg_int0("p", "port", "<port>", "server port to listen on/connect to");
+    iperf_args.length = arg_int0("l", "len", "<length>", "set read/write buffer size");
+    iperf_args.interval = arg_int0("i", "interval", "<interval>", "seconds between periodic bandwidth reports");
+    iperf_args.time = arg_int0("t", "time", "<time>", "time in seconds to transmit for (default 10 secs)");
+    iperf_args.bw_limit = arg_int0("b", "bandwidth", "<bandwidth>", "bandwidth to send at in Mbits/sec");
+    iperf_args.abort = arg_lit0("a", "abort", "abort running iperf");
+    iperf_args.end = arg_end(1);
+
+    esp_err_t ret;
+    const esp_console_cmd_t command = {
+        .command = "iperf",
+        .help = "Command to measure network performance, through TCP or UDP connections.",
+        .hint = NULL,
+        .func = &do_cmd_iperf,
+        .argtable = &iperf_args
+    };
+
+    ret = esp_console_cmd_register(&command);
+    if (ret) {
+        ESP_LOGE(TAG, "Unable to register iperf");
+    }
+
+    return ret;
+}

--- a/components/iperf/examples/iperf-basic/CMakeLists.txt
+++ b/components/iperf/examples/iperf-basic/CMakeLists.txt
@@ -1,0 +1,8 @@
+# For more information about build system see
+# https://docs.espressif.com/projects/esp-idf/en/latest/api-guides/build-system.html
+# The following five lines of boilerplate have to be in your project's
+# CMakeLists in this exact order for cmake to work correctly
+cmake_minimum_required(VERSION 3.16)
+
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(iperf-basic)

--- a/components/iperf/examples/iperf-basic/main/CMakeLists.txt
+++ b/components/iperf/examples/iperf-basic/main/CMakeLists.txt
@@ -1,0 +1,2 @@
+idf_component_register(SRCS "iperf-basic.c"
+                    INCLUDE_DIRS ".")

--- a/components/iperf/examples/iperf-basic/main/idf_component.yml
+++ b/components/iperf/examples/iperf-basic/main/idf_component.yml
@@ -1,0 +1,6 @@
+dependencies:
+  idf:
+    version: ">=5.0"
+  iperf:
+    version: "*"
+    override_path: '../../../'

--- a/components/iperf/examples/iperf-basic/main/iperf-basic.c
+++ b/components/iperf/examples/iperf-basic/main/iperf-basic.c
@@ -1,0 +1,26 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <stdio.h>
+#include "esp_netif.h"
+#include "nvs_flash.h"
+#include "esp_netif.h"
+#include "esp_event.h"
+#include "console_iperf.h"
+
+void app_main(void)
+{
+    ESP_ERROR_CHECK(esp_netif_init());
+    ESP_ERROR_CHECK(esp_event_loop_create_default());
+
+    // Initialize console REPL
+    ESP_ERROR_CHECK(console_cmd_init());
+
+    ESP_ERROR_CHECK(console_cmd_all_register());
+
+    // start console REPL
+    ESP_ERROR_CHECK(console_cmd_start());
+
+}

--- a/components/iperf/examples/iperf-basic/pytest_iperf-basic.py
+++ b/components/iperf/examples/iperf-basic/pytest_iperf-basic.py
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
+# SPDX-License-Identifier: Unlicense OR CC0-1.0
+
+# -*- coding: utf-8 -*-
+import pytest
+
+
+@pytest.mark.esp32
+def test_examples_iperf_command(dut):
+    dut.expect('esp>', timeout=30)
+    dut.write('help iperf')
+    dut.expect('esp>', timeout=5)
+    pass

--- a/components/iperf/idf_component.yml
+++ b/components/iperf/idf_component.yml
@@ -1,0 +1,13 @@
+version: 1.0.3
+url: https://github.com/espressif/esp-protocols/tree/master/components/iperf
+description: The component provides a console where the 'iperf' command can be executed.
+dependencies:
+  idf:
+    version: '>=5.0'
+  espressif/console_simple_init:
+    version: '>=1.1.0'
+    override_path: '../console_simple_init'
+    public: true
+  espressif/console_cmd_wifi:
+    version: "~1.0.2"
+    service_url: "https://components-staging.espressif.com/api"

--- a/components/iperf/include/console_iperf.h
+++ b/components/iperf/include/console_iperf.h
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "console_simple_init.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Registers the iperf command.
+ *
+ * @return
+ *          - esp_err_t
+ */
+esp_err_t console_cmd_iperf_register(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/components/iperf/include/iperf.h
+++ b/components/iperf/include/iperf.h
@@ -1,0 +1,86 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef __IPERF_H_
+#define __IPERF_H_
+
+#include "esp_err.h"
+#include "esp_types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define IPERF_IP_TYPE_IPV4 0
+#define IPERF_IP_TYPE_IPV6 1
+#define IPERF_TRANS_TYPE_TCP 0
+#define IPERF_TRANS_TYPE_UDP 1
+
+#define IPERF_FLAG_SET(cfg, flag) ((cfg) |= (flag))
+#define IPERF_FLAG_CLR(cfg, flag) ((cfg) &= (~(flag)))
+
+#define IPERF_FLAG_CLIENT (1)
+#define IPERF_FLAG_SERVER (1 << 1)
+#define IPERF_FLAG_TCP (1 << 2)
+#define IPERF_FLAG_UDP (1 << 3)
+
+#define IPERF_DEFAULT_PORT 5001
+#define IPERF_DEFAULT_INTERVAL 3
+#define IPERF_DEFAULT_TIME 30
+#define IPERF_DEFAULT_NO_BW_LIMIT -1
+
+#define IPERF_TRAFFIC_TASK_NAME "iperf_traffic"
+#define IPERF_TRAFFIC_TASK_PRIORITY CONFIG_IPERF_TRAFFIC_TASK_PRIORITY
+#define IPERF_TRAFFIC_TASK_STACK 4096
+#define IPERF_REPORT_TASK_NAME "iperf_report"
+#define IPERF_REPORT_TASK_PRIORITY CONFIG_IPERF_REPORT_TASK_PRIORITY
+#define IPERF_REPORT_TASK_STACK 4096
+
+#define IPERF_DEFAULT_IPV4_UDP_TX_LEN   (1470)
+#define IPERF_DEFAULT_IPV6_UDP_TX_LEN   (1450)
+#define IPERF_DEFAULT_UDP_RX_LEN        (16 << 10)
+#define IPERF_DEFAULT_TCP_TX_LEN        (16 << 10)
+#define IPERF_DEFAULT_TCP_RX_LEN        (16 << 10)
+
+#define IPERF_MAX_DELAY 64
+
+#define IPERF_SOCKET_RX_TIMEOUT     CONFIG_IPERF_SOCKET_RX_TIMEOUT
+#define IPERF_SOCKET_TCP_TX_TIMEOUT CONFIG_IPERF_SOCKET_TCP_TX_TIMEOUT
+#define IPERF_SOCKET_ACCEPT_TIMEOUT 5
+
+typedef enum {
+    MBITS_PER_SEC, KBITS_PER_SEC, BITS_PER_SEC
+} iperf_output_format;
+
+typedef struct {
+    uint32_t flag;
+    union {
+        uint32_t destination_ip4;
+        char    *destination_ip6;
+    };
+    union {
+        uint32_t source_ip4;
+        char    *source_ip6;
+    };
+    uint8_t type;
+    uint16_t dport;
+    uint16_t sport;
+    uint32_t interval;
+    uint32_t time;
+    uint16_t len_send_buf;
+    int32_t bw_lim;
+    iperf_output_format format;
+} iperf_cfg_t;
+
+esp_err_t iperf_start(iperf_cfg_t *cfg);
+
+esp_err_t iperf_stop(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/components/iperf/iperf.c
+++ b/components/iperf/iperf.c
@@ -1,0 +1,614 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/* Iperf Example - iperf implementation
+
+   This example code is in the Public Domain (or CC0 licensed, at your option.)
+/
+   Unless required by applicable law or agreed to in writing, this
+   software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied.
+*/
+
+#include "sdkconfig.h"
+#include <stdio.h>
+#include <string.h>
+#include <sys/param.h>
+#include <sys/socket.h>
+#include <inttypes.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "esp_check.h"
+#include "esp_log.h"
+#include "esp_rom_sys.h"
+#include "esp_timer.h"
+#include "iperf.h"
+#include "wifi_stats.h"
+
+
+typedef struct {
+    iperf_cfg_t cfg;
+    bool finish;
+    uint32_t actual_len;
+    uint32_t buffer_len;
+    uint8_t *buffer;
+    uint32_t sockfd;
+} iperf_ctrl_t;
+
+static bool s_iperf_is_running = false;
+static iperf_ctrl_t s_iperf_ctrl;
+static const char *TAG = "iperf";
+
+inline static bool iperf_is_udp_client(void)
+{
+    return ((s_iperf_ctrl.cfg.flag & IPERF_FLAG_CLIENT) && (s_iperf_ctrl.cfg.flag & IPERF_FLAG_UDP));
+}
+
+inline static bool iperf_is_udp_server(void)
+{
+    return ((s_iperf_ctrl.cfg.flag & IPERF_FLAG_SERVER) && (s_iperf_ctrl.cfg.flag & IPERF_FLAG_UDP));
+}
+
+inline static bool iperf_is_tcp_client(void)
+{
+    return ((s_iperf_ctrl.cfg.flag & IPERF_FLAG_CLIENT) && (s_iperf_ctrl.cfg.flag & IPERF_FLAG_TCP));
+}
+
+inline static bool iperf_is_tcp_server(void)
+{
+    return ((s_iperf_ctrl.cfg.flag & IPERF_FLAG_SERVER) && (s_iperf_ctrl.cfg.flag & IPERF_FLAG_TCP));
+}
+
+static int iperf_get_socket_error_code(int sockfd)
+{
+    return errno;
+}
+
+static int iperf_show_socket_error_reason(const char *str, int sockfd)
+{
+    int err = errno;
+    if (err != 0) {
+        ESP_LOGW(TAG, "%s error, error code: %d, reason: %s", str, err, strerror(err));
+    }
+
+    return err;
+}
+
+static void iperf_report_task(void *arg)
+{
+    uint32_t interval = s_iperf_ctrl.cfg.interval;
+    uint32_t time = s_iperf_ctrl.cfg.time;
+    TickType_t delay_interval = (interval * 1000) / portTICK_PERIOD_MS;
+    uint32_t cur = 0;
+    double average = 0;
+    double actual_bandwidth = 0;
+    int k = 1;
+    const double coefficient[3] = {1048576.0, 1024.0, 1.0};
+    const char unit[3] = {'M', 'K', '\0'};
+    iperf_output_format format = s_iperf_ctrl.cfg.format;
+
+    printf("\n%16s %s\n", "Interval", "Bandwidth");
+    while (!s_iperf_ctrl.finish) {
+        vTaskDelay(delay_interval);
+        actual_bandwidth = (s_iperf_ctrl.actual_len / coefficient[format] * 8) / interval;
+        printf("%4" PRIi32 "-%4" PRIi32 " sec       %.2f %cbits/sec\n", cur, cur + interval,
+               actual_bandwidth, unit[format]);
+        cur += interval;
+        average = ((average * (k - 1) / k) + (actual_bandwidth / k));
+        k++;
+        s_iperf_ctrl.actual_len = 0;
+        if (cur >= time) {
+            printf("%4d-%4" PRIu32 " sec       %.2f %cbits/sec\n", 0, time,
+                   average, unit[format]);
+            break;
+        }
+    }
+
+    s_iperf_ctrl.finish = true;
+    vTaskDelete(NULL);
+}
+
+static esp_err_t iperf_start_report(void)
+{
+    int ret;
+
+    ret = xTaskCreatePinnedToCore(iperf_report_task, IPERF_REPORT_TASK_NAME, IPERF_REPORT_TASK_STACK, NULL, IPERF_REPORT_TASK_PRIORITY, NULL, CONFIG_FREERTOS_NUMBER_OF_CORES - 1);
+
+    if (ret != pdPASS) {
+        ESP_LOGE(TAG, "create task %s failed", IPERF_REPORT_TASK_NAME);
+        return ESP_FAIL;
+    }
+
+    return ESP_OK;
+}
+
+static void IRAM_ATTR socket_recv(int recv_socket, struct sockaddr_storage listen_addr, uint8_t type)
+{
+    bool iperf_recv_start = true;
+    uint8_t *buffer;
+    int want_recv = 0;
+    int actual_recv = 0;
+#ifdef CONFIG_LWIP_IPV6
+    socklen_t socklen = (s_iperf_ctrl.cfg.type == IPERF_IP_TYPE_IPV6) ? sizeof(struct sockaddr_in6) : sizeof(struct sockaddr_in);
+#else
+    socklen_t socklen = sizeof(struct sockaddr_in);
+#endif
+    const char *error_log = (type == IPERF_TRANS_TYPE_TCP) ? "tcp server recv" : "udp server recv";
+
+    buffer = s_iperf_ctrl.buffer;
+    want_recv = s_iperf_ctrl.buffer_len;
+    while (!s_iperf_ctrl.finish) {
+        actual_recv = recvfrom(recv_socket, buffer, want_recv, 0, (struct sockaddr *)&listen_addr, &socklen);
+        if (actual_recv < 0) {
+            iperf_show_socket_error_reason(error_log, recv_socket);
+            s_iperf_ctrl.finish = true;
+            break;
+        } else {
+            if (iperf_recv_start) {
+                iperf_start_report();
+                iperf_recv_start = false;
+            }
+            s_iperf_ctrl.actual_len += actual_recv;
+        }
+    }
+}
+
+static void IRAM_ATTR socket_send(int send_socket, struct sockaddr_storage dest_addr, uint8_t type, int bw_lim)
+{
+    uint8_t *buffer;
+    uint32_t *pkt_id_p;
+    uint32_t pkt_cnt = 0;
+    int actual_send = 0;
+    int want_send = 0;
+    int period_us = -1;
+    int delay_us = 0;
+    int64_t prev_time = 0;
+    int64_t send_time = 0;
+    int err = 0;
+#ifdef CONFIG_LWIP_IPV6
+    const socklen_t socklen = (s_iperf_ctrl.cfg.type == IPERF_IP_TYPE_IPV6) ? sizeof(struct sockaddr_in6) : sizeof(struct sockaddr_in);
+#else
+    const socklen_t socklen = sizeof(struct sockaddr_in);
+#endif
+    const char *error_log = (type == IPERF_TRANS_TYPE_TCP) ? "tcp client send" : "udp client send";
+
+    buffer = s_iperf_ctrl.buffer;
+    pkt_id_p = (uint32_t *)s_iperf_ctrl.buffer;
+    want_send = s_iperf_ctrl.buffer_len;
+    iperf_start_report();
+
+    if (bw_lim > 0) {
+        period_us = want_send * 8 / bw_lim;
+    }
+
+    while (!s_iperf_ctrl.finish) {
+        if (period_us > 0) {
+            send_time = esp_timer_get_time();
+            if (actual_send > 0) {
+                // Last packet "send" was successful, check how much off the previous loop duration was to the ideal send period. Result will adjust the
+                // next send delay.
+                delay_us += period_us + (int32_t)(prev_time - send_time);
+            } else {
+                // Last packet "send" was not successful. Ideally we should try to catch up the whole previous loop duration (e.g. prev_time - send_time).
+                // However, that's not possible since the most probable reason why the send was unsuccessful is the HW was not able to process the packet.
+                // Hence, we cannot queue more packets with shorter (or no) delay to catch up since we are already at the performance edge. The best we
+                // can do is to reset the send delay (which is probably big negative number) and start all over again.
+                delay_us = 0;
+            }
+            prev_time = send_time;
+        }
+        *pkt_id_p = htonl(pkt_cnt++); // datagrams need to be sequentially numbered
+        actual_send = sendto(send_socket, buffer, want_send, 0, (struct sockaddr *)&dest_addr, socklen);
+        if (actual_send != want_send) {
+            if (type == IPERF_TRANS_TYPE_UDP) {
+                err = iperf_get_socket_error_code(send_socket);
+                // ENOMEM is expected under heavy load => do not print it
+                if (err != ENOMEM) {
+                    iperf_show_socket_error_reason(error_log, send_socket);
+                }
+            } else if (type == IPERF_TRANS_TYPE_TCP) {
+                iperf_show_socket_error_reason(error_log, send_socket);
+                break;
+            }
+        } else {
+            s_iperf_ctrl.actual_len += actual_send;
+        }
+        // The send delay may be negative, it indicates we are trying to catch up and hence to not delay the loop at all.
+        if (delay_us > 0) {
+            esp_rom_delay_us(delay_us);
+        }
+    }
+}
+
+static esp_err_t iperf_run_tcp_server(void)
+{
+    int listen_socket = -1;
+    int client_socket = -1;
+    int opt = 1;
+    int err = 0;
+    esp_err_t ret = ESP_OK;
+    struct sockaddr_in remote_addr;
+    struct timeval timeout = { 0 };
+    socklen_t addr_len = sizeof(struct sockaddr);
+    struct sockaddr_storage listen_addr = { 0 };
+
+    struct sockaddr_in listen_addr4 = { 0 };
+#ifdef CONFIG_LWIP_IPV6
+    struct sockaddr_in6 listen_addr6 = { 0 };
+    ESP_GOTO_ON_FALSE((s_iperf_ctrl.cfg.type == IPERF_IP_TYPE_IPV6 || s_iperf_ctrl.cfg.type == IPERF_IP_TYPE_IPV4), ESP_FAIL, exit, TAG, "Ivalid AF types");
+#else
+    ESP_GOTO_ON_FALSE((s_iperf_ctrl.cfg.type == IPERF_IP_TYPE_IPV4), ESP_FAIL, exit, TAG, "Invalid AF types");
+#endif
+#ifdef CONFIG_LWIP_IPV6
+    if (s_iperf_ctrl.cfg.type == IPERF_IP_TYPE_IPV6) {
+        // The TCP server listen at the address "::", which means all addresses can be listened to.
+        inet6_aton("::", &listen_addr6.sin6_addr);
+        listen_addr6.sin6_family = AF_INET6;
+        listen_addr6.sin6_port = htons(s_iperf_ctrl.cfg.sport);
+
+        listen_socket = socket(AF_INET6, SOCK_STREAM, IPPROTO_IPV6);
+        ESP_GOTO_ON_FALSE((listen_socket >= 0), ESP_FAIL, exit, TAG, "Unable to create socket: errno %d", errno);
+
+        setsockopt(listen_socket, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+        setsockopt(listen_socket, IPPROTO_IPV6, IPV6_V6ONLY, &opt, sizeof(opt));
+
+        ESP_LOGI(TAG, "Socket created");
+
+        err = bind(listen_socket, (struct sockaddr *)&listen_addr6, sizeof(listen_addr6));
+        ESP_GOTO_ON_FALSE((err == 0), ESP_FAIL, exit, TAG, "Socket unable to bind: errno %d, IPPROTO: %d", errno, AF_INET6);
+        err = listen(listen_socket, 1);
+        ESP_GOTO_ON_FALSE((err == 0), ESP_FAIL, exit, TAG, "Error occurred during listen: errno %d", errno);
+
+        memcpy(&listen_addr, &listen_addr6, sizeof(listen_addr6));
+    } else
+#endif
+        if (s_iperf_ctrl.cfg.type == IPERF_IP_TYPE_IPV4) {
+            listen_addr4.sin_family = AF_INET;
+            listen_addr4.sin_port = htons(s_iperf_ctrl.cfg.sport);
+            listen_addr4.sin_addr.s_addr = s_iperf_ctrl.cfg.source_ip4;
+
+            listen_socket = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+            ESP_GOTO_ON_FALSE((listen_socket >= 0), ESP_FAIL, exit, TAG, "Unable to create socket: errno %d", errno);
+
+            setsockopt(listen_socket, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+
+            ESP_LOGI(TAG, "Socket created");
+
+            err = bind(listen_socket, (struct sockaddr *)&listen_addr4, sizeof(listen_addr4));
+            ESP_GOTO_ON_FALSE((err == 0), ESP_FAIL, exit, TAG, "Socket unable to bind: errno %d, IPPROTO: %d", errno, AF_INET);
+
+            err = listen(listen_socket, 5);
+            ESP_GOTO_ON_FALSE((err == 0), ESP_FAIL, exit, TAG, "Error occurred during listen: errno %d", errno);
+            memcpy(&listen_addr, &listen_addr4, sizeof(listen_addr4));
+        }
+
+    timeout.tv_sec = IPERF_SOCKET_RX_TIMEOUT;
+    setsockopt(listen_socket, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout));
+    client_socket = accept(listen_socket, (struct sockaddr *)&remote_addr, &addr_len);
+    ESP_GOTO_ON_FALSE((client_socket >= 0), ESP_FAIL, exit, TAG, "Unable to accept connection: errno %d", errno);
+    ESP_LOGI(TAG, "accept: %s,%d", inet_ntoa(remote_addr.sin_addr), htons(remote_addr.sin_port));
+
+    timeout.tv_sec = IPERF_SOCKET_RX_TIMEOUT;
+    setsockopt(client_socket, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout));
+
+#if CONFIG_ESP_WIFI_ENABLE_WIFI_TX_STATS
+    wifi_cmd_clr_tx_statistics(0, NULL);
+#endif
+#if CONFIG_ESP_WIFI_ENABLE_WIFI_RX_STATS
+    wifi_cmd_clr_rx_statistics(0, NULL);
+#endif
+    socket_recv(client_socket, listen_addr, IPERF_TRANS_TYPE_TCP);
+#if CONFIG_ESP_WIFI_ENABLE_WIFI_RX_STATS
+    wifi_cmd_get_rx_statistics(0, NULL);
+#endif
+#if CONFIG_ESP_WIFI_ENABLE_WIFI_TX_STATS
+    wifi_cmd_get_tx_statistics(0, NULL);
+#endif
+
+exit:
+    if (client_socket != -1) {
+        close(client_socket);
+    }
+
+    if (listen_socket != -1) {
+        shutdown(listen_socket, 0);
+        close(listen_socket);
+        ESP_LOGI(TAG, "TCP Socket server is closed.");
+    }
+    s_iperf_ctrl.finish = true;
+    return ret;
+}
+
+static esp_err_t iperf_run_tcp_client(void)
+{
+    int client_socket = -1;
+    int err = 0;
+    esp_err_t ret = ESP_OK;
+    struct sockaddr_storage dest_addr = { 0 };
+    struct sockaddr_in dest_addr4 = { 0 };
+    struct timeval timeout = { 0 };
+#ifdef CONFIG_LWIP_IPV6
+    struct sockaddr_in6 dest_addr6 = { 0 };
+    ESP_GOTO_ON_FALSE((s_iperf_ctrl.cfg.type == IPERF_IP_TYPE_IPV6 || s_iperf_ctrl.cfg.type == IPERF_IP_TYPE_IPV4), ESP_FAIL, exit, TAG, "Ivalid AF types");
+#else
+    ESP_GOTO_ON_FALSE((s_iperf_ctrl.cfg.type == IPERF_IP_TYPE_IPV4), ESP_FAIL, exit, TAG, "Invalid AF types");
+#endif
+#ifdef CONFIG_LWIP_IPV6
+    if (s_iperf_ctrl.cfg.type == IPERF_IP_TYPE_IPV6) {
+        client_socket = socket(AF_INET6, SOCK_STREAM, IPPROTO_IPV6);
+        ESP_GOTO_ON_FALSE((client_socket >= 0), ESP_FAIL, exit, TAG, "Unable to create socket: errno %d", errno);
+
+        inet6_aton(s_iperf_ctrl.cfg.destination_ip6, &dest_addr6.sin6_addr);
+        dest_addr6.sin6_family = AF_INET6;
+        dest_addr6.sin6_port = htons(s_iperf_ctrl.cfg.dport);
+
+        err = connect(client_socket, (struct sockaddr *)&dest_addr6, sizeof(struct sockaddr_in6));
+        ESP_GOTO_ON_FALSE((err == 0), ESP_FAIL, exit, TAG, "Socket unable to connect: errno %d", errno);
+        ESP_LOGI(TAG, "Successfully connected");
+        memcpy(&dest_addr, &dest_addr6, sizeof(dest_addr6));
+    } else
+#endif
+        if (s_iperf_ctrl.cfg.type == IPERF_IP_TYPE_IPV4) {
+            client_socket = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+            ESP_GOTO_ON_FALSE((client_socket >= 0), ESP_FAIL, exit, TAG, "Unable to create socket: errno %d", errno);
+
+            dest_addr4.sin_family = AF_INET;
+            dest_addr4.sin_port = htons(s_iperf_ctrl.cfg.dport);
+            dest_addr4.sin_addr.s_addr = s_iperf_ctrl.cfg.destination_ip4;
+            err = connect(client_socket, (struct sockaddr *)&dest_addr4, sizeof(struct sockaddr_in));
+            ESP_GOTO_ON_FALSE((err == 0), ESP_FAIL, exit, TAG, "Socket unable to connect: errno %d", errno);
+            ESP_LOGI(TAG, "Successfully connected");
+            memcpy(&dest_addr, &dest_addr4, sizeof(dest_addr4));
+        }
+    timeout.tv_sec = IPERF_SOCKET_TCP_TX_TIMEOUT;
+    setsockopt(client_socket, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(timeout));
+
+#if CONFIG_ESP_WIFI_ENABLE_WIFI_RX_STATS
+    wifi_cmd_clr_rx_statistics(0, NULL);
+#endif
+#if CONFIG_ESP_WIFI_ENABLE_WIFI_TX_STATS
+    wifi_cmd_clr_tx_statistics(0, NULL);
+#endif
+    socket_send(client_socket, dest_addr, IPERF_TRANS_TYPE_TCP, s_iperf_ctrl.cfg.bw_lim);
+#if CONFIG_ESP_WIFI_ENABLE_WIFI_RX_STATS
+    wifi_cmd_get_rx_statistics(0, NULL);
+#endif
+#if CONFIG_ESP_WIFI_ENABLE_WIFI_TX_STATS
+    wifi_cmd_get_tx_statistics(0, NULL);
+#endif
+
+exit:
+    if (client_socket != -1) {
+        shutdown(client_socket, 0);
+        close(client_socket);
+        ESP_LOGI(TAG, "TCP Socket client is closed.");
+    }
+    s_iperf_ctrl.finish = true;
+    return ret;
+}
+
+static esp_err_t iperf_run_udp_server(void)
+{
+    int listen_socket = -1;
+    int opt = 1;
+    int err = 0;
+    esp_err_t ret = ESP_OK;
+    struct timeval timeout = { 0 };
+    struct sockaddr_storage listen_addr = { 0 };
+    struct sockaddr_in listen_addr4 = { 0 };
+#ifdef CONFIG_LWIP_IPV6
+    struct sockaddr_in6 listen_addr6 = { 0 };
+    ESP_GOTO_ON_FALSE((s_iperf_ctrl.cfg.type == IPERF_IP_TYPE_IPV6 || s_iperf_ctrl.cfg.type == IPERF_IP_TYPE_IPV4), ESP_FAIL, exit, TAG, "Ivalid AF types");
+#else
+    ESP_GOTO_ON_FALSE((s_iperf_ctrl.cfg.type == IPERF_IP_TYPE_IPV4), ESP_FAIL, exit, TAG, "Ivalid AF types");
+#endif
+#ifdef CONFIG_LWIP_IPV6
+    if (s_iperf_ctrl.cfg.type == IPERF_IP_TYPE_IPV6) {
+        // The UDP server listen at the address "::", which means all addresses can be listened to.
+        inet6_aton("::", &listen_addr6.sin6_addr);
+        listen_addr6.sin6_family = AF_INET6;
+        listen_addr6.sin6_port = htons(s_iperf_ctrl.cfg.sport);
+
+        listen_socket = socket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP);
+        ESP_GOTO_ON_FALSE((listen_socket >= 0), ESP_FAIL, exit, TAG, "Unable to create socket: errno %d", errno);
+        ESP_LOGI(TAG, "Socket created");
+
+        setsockopt(listen_socket, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+
+        err = bind(listen_socket, (struct sockaddr *)&listen_addr6, sizeof(struct sockaddr_in6));
+        ESP_GOTO_ON_FALSE((err == 0), ESP_FAIL, exit, TAG, "Socket unable to bind: errno %d", errno);
+        ESP_LOGI(TAG, "Socket bound, port %" PRIu16, listen_addr6.sin6_port);
+
+        memcpy(&listen_addr, &listen_addr6, sizeof(listen_addr6));
+    } else
+#endif
+        if (s_iperf_ctrl.cfg.type == IPERF_IP_TYPE_IPV4) {
+            listen_addr4.sin_family = AF_INET;
+            listen_addr4.sin_port = htons(s_iperf_ctrl.cfg.sport);
+            listen_addr4.sin_addr.s_addr = s_iperf_ctrl.cfg.source_ip4;
+
+            listen_socket = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+            ESP_GOTO_ON_FALSE((listen_socket >= 0), ESP_FAIL, exit, TAG, "Unable to create socket: errno %d", errno);
+            ESP_LOGI(TAG, "Socket created");
+
+            setsockopt(listen_socket, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+
+            err = bind(listen_socket, (struct sockaddr *)&listen_addr4, sizeof(struct sockaddr_in));
+            ESP_GOTO_ON_FALSE((err == 0), ESP_FAIL, exit, TAG, "Socket unable to bind: errno %d", errno);
+            ESP_LOGI(TAG, "Socket bound, port %d", listen_addr4.sin_port);
+            memcpy(&listen_addr, &listen_addr4, sizeof(listen_addr4));
+        }
+
+    timeout.tv_sec = IPERF_SOCKET_RX_TIMEOUT;
+    setsockopt(listen_socket, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout));
+#if CONFIG_ESP_WIFI_ENABLE_WIFI_RX_STATS
+    wifi_cmd_clr_rx_statistics(0, NULL);
+#endif
+    socket_recv(listen_socket, listen_addr, IPERF_TRANS_TYPE_UDP);
+#if CONFIG_ESP_WIFI_ENABLE_WIFI_RX_STATS
+    wifi_cmd_get_rx_statistics(0, NULL);
+#endif
+exit:
+    if (listen_socket != -1) {
+        shutdown(listen_socket, 0);
+        close(listen_socket);
+    }
+    ESP_LOGI(TAG, "Udp socket server is closed.");
+    s_iperf_ctrl.finish = true;
+    return ret;
+}
+
+static esp_err_t iperf_run_udp_client(void)
+{
+    int client_socket = -1;
+    int opt = 1;
+    esp_err_t ret = ESP_OK;
+    struct sockaddr_storage dest_addr = { 0 };
+    struct sockaddr_in dest_addr4 = { 0 };
+#ifdef CONFIG_LWIP_IPV6
+    struct sockaddr_in6 dest_addr6 = { 0 };
+    ESP_GOTO_ON_FALSE((s_iperf_ctrl.cfg.type == IPERF_IP_TYPE_IPV6 || s_iperf_ctrl.cfg.type == IPERF_IP_TYPE_IPV4), ESP_FAIL, exit, TAG, "Ivalid AF types");
+#else
+    ESP_GOTO_ON_FALSE((s_iperf_ctrl.cfg.type == IPERF_IP_TYPE_IPV4), ESP_FAIL, exit, TAG, "Ivalid AF types");
+#endif
+#ifdef CONFIG_LWIP_IPV6
+    if (s_iperf_ctrl.cfg.type == IPERF_IP_TYPE_IPV6) {
+        inet6_aton(s_iperf_ctrl.cfg.destination_ip6, &dest_addr6.sin6_addr);
+        dest_addr6.sin6_family = AF_INET6;
+        dest_addr6.sin6_port = htons(s_iperf_ctrl.cfg.dport);
+
+        client_socket = socket(AF_INET6, SOCK_DGRAM, IPPROTO_IPV6);
+        ESP_GOTO_ON_FALSE((client_socket >= 0), ESP_FAIL, exit, TAG, "Unable to create socket: errno %d", errno);
+        ESP_LOGI(TAG, "Socket created, sending to %s:%" PRIu16, s_iperf_ctrl.cfg.destination_ip6, s_iperf_ctrl.cfg.dport);
+
+        setsockopt(client_socket, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+        memcpy(&dest_addr, &dest_addr6, sizeof(dest_addr6));
+    } else
+#endif
+        if (s_iperf_ctrl.cfg.type == IPERF_IP_TYPE_IPV4) {
+            dest_addr4.sin_family = AF_INET;
+            dest_addr4.sin_port = htons(s_iperf_ctrl.cfg.dport);
+            dest_addr4.sin_addr.s_addr = s_iperf_ctrl.cfg.destination_ip4;
+
+            client_socket = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+            ESP_GOTO_ON_FALSE((client_socket >= 0), ESP_FAIL, exit, TAG, "Unable to create socket: errno %d", errno);
+            ESP_LOGI(TAG, "Socket created, sending to %d.%d.%d.%d:%" PRIu16,
+                     (uint16_t) s_iperf_ctrl.cfg.destination_ip4 & 0xFF,
+                     (uint16_t) (s_iperf_ctrl.cfg.destination_ip4 >> 8) & 0xFF,
+                     (uint16_t) (s_iperf_ctrl.cfg.destination_ip4 >> 16) & 0xFF,
+                     (uint16_t) (s_iperf_ctrl.cfg.destination_ip4 >> 24) & 0xFF,
+                     s_iperf_ctrl.cfg.dport);
+
+            setsockopt(client_socket, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+            memcpy(&dest_addr, &dest_addr4, sizeof(dest_addr4));
+        }
+#if CONFIG_ESP_WIFI_ENABLE_WIFI_TX_STATS
+    wifi_cmd_clr_tx_statistics(0, NULL);
+#endif
+    socket_send(client_socket, dest_addr, IPERF_TRANS_TYPE_UDP, s_iperf_ctrl.cfg.bw_lim);
+#if CONFIG_ESP_WIFI_ENABLE_WIFI_TX_STATS
+    wifi_cmd_get_tx_statistics(0, NULL);
+#endif
+exit:
+    if (client_socket != -1) {
+        shutdown(client_socket, 0);
+        close(client_socket);
+    }
+    s_iperf_ctrl.finish = true;
+    ESP_LOGI(TAG, "UDP Socket client is closed");
+    return ret;
+}
+
+static void iperf_task_traffic(void *arg)
+{
+    if (iperf_is_udp_client()) {
+        iperf_run_udp_client();
+    } else if (iperf_is_udp_server()) {
+        iperf_run_udp_server();
+    } else if (iperf_is_tcp_client()) {
+        iperf_run_tcp_client();
+    } else {
+        iperf_run_tcp_server();
+    }
+
+    if (s_iperf_ctrl.buffer) {
+        free(s_iperf_ctrl.buffer);
+        s_iperf_ctrl.buffer = NULL;
+    }
+    ESP_LOGI(TAG, "iperf exit");
+    s_iperf_is_running = false;
+    vTaskDelete(NULL);
+}
+
+static uint32_t iperf_get_buffer_len(void)
+{
+    if (iperf_is_udp_client()) {
+#ifdef CONFIG_LWIP_IPV6
+        if (s_iperf_ctrl.cfg.len_send_buf) {
+            return s_iperf_ctrl.cfg.len_send_buf;
+        } else if (s_iperf_ctrl.cfg.type == IPERF_IP_TYPE_IPV6) {
+            return IPERF_DEFAULT_IPV6_UDP_TX_LEN;
+        } else {
+            return IPERF_DEFAULT_IPV4_UDP_TX_LEN;
+        }
+#else
+        return (s_iperf_ctrl.cfg.len_send_buf == 0 ? IPERF_DEFAULT_IPV4_UDP_TX_LEN : s_iperf_ctrl.cfg.len_send_buf);
+#endif
+    } else if (iperf_is_udp_server()) {
+        return IPERF_DEFAULT_UDP_RX_LEN;
+    } else if (iperf_is_tcp_client()) {
+        return (s_iperf_ctrl.cfg.len_send_buf == 0 ? IPERF_DEFAULT_TCP_TX_LEN : s_iperf_ctrl.cfg.len_send_buf);
+    } else {
+        return IPERF_DEFAULT_TCP_RX_LEN;
+    }
+    return 0;
+}
+
+esp_err_t iperf_start(iperf_cfg_t *cfg)
+{
+    BaseType_t ret;
+
+    if (!cfg) {
+        return ESP_FAIL;
+    }
+
+    if (s_iperf_is_running) {
+        ESP_LOGW(TAG, "iperf is running");
+        return ESP_FAIL;
+    }
+
+    memset(&s_iperf_ctrl, 0, sizeof(s_iperf_ctrl));
+    memcpy(&s_iperf_ctrl.cfg, cfg, sizeof(*cfg));
+    s_iperf_is_running = true;
+    s_iperf_ctrl.finish = false;
+    s_iperf_ctrl.buffer_len = iperf_get_buffer_len();
+    s_iperf_ctrl.buffer = (uint8_t *)malloc(s_iperf_ctrl.buffer_len);
+    if (!s_iperf_ctrl.buffer) {
+        ESP_LOGE(TAG, "create buffer: not enough memory");
+        return ESP_FAIL;
+    }
+    memset(s_iperf_ctrl.buffer, 0, s_iperf_ctrl.buffer_len);
+    ret = xTaskCreatePinnedToCore(iperf_task_traffic, IPERF_TRAFFIC_TASK_NAME, IPERF_TRAFFIC_TASK_STACK, NULL, IPERF_TRAFFIC_TASK_PRIORITY, NULL, CONFIG_FREERTOS_NUMBER_OF_CORES - 1);
+    if (ret != pdPASS) {
+        ESP_LOGE(TAG, "create task %s failed", IPERF_TRAFFIC_TASK_NAME);
+        free(s_iperf_ctrl.buffer);
+        s_iperf_ctrl.buffer = NULL;
+        return ESP_FAIL;
+    }
+    return ESP_OK;
+}
+
+esp_err_t iperf_stop(void)
+{
+    if (s_iperf_is_running) {
+        s_iperf_ctrl.finish = true;
+    }
+
+    while (s_iperf_is_running) {
+        ESP_LOGI(TAG, "wait current iperf to stop ...");
+        vTaskDelay(300 / portTICK_PERIOD_MS);
+    }
+    return ESP_OK;
+}


### PR DESCRIPTION
The iperf component, previously located in esp-idf **examples/common_components/iperf**, has been relocated to esp-protocols as a managed component. It encompasses an iperf network performance tester implementation and includes a console for executing the 'iperf' command in any example project.