### PR TITLE
fix(wifi_remote): Publish missing esp_wifi_remote and add to README

### DIFF
--- a/.github/workflows/publish-docs-component.yml
+++ b/.github/workflows/publish-docs-component.yml
@@ -98,5 +98,6 @@ jobs:
             components/console_cmd_ping;
             components/console_cmd_ifconfig;
             components/console_cmd_wifi;
+            components/esp_wifi_remote;
           namespace: "espressif"
           api_token: ${{ secrets.IDF_COMPONENT_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -53,3 +53,7 @@ Please refer to instructions in [ESP-IDF](https://github.com/espressif/esp-idf)
 ### ESP PPP Link (eppp)
 
 * Brief introduction [README](components/eppp_link/README.md)
+
+### esp_wifi_remote
+
+* Brief introduction [README](components/esp_wifi_remote/README.md)


### PR DESCRIPTION
Just to publish the same version to component manager. Doesn't need a bump commit or newer version, since it's been tagged and released here with `v.0.1.12`