### PR TITLE
bump(mdns): 1.2.5 -> 1.2.6

### DIFF
--- a/components/mdns/.cz.yaml
+++ b/components/mdns/.cz.yaml
@@ -3,6 +3,6 @@ commitizen:
   bump_message: 'bump(mdns): $current_version -> $new_version'
   pre_bump_hooks: python ../../ci/changelog.py mdns
   tag_format: mdns-v$version
-  version: 1.2.5
+  version: 1.2.6
   version_files:
   - idf_component.yml

--- a/components/mdns/CHANGELOG.md
+++ b/components/mdns/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [1.2.6](https://github.com/espressif/esp-protocols/commits/mdns-v1.2.6)
+
+### Features
+
+- add a new mdns query mode `browse` ([af330b6](https://github.com/espressif/esp-protocols/commit/af330b6))
+- Make including mdns_console KConfigurable ([27adbfe](https://github.com/espressif/esp-protocols/commit/27adbfe))
+
+### Bug Fixes
+
+- Schedule all queued Tx packets from timer task ([d4e693e](https://github.com/espressif/esp-protocols/commit/d4e693e))
+- add lock for some common apis ([21c84bf](https://github.com/espressif/esp-protocols/commit/21c84bf))
+- fix mdns answer append while host is invalid ([7be16bc](https://github.com/espressif/esp-protocols/commit/7be16bc))
+
 ## [1.2.5](https://github.com/espressif/esp-protocols/commits/mdns-v1.2.5)
 
 ### Bug Fixes

--- a/components/mdns/idf_component.yml
+++ b/components/mdns/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.2.5"
+version: "1.2.6"
 description: mDNS
 url: https://github.com/espressif/esp-protocols/tree/master/components/mdns
 dependencies:


### PR DESCRIPTION
1.2.6
Features
- add a new mdns query mode `browse` (af330b6)
- Make including mdns_console KConfigurable (27adbfe) 
Bug Fixes
- Schedule all queued Tx packets from timer task (d4e693e)
- add lock for some common apis (21c84bf)
- fix mdns answer append while host is invalid (7be16bc)