### PR TITLE
fix(mdns): Schedule all queued Tx packets from timer task

### DIFF
--- a/components/mdns/mdns.c
+++ b/components/mdns/mdns.c
@@ -5191,7 +5191,7 @@ static void _mdns_scheduler_run(void)
         MDNS_SERVICE_UNLOCK();
         return;
     }
-    if ((int32_t)(p->send_at - (xTaskGetTickCount() * portTICK_PERIOD_MS)) < 0) {
+    while (p && (int32_t)(p->send_at - (xTaskGetTickCount() * portTICK_PERIOD_MS)) < 0) {
         action = (mdns_action_t *)malloc(sizeof(mdns_action_t));
         if (action) {
             action->type = ACTION_TX_HANDLE;
@@ -5203,8 +5203,10 @@ static void _mdns_scheduler_run(void)
             }
         } else {
             HOOK_MALLOC_FAILED;
-            // continue
+            break;
         }
+        //Find the next unqued packet
+        p = p->next;
     }
     MDNS_SERVICE_UNLOCK();
 }


### PR DESCRIPTION
Instead of processing only one Tx packet at a time, goes over all in the linked list and queue all of them if `send_at` field indicates it should be sent.

Partially addresses: https://github.com/espressif/esp-idf/issues/13333