### PR TITLE
fix(websocket): fix esp_event dependency management (IDFGH-12301) (IDFGH-12302)

### DIFF
--- a/components/esp_websocket_client/CMakeLists.txt
+++ b/components/esp_websocket_client/CMakeLists.txt
@@ -16,6 +16,6 @@ if(${IDF_TARGET} STREQUAL "linux")
 else()
     idf_component_register(SRCS "esp_websocket_client.c"
                     INCLUDE_DIRS "include"
-                    REQUIRES lwip esp-tls tcp_transport http_parser
-                    PRIV_REQUIRES esp_timer esp_event)
+                    REQUIRES lwip esp-tls tcp_transport http_parser esp_event
+                    PRIV_REQUIRES esp_timer)
 endif()


### PR DESCRIPTION
Move esp_event from PRIV_REQUIRES to REQUIRES, as it is included by esp_websocket_client.h, so any code including that header also requires esp_event.

This resolves the following build error for files not explicitly requiring esp_event:

ninja: build stopped: subcommand failed.
Compilation failed because esp_websocket_client.h (in "espressif__esp_websocket_client" component) includes esp_event.h, provided by esp_event component(s). However, esp_event component(s) is in the private requirements list of "espressif__esp_websocket_client". To fix this, move esp_event from PRIV_REQUIRES into REQUIRES list of idf_component_register call in ...\managed_components\espressif__esp_websocket_client\CMakeLists.txt. ninja failed with exit code 1, output of the command is in...