### PR TITLE
fix(wifi_remote): Do not restrict EPPP config to RSA keys only

### DIFF
--- a/.github/workflows/wifi_remote__build.yml
+++ b/.github/workflows/wifi_remote__build.yml
@@ -22,8 +22,8 @@ jobs:
       - name: Check that headers are the same as generated
         shell: bash
         run: |
-          ${IDF_PATH}/install.sh --enable-pytest
           . ${IDF_PATH}/export.sh
+          pip install idf-component-manager idf-build-apps --upgrade
           cd ./components/esp_wifi_remote/scripts
           python generate_and_check.py
 
@@ -46,8 +46,8 @@ jobs:
       - name: Build ${{ matrix.test.app }} with IDF-${{ matrix.idf_ver }}
         shell: bash
         run: |
-          ${IDF_PATH}/install.sh --enable-pytest
           . ${IDF_PATH}/export.sh
+          pip install idf-component-manager idf-build-apps --upgrade
           python ./ci/build_apps.py ./components/esp_wifi_remote/${{matrix.test.path}} -vv --preserve-all
 
   build_wifi_remote_example:
@@ -72,6 +72,6 @@ jobs:
           EXPECTED_WARNING: ${{ matrix.warning }}
         shell: bash
         run: |
-          ${IDF_PATH}/install.sh --enable-pytest
           . ${IDF_PATH}/export.sh
+          pip install idf-component-manager idf-build-apps --upgrade
           python ./ci/build_apps.py ./components/esp_wifi_remote/${{matrix.example.path}} -vv --preserve-all

--- a/components/esp_wifi_remote/eppp/wifi_remote_rpc_client.cpp
+++ b/components/esp_wifi_remote/eppp/wifi_remote_rpc_client.cpp
@@ -25,7 +25,7 @@ const char *TAG = "rpc_client";
 
 const unsigned char ca_crt[] = "-----BEGIN CERTIFICATE-----\n" CONFIG_ESP_WIFI_REMOTE_EPPP_SERVER_CA "\n-----END CERTIFICATE-----";
 const unsigned char crt[] = "-----BEGIN CERTIFICATE-----\n" CONFIG_ESP_WIFI_REMOTE_EPPP_CLIENT_CRT "\n-----END CERTIFICATE-----";
-const unsigned char key[] = "-----BEGIN RSA PRIVATE KEY-----\n" CONFIG_ESP_WIFI_REMOTE_EPPP_CLIENT_KEY "\n-----END RSA PRIVATE KEY-----";
+const unsigned char key[] = "-----BEGIN PRIVATE KEY-----\n" CONFIG_ESP_WIFI_REMOTE_EPPP_CLIENT_KEY "\n-----END PRIVATE KEY-----";
 // TODO: Add option to supply keys and certs via a global symbol (file)
 
 }

--- a/components/esp_wifi_remote/eppp/wifi_remote_rpc_server.cpp
+++ b/components/esp_wifi_remote/eppp/wifi_remote_rpc_server.cpp
@@ -25,7 +25,7 @@ const char *TAG = "rpc_server";
 
 const unsigned char ca_crt[] = "-----BEGIN CERTIFICATE-----\n" CONFIG_ESP_WIFI_REMOTE_EPPP_CLIENT_CA "\n-----END CERTIFICATE-----";
 const unsigned char crt[] = "-----BEGIN CERTIFICATE-----\n" CONFIG_ESP_WIFI_REMOTE_EPPP_SERVER_CRT "\n-----END CERTIFICATE-----";
-const unsigned char key[] = "-----BEGIN RSA PRIVATE KEY-----\n" CONFIG_ESP_WIFI_REMOTE_EPPP_SERVER_KEY "\n-----END RSA PRIVATE KEY-----";
+const unsigned char key[] = "-----BEGIN PRIVATE KEY-----\n" CONFIG_ESP_WIFI_REMOTE_EPPP_SERVER_KEY "\n-----END PRIVATE KEY-----";
 // TODO: Add option to supply keys and certs via a global symbol (file)
 
 }

--- a/components/esp_wifi_remote/examples/test_certs/generate_test_certs.sh
+++ b/components/esp_wifi_remote/examples/test_certs/generate_test_certs.sh
@@ -1,5 +1,19 @@
 #!/usr/bin/env bash
 
+function gen_pkey { # Params: [KEY_FILE]
+    openssl genpkey -algorithm RSA  -pkeyopt rsa_keygen_bits:2048 |  openssl pkcs8 -topk8 -outform PEM  -nocrypt -out $1
+}
+
+function sign_with_ca { # Params: [KEY_FILE] [CN] [CRT_FILE]
+    openssl req -out request.csr -key $1 -subj "/CN=$2" -new -sha256
+    openssl x509 -req -in request.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out $3 -days 365 -sha256
+}
+
+function export_config { # Params: [FILE/CONFIG_NAME]
+    content=`cat $1 | sed '/---/d' | tr -d '\n'`
+    echo "CONFIG_ESP_WIFI_REMOTE_EPPP_$1=\"${content}\""
+}
+
 if [ -z "$1" ]; then
     echo "Usage $0 <SERVER_CN> [CLIENT_CN]"
     exit 1;
@@ -12,30 +26,27 @@ echo "Server's CN: $SERVER_CN"
 echo "Client's CN: $CLIENT_CN"
 
 ## First create our own CA
-openssl genrsa  -out ca.key 2048
+gen_pkey ca.key
 openssl req -new -x509 -subj "/C=CZ/CN=Espressif" -days 365 -key ca.key -out ca.crt
+# will use the same CA for both server and client side
+cp ca.crt SERVER_CA
+cp ca.crt CLIENT_CA
 
 # Server side
-openssl genrsa -out srv.key 2048
-openssl req -out srv.csr -key srv.key -subj "/CN=$SERVER_CN" -new -sha256
-openssl x509 -req -in srv.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out srv.crt -days 365 -sha256
+gen_pkey SERVER_KEY
+sign_with_ca SERVER_KEY $SERVER_CN SERVER_CRT
 
 # Client side
-openssl genrsa  -out client.key 2048
-openssl req -out client.csr -key client.key -subj "/CN=$CLIENT_CN" -new -sha256
-openssl  x509 -req -in client.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out client.crt -days 365 -sha256
+gen_pkey CLIENT_KEY
+sign_with_ca CLIENT_KEY $CLIENT_CN CLIENT_CRT
 
 ## Generate config options
-# Client side:
-CA_CRT=`cat ca.crt | sed '/---/d' | tr -d '\n'`
-echo "CONFIG_ESP_WIFI_REMOTE_EPPP_SERVER_CA=\"$CA_CRT\""
-CLIENT_CRT=`cat client.crt | sed '/---/d' | tr -d '\n'`
-echo "CONFIG_ESP_WIFI_REMOTE_EPPP_CLIENT_CRT=\"$CLIENT_CRT\""
-CLIENT_KEY=`cat client.key | sed '/---/d' | tr -d '\n'`
-echo "CONFIG_ESP_WIFI_REMOTE_EPPP_CLIENT_KEY=\"$CLIENT_KEY\""
-## Server side (here it uses the same CA)
-echo "CONFIG_ESP_WIFI_REMOTE_EPPP_CLIENT_CA=\"$CA_CRT\""
-SERVER_CRT=`cat srv.crt | sed '/---/d' | tr -d '\n'`
-echo "CONFIG_ESP_WIFI_REMOTE_EPPP_SERVER_CRT=\"$SERVER_CRT\""
-SERVER_KEY=`cat srv.key | sed '/---/d' | tr -d '\n'`
-echo "CONFIG_ESP_WIFI_REMOTE_EPPP_SERVER_KEY=\"$SERVER_KEY\""
+echo -e "\n# Client side: need own cert and key and ca-cert for server validation"
+for f in SERVER_CA CLIENT_CRT CLIENT_KEY; do
+    export_config $f
+done
+
+echo -e "\n# Server side: need own cert and key and ca-cert for client validation"
+for f in CLIENT_CA SERVER_CRT SERVER_KEY; do
+    export_config $f
+done


### PR DESCRIPTION
Now we can use any kind of certificate and keys, as long as they're in PEM format.

Closes https://github.com/espressif/esp-protocols/issues/570