### PR TITLE
feat(websocket): allow using external TCP transport handle (IDFGH-12825)

### DIFF
--- a/components/esp_websocket_client/include/esp_websocket_client.h
+++ b/components/esp_websocket_client/include/esp_websocket_client.h
@@ -127,6 +127,7 @@ typedef struct {
     int                         network_timeout_ms;         /*!< Abort network operation if it is not completed after this value, in milliseconds (defaults to 10s) */
     size_t                      ping_interval_sec;          /*!< Websocket ping interval, defaults to 10 seconds if not set */
     struct ifreq                *if_name;                   /*!< The name of interface for data to go through. Use the default interface without setting */
+    esp_transport_handle_t      ext_transport;              /*!< External WebSocket tcp_transport handle to the client; or if null, the client will create its own transport handle. */
 } esp_websocket_client_config_t;
 
 /**


### PR DESCRIPTION
Hi there,

This PR was originally done last year (May 2023), but I forgot to submit it... 😅 

Anyway, this PR is for adding support to let WebSocket client to take external handles, similar to my another PR for MQTT client, see:

- https://github.com/espressif/esp-mqtt/blob/master/include/mqtt_client.h#L339
- https://github.com/espressif/esp-mqtt/pull/260

This is very useful for scenarios where: 

1. The application requires proxies to access network (via my [esp_tcp_transport_addons](https://github.com/huming2207/esp_tcp_transport_addons) hack for HTTP proxy access, or a SOCK4 proxy via the `transport_socks_proxy.c` in `tcp_transport` component) ;
2. The application somehow requires external TCP/IP stack on a modem via serial port, see [this example](https://github.com/espressif/esp-protocols/tree/c9439bd3d57f4941c980476f9961ff04687a9f7a/components/esp_modem/examples/modem_tcp_client)

Currently for my company, we are using my HTTP proxy library mentioned above to achieve HTTP proxy access feature. But we are currently using my modified `esp-websocket-client` and we wish to merge this into mainline soon instead. 

Please provide suggestion if there's any and I will modify accordingly. Thanks.

Regards,
Jackson