### PR TITLE
bump(mdns): 1.2.3 -> 1.2.4

### DIFF
--- a/components/mdns/.cz.yaml
+++ b/components/mdns/.cz.yaml
@@ -3,6 +3,6 @@ commitizen:
   bump_message: 'bump(mdns): $current_version -> $new_version'
   pre_bump_hooks: python ../../ci/changelog.py mdns
   tag_format: mdns-v$version
-  version: 1.2.3
+  version: 1.2.4
   version_files:
   - idf_component.yml

--- a/components/mdns/CHANGELOG.md
+++ b/components/mdns/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [1.2.4](https://github.com/espressif/esp-protocols/commits/mdns-v1.2.4)
+
+### Bug Fixes
+
+- Correction on 6d2c475 MDNS_PREDEF_NETIF_ETH fix ([fc59f87c4e](https://github.com/espressif/esp-protocols/commit/fc59f87c4e))
+- fix the logic of creating pcb for networking socket ([5000a9a20a](https://github.com/espressif/esp-protocols/commit/5000a9a20a))
+- fix compiling issue when disabling IPv4 ([2646dcd23a](https://github.com/espressif/esp-protocols/commit/2646dcd23a))
+- Fix compile error when MDNS_PREDEF_NETIF_ETH is defined, but ETH_ENABLED is not (#459) ([6d2c475c20](https://github.com/espressif/esp-protocols/commit/6d2c475c20))
+
 ## [1.2.3](https://github.com/espressif/esp-protocols/commits/mdns-v1.2.3)
 
 ### Bug Fixes

--- a/components/mdns/idf_component.yml
+++ b/components/mdns/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.2.3"
+version: "1.2.4"
 description: mDNS
 url: https://github.com/espressif/esp-protocols/tree/master/components/mdns
 dependencies:


### PR DESCRIPTION
1.2.4
Bug Fixes
- Correction on 6d2c475 MDNS_PREDEF_NETIF_ETH fix (fc59f87c4e)
- fix the logic of creating pcb for networking socket (5000a9a20a)
- fix compiling issue when disabling IPv4 (2646dcd23a)
- Fix compile error when MDNS_PREDEF_NETIF_ETH is defined, but ETH_ENABLED is not (#459) (6d2c475c20)