### PR TITLE
CI: Fixed clang-tidy job

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -15,10 +15,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: 'true'
-      - name: Install libtinfo (esp-clang dependency)
-        run: |
-          export DEBIAN_FRONTEND=noninteractive
-          apt update && apt-get install -y libtinfo5
       - name: Install esp-clang
         run: |
           ${IDF_PATH}/tools/idf_tools.py --non-interactive install esp-clang


### PR DESCRIPTION
Cherry-picked Ivan's commit from extra-comonents repo:

[ci: remove libtinfo5 installation step](https://github.com/espressif/idf-extra-components/commit/ab23c2bebcf7a6fc3471da595758bbc2c16ad8bd)