### PR TITLE
fix(mdns): free txt value len (IDFGH-12817)

### DIFF
--- a/components/mdns/mdns.c
+++ b/components/mdns/mdns.c
@@ -4739,7 +4739,7 @@ free_txt:
         free((char *)(txt[i].value));
     }
     free(txt);
-    free(r->txt_value_len);
+    free(txt_value_len);
 }
 
 /**
@@ -7437,7 +7437,7 @@ free_txt:
         free((char *)(txt[i].value));
     }
     free(txt);
-    free(r->txt_value_len);
+    free(txt_value_len);
     return;
 }
 


### PR DESCRIPTION
Free the new malloced txt_value_len instead of the txt_value_len in search result. If there exits txt entry in query results, the origin free processing will lead a crash due to multi free.