### PR TITLE
mdns add browse support (IDFGH-12512)

### DIFF
--- a/components/mdns/include/mdns.h
+++ b/components/mdns/include/mdns.h
@@ -26,6 +26,11 @@ extern "C" {
  */
 typedef struct mdns_search_once_s mdns_search_once_t;
 
+/**
+ * @brief   Daemon query handle
+ */
+typedef struct mdns_browse_s mdns_browse_t;
+
 typedef enum {
     MDNS_EVENT_ENABLE_IP4                   = 1 << 1,
     MDNS_EVENT_ENABLE_IP6                   = 1 << 2,
@@ -97,6 +102,7 @@ typedef struct mdns_result_s {
 } mdns_result_t;
 
 typedef void (*mdns_query_notify_t)(mdns_search_once_t *search);
+typedef void (*mdns_browse_notify_t)(mdns_result_t *result);
 
 /**
  * @brief  Initialize mDNS on given interface
@@ -829,6 +835,28 @@ esp_err_t mdns_unregister_netif(esp_netif_t *esp_netif);
  *     - ESP_ERR_NO_MEM         memory error
  */
 esp_err_t mdns_netif_action(esp_netif_t *esp_netif, mdns_event_actions_t event_action);
+
+/**
+ * @brief   Browse mDNS for a service `_service._proto`.
+ *
+ * @param service  Pointer to the `_service` which will be browsed.
+ * @param proto    Pointer to the `_proto` which will be browsed.
+ * @param notifier The callback which will be called when the browsing service changed.
+ * @return mdns_browse_t pointer to new browse object if initiated successfully.
+ *         NULL otherwise.
+ */
+mdns_browse_t *mdns_browse_new(const char *service, const char *proto, mdns_browse_notify_t notifier);
+
+/**
+ * @brief   Stop the `_service._proto` browse.
+ * @param service  Pointer to the `_service` which will be browsed.
+ * @param proto    Pointer to the `_proto` which will be browsed.
+ * @return
+ *     - ESP_OK                 success.
+ *     - ESP_ERR_FAIL           mDNS is not running or the browsing of `_service._proto` is never started.
+ *     - ESP_ERR_NO_MEM         memory error.
+ */
+esp_err_t mdns_browse_delete(const char *service, const char *proto);
 
 #ifdef __cplusplus
 }

--- a/components/mdns/private_include/mdns_private.h
+++ b/components/mdns/private_include/mdns_private.h
@@ -199,6 +199,9 @@ typedef enum {
     ACTION_SEARCH_ADD,
     ACTION_SEARCH_SEND,
     ACTION_SEARCH_END,
+    ACTION_BROWSE_ADD,
+    ACTION_BROWSE_SYNC,
+    ACTION_BROWSE_END,
     ACTION_TX_HANDLE,
     ACTION_RX_HANDLE,
     ACTION_TASK_STOP,
@@ -370,6 +373,13 @@ typedef enum {
     SEARCH_MAX
 } mdns_search_once_state_t;
 
+typedef enum {
+    BROWSE_OFF,
+    BROWSE_INIT,
+    BROWSE_RUNNING,
+    BROWSE_MAX
+} mdns_browse_state_t;
+
 typedef struct mdns_search_once_s {
     struct mdns_search_once_s *next;
 
@@ -389,6 +399,27 @@ typedef struct mdns_search_once_s {
     mdns_result_t *result;
 } mdns_search_once_t;
 
+typedef struct mdns_browse_s {
+    struct mdns_browse_s *next;
+
+    mdns_browse_state_t state;
+    mdns_browse_notify_t notifier;
+
+    char *service;
+    char *proto;
+    mdns_result_t *result;
+} mdns_browse_t;
+
+typedef struct mdns_browse_result_sync_t {
+    mdns_result_t *result;
+    struct mdns_browse_result_sync_t *next;
+} mdns_browse_result_sync_t;
+
+typedef struct mdns_browse_sync {
+    mdns_browse_t *browse;
+    mdns_browse_result_sync_t *sync_result;
+} mdns_browse_sync_t;
+
 typedef struct mdns_server_s {
     struct {
         mdns_pcb_t pcbs[MDNS_IP_PROTOCOL_MAX];
@@ -401,6 +432,7 @@ typedef struct mdns_server_s {
     mdns_tx_packet_t *tx_queue_head;
     mdns_search_once_t *search_once;
     esp_timer_handle_t timer_handle;
+    mdns_browse_t *browse;
 } mdns_server_t;
 
 typedef struct {
@@ -459,6 +491,12 @@ typedef struct {
             const char *hostname;
             mdns_ip_addr_t *address_list;
         } delegate_hostname;
+        struct {
+            mdns_browse_t *browse;
+        } browse_add;
+        struct {
+            mdns_browse_sync_t *browse_sync;
+        } browse_sync;
     } data;
 } mdns_action_t;
 


### PR DESCRIPTION
This MR introduces a new query mode: browse(like the `avahi-browse -r _test._tcp`).

`mdns_browse_new` is used for starting a browse, it will add a browse in the link list of `_mdns_server`, if there is some service start or leave, it will be notified by the callback passed in the API. When the service is leaved, the ttl will be `0`, the related result will be freed after syncing to the notifier callback.

`mdns_browse_delete` is used for stop the browse query and free the related memory.

All apis are followed the mdns action mechanism.