### PR TITLE
ci(common): Fix build jobs to install only idf-build-apps in idf cotainer

### DIFF
--- a/.github/workflows/console_cmd_ifconfig__build.yml
+++ b/.github/workflows/console_cmd_ifconfig__build.yml
@@ -33,6 +33,6 @@ jobs:
         shell: bash
         working-directory: ${{matrix.test.path}}
         run: |
-          ${IDF_PATH}/install.sh --enable-pytest
           . ${IDF_PATH}/export.sh
+          pip install idf-component-manager idf-build-apps --upgrade
           python ../../../ci/build_apps.py ./${{ matrix.test.app }} --target ${{ matrix.idf_target }} -vv --preserve-all --pytest-app

--- a/.github/workflows/console_cmd_ping__build.yml
+++ b/.github/workflows/console_cmd_ping__build.yml
@@ -27,6 +27,6 @@ jobs:
         shell: bash
         working-directory: ${{matrix.test.path}}
         run: |
-          ${IDF_PATH}/install.sh --enable-pytest
           . ${IDF_PATH}/export.sh
+          pip install idf-component-manager idf-build-apps --upgrade
           python ../../../ci/build_apps.py ./${{ matrix.test.app }} --target ${{ matrix.idf_target }} -vv --preserve-all --pytest-app

--- a/.github/workflows/console_cmd_wifi__build.yml
+++ b/.github/workflows/console_cmd_wifi__build.yml
@@ -27,6 +27,6 @@ jobs:
         shell: bash
         working-directory: ${{matrix.test.path}}
         run: |
-          ${IDF_PATH}/install.sh --enable-pytest
           . ${IDF_PATH}/export.sh
+          pip install idf-component-manager idf-build-apps --upgrade
           python ../../../ci/build_apps.py ./${{ matrix.test.app }} --target ${{ matrix.idf_target }} -vv --preserve-all --pytest-app

--- a/.github/workflows/console_simple_init__build.yml
+++ b/.github/workflows/console_simple_init__build.yml
@@ -27,6 +27,6 @@ jobs:
         shell: bash
         working-directory: ${{matrix.test.path}}
         run: |
-          ${IDF_PATH}/install.sh --enable-pytest
           . ${IDF_PATH}/export.sh
+          pip install idf-component-manager idf-build-apps --upgrade
           python ../../../ci/build_apps.py ./${{ matrix.test.app }} --target ${{ matrix.idf_target }} -vv --preserve-all --pytest-app

--- a/.github/workflows/mqtt_cxx__build.yml
+++ b/.github/workflows/mqtt_cxx__build.yml
@@ -27,6 +27,6 @@ jobs:
         shell: bash
         working-directory: ${{matrix.test.path}}
         run: |
-          ${IDF_PATH}/install.sh --enable-pytest
           . ${IDF_PATH}/export.sh
+          pip install idf-component-manager idf-build-apps --upgrade
           python ../../../ci/build_apps.py ./${{ matrix.test.app }} --target ${{ matrix.idf_target }} -vv --preserve-all --pytest-app

--- a/.github/workflows/tls_cxx__build.yml
+++ b/.github/workflows/tls_cxx__build.yml
@@ -25,6 +25,6 @@ jobs:
       - name: Build ${{ matrix.test.app }} with IDF-${{ matrix.idf_ver }}
         shell: bash
         run: |
-          ${IDF_PATH}/install.sh --enable-pytest
           . ${IDF_PATH}/export.sh
+          pip install idf-component-manager idf-build-apps --upgrade
           python ./ci/build_apps.py ./components/mbedtls_cxx/${{ matrix.test.path }} -vv --preserve-all


### PR DESCRIPTION
Fixes recent python-dbus install issues: https://github.com/espressif/esp-protocols/actions/runs/9264801912/job/25485576463