### PR TITLE
[eppp]: Force the `PPP` LWIP opts which are OFF by default

### DIFF
--- a/components/eppp_link/.cz.yaml
+++ b/components/eppp_link/.cz.yaml
@@ -3,6 +3,6 @@ commitizen:
   bump_message: 'bump(eppp): $current_version -> $new_version'
   pre_bump_hooks: python ../../ci/changelog.py eppp_link
   tag_format: eppp-v$version
-  version: 0.0.1
+  version: 0.1.0
   version_files:
   - idf_component.yml

--- a/components/eppp_link/CHANGELOG.md
+++ b/components/eppp_link/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.1.0](https://github.com/espressif/esp-protocols/commits/eppp-v0.1.0)
+
+### Features
+
+- Added CI job to build examples and tests ([7eefcf0](https://github.com/espressif/esp-protocols/commit/7eefcf0))
+
+### Bug Fixes
+
+- Fixed to select PPP LWIP opts which are OFF by default ([16be2f9](https://github.com/espressif/esp-protocols/commit/16be2f9))
+- Example to use iperf component from the registry ([bd6b66d](https://github.com/espressif/esp-protocols/commit/bd6b66d))
+- Fixed defalt config designated init issue in C++ ([8bd4712](https://github.com/espressif/esp-protocols/commit/8bd4712))
+
 ## [0.0.1](https://github.com/espressif/esp-protocols/commits/eppp-v0.0.1)
 
 ### Features

--- a/components/eppp_link/Kconfig
+++ b/components/eppp_link/Kconfig
@@ -1,5 +1,11 @@
 menu "eppp_link"
 
+    config EPPP_LINK_USES_LWIP
+        bool
+        default "y"
+        select LWIP_PPP_SUPPORT
+        select LWIP_PPP_SERVER_SUPPORT
+
     choice EPPP_LINK_DEVICE
         prompt "Choose PPP device"
         default EPPP_LINK_DEVICE_UART

--- a/components/eppp_link/idf_component.yml
+++ b/components/eppp_link/idf_component.yml
@@ -1,4 +1,4 @@
-version: 0.0.1
+version: 0.1.0
 url: https://github.com/espressif/esp-protocols/tree/master/components/eppp_link
 description: The component provides a general purpose PPP connectivity, typically used as WiFi-PPP router
 dependencies:


### PR DESCRIPTION
## [0.1.0](https://github.com/espressif/esp-protocols/commits/eppp-v0.1.0)

### Features

- Added CI job to build examples and tests ([7eefcf0](https://github.com/espressif/esp-protocols/commit/7eefcf0))

### Bug Fixes

- Fixed to select PPP LWIP opts which are OFF by default ([16be2f9](https://github.com/espressif/esp-protocols/commit/16be2f9))
- Example to use iperf component from the registry ([bd6b66d](https://github.com/espressif/esp-protocols/commit/bd6b66d))
- Fixed defalt config designated init issue in C++ ([8bd4712](https://github.com/espressif/esp-protocols/commit/8bd4712))
