### PR TITLE
bump(mdns): 1.2.4 -> 1.2.5

### DIFF
--- a/components/mdns/.cz.yaml
+++ b/components/mdns/.cz.yaml
@@ -3,6 +3,6 @@ commitizen:
   bump_message: 'bump(mdns): $current_version -> $new_version'
   pre_bump_hooks: python ../../ci/changelog.py mdns
   tag_format: mdns-v$version
-  version: 1.2.4
+  version: 1.2.5
   version_files:
   - idf_component.yml

--- a/components/mdns/CHANGELOG.md
+++ b/components/mdns/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.2.5](https://github.com/espressif/esp-protocols/commits/mdns-v1.2.5)
+
+### Bug Fixes
+
+- Fixed build issues for targets without WiFi caps ([302b46f](https://github.com/espressif/esp-protocols/commit/302b46f))
+
 ## [1.2.4](https://github.com/espressif/esp-protocols/commits/mdns-v1.2.4)
 
 ### Bug Fixes

--- a/components/mdns/idf_component.yml
+++ b/components/mdns/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.2.4"
+version: "1.2.5"
 description: mDNS
 url: https://github.com/espressif/esp-protocols/tree/master/components/mdns
 dependencies:


### PR DESCRIPTION
1.2.5
Bug Fixes
- Fixed build issues for targets without WiFi caps (302b46f)