### PR TITLE
fix(modem): Fixed UART task to check for buffered data periodically

### DIFF
--- a/components/esp_modem/src/esp_modem_uart.cpp
+++ b/components/esp_modem/src/esp_modem_uart.cpp
@@ -160,6 +160,11 @@ void UartTerminal::task()
                 ESP_LOGW(TAG, "unknown uart event type: %d", event.type);
                 break;
             }
+        } else {
+            uart_get_buffered_data_len(uart.port, &len);
+            if (len && on_read) {
+                on_read(nullptr, len);
+            }
         }
     }
 }


### PR DESCRIPTION
If we're missing an UART DATA event, or more data than we read are coming from one event, we would never get another event with the buffered data.

## Solution

Checking the data periodically (every 100ms) if no event's coming.

## Closes

https://github.com/espressif/esp-protocols/issues/536