### PR TITLE
Fix CI build per IDFv5.3

### DIFF
--- a/.github/workflows/console_cmd_ifconfig__build.yml
+++ b/.github/workflows/console_cmd_ifconfig__build.yml
@@ -13,9 +13,13 @@ jobs:
     name: Build
     strategy:
       matrix:
-        idf_ver: ["latest", "release-v5.0"]
+        idf_ver: ["latest", "release-v5.1", "release-v5.0"]
         idf_target: ["esp32"]
         test: [ { app: ifconfig-basic, path: "components/console_cmd_ifconfig/examples"}]
+        include:
+          - idf_ver: "latest"
+            warning: "the choice symbol ETHERNET_PHY_LAN867X"
+
     runs-on: ubuntu-22.04
     container: espressif/idf:${{ matrix.idf_ver }}
     steps:
@@ -24,6 +28,8 @@ jobs:
         with:
           submodules: recursive
       - name: Build ${{ matrix.test.app }} with IDF-${{ matrix.idf_ver }} for ${{ matrix.idf_target }}
+        env:
+          EXPECTED_WARNING: ${{ matrix.warning }}
         shell: bash
         working-directory: ${{matrix.test.path}}
         run: |

--- a/components/eppp_link/examples/host/CMakeLists.txt
+++ b/components/eppp_link/examples/host/CMakeLists.txt
@@ -1,7 +1,6 @@
 # The following four lines of boilerplate have to be in your project's CMakeLists
 # in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.16)
-set(EXTRA_COMPONENT_DIRS $ENV{IDF_PATH}/examples/common_components/iperf)
 
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)

--- a/components/eppp_link/examples/host/main/idf_component.yml
+++ b/components/eppp_link/examples/host/main/idf_component.yml
@@ -1,4 +1,5 @@
 dependencies:
+  espressif/iperf-cmd: "^0.1.1"
   espressif/eppp_link:
     version: "*"
     override_path: "../../.."

--- a/components/esp_modem/.build-test-rules.yml
+++ b/components/esp_modem/.build-test-rules.yml
@@ -1,6 +1,6 @@
 components/esp_modem/examples/ap_to_pppos:
   disable:
-    - if: IDF_TARGET in ["esp32h2"]
+    - if: IDF_TARGET in ["esp32h2", "esp32p4"]
 
 components/esp_modem/examples/modem_console:
   disable:

--- a/components/esp_modem/test/target_iperf/CMakeLists.txt
+++ b/components/esp_modem/test/target_iperf/CMakeLists.txt
@@ -2,9 +2,5 @@
 # CMakeLists in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.5)
 
-set(EXTRA_COMPONENT_DIRS    $ENV{IDF_PATH}/examples/system/console/advanced/components
-                            $ENV{IDF_PATH}/examples/common_components/iperf
-                            "../..")
-
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(pppd_test)

--- a/components/esp_modem/test/target_iperf/main/idf_component.yml
+++ b/components/esp_modem/test/target_iperf/main/idf_component.yml
@@ -1,0 +1,6 @@
+## IDF Component Manager Manifest File
+dependencies:
+  espressif/esp_modem:
+    version: "^1.1.0"
+    override_path: "../../.."
+  espressif/iperf-cmd: "^0.1.1"

--- a/components/esp_modem/test/target_iperf/main/pppd_iperf_main.c
+++ b/components/esp_modem/test/target_iperf/main/pppd_iperf_main.c
@@ -8,7 +8,6 @@
 #include "sdkconfig.h"
 #include "esp_log.h"
 #include "esp_console.h"
-#include "cmd_system.h"
 
 void register_pppd(void);
 
@@ -22,7 +21,6 @@ void app_main(void)
     ESP_ERROR_CHECK(esp_console_new_repl_uart(&uart_config, &repl_config, &repl));
 
     /* Register commands */
-    register_system_common();
     register_pppd();
 
     printf("\n =======================================================\n");


### PR DESCRIPTION
Fixes recent incompatibilities with latest IDF (v5.3)

* Moving `iperf` out of IDF
* ESP32P4 is supported target
* warning: the choice symbol ETHERNET_PHY_... has no prompt
* 