### PR TITLE
Reduce maximum wait time for get_operator_name() to fix hangups

### DIFF
--- a/components/esp_modem/src/esp_modem_command_library.cpp
+++ b/components/esp_modem/src/esp_modem_command_library.cpp
@@ -243,7 +243,7 @@ command_result get_operator_name(CommandableIf *t, std::string &operator_name, i
 {
     ESP_LOGV(TAG, "%s", __func__ );
     std::string out;
-    auto ret = generic_get_string(t, "AT+COPS?\r", out, 75000);
+    auto ret = generic_get_string(t, "AT+COPS?\r", out, 1000);
     if (ret != command_result::OK) {
         return ret;
     }


### PR DESCRIPTION
Is there a reason why we have to freeze the task for 75 seconds here?

We have had lots of hangups and it seems like the answer is typically there after ~100ms, not 75000ms