### PR TITLE
feat(websocket_client): Add option to set and use cert_common_name in Websocket client (IDFGH-12926)

### DIFF
--- a/components/esp_websocket_client/include/esp_websocket_client.h
+++ b/components/esp_websocket_client/include/esp_websocket_client.h
@@ -118,6 +118,7 @@ typedef struct {
     bool                        disable_pingpong_discon;    /*!< Disable auto-disconnect due to no PONG received within pingpong_timeout_sec */
     bool                        use_global_ca_store;        /*!< Use a global ca_store for all the connections in which this bool is set. */
     esp_err_t (*crt_bundle_attach)(void *conf);             /*!< Function pointer to esp_crt_bundle_attach. Enables the use of certification bundle for server verification, MBEDTLS_CERTIFICATE_BUNDLE must be enabled in menuconfig. Include esp_crt_bundle.h, and use `esp_crt_bundle_attach` here to include bundled CA certificates. */
+    const char                  *cert_common_name;          /*!< Expected common name of the server certificate */
     bool                        skip_cert_common_name_check;/*!< Skip any validation of server certificate CN field */
     bool                        keep_alive_enable;          /*!< Enable keep-alive timeout */
     int                         keep_alive_idle;            /*!< Keep-alive idle time. Default is 5 (second) */


### PR DESCRIPTION
Set a common name that is verified. We use this via a server using a custom certificate bundle + common name combo.

I am not really sure if we need to deny when `skip_common_name && cert_common_name` is set.