### PR TITLE
Websocket heap_caps_malloc and heap_caps_calloc to permit other memory type caps to be used in the websocket protocol (IDFGH-12945)

### DIFF
--- a/components/esp_websocket_client/esp_websocket_client.c
+++ b/components/esp_websocket_client/esp_websocket_client.c
@@ -143,6 +143,7 @@ struct esp_websocket_client {
     int                         payload_offset;
     esp_transport_keep_alive_t  keep_alive_cfg;
     struct ifreq                *if_name;
+    int                         memory_type;
 };
 
 static uint64_t _tick_get_ms(void)

--- a/components/esp_websocket_client/include/esp_websocket_client.h
+++ b/components/esp_websocket_client/include/esp_websocket_client.h
@@ -127,7 +127,7 @@ typedef struct {
     int                         network_timeout_ms;         /*!< Abort network operation if it is not completed after this value, in milliseconds (defaults to 10s) */
     size_t                      ping_interval_sec;          /*!< Websocket ping interval, defaults to 10 seconds if not set */
     struct ifreq                *if_name;                   /*!< The name of interface for data to go through. Use the default interface without setting */
-    int                         memory_type;
+    int                         memory_type;                /*!< The name of memory region type to be used in the heap_caps_malloc / heap_caps_calloc  */
 } esp_websocket_client_config_t;
 
 /**

--- a/components/esp_websocket_client/include/esp_websocket_client.h
+++ b/components/esp_websocket_client/include/esp_websocket_client.h
@@ -127,6 +127,7 @@ typedef struct {
     int                         network_timeout_ms;         /*!< Abort network operation if it is not completed after this value, in milliseconds (defaults to 10s) */
     size_t                      ping_interval_sec;          /*!< Websocket ping interval, defaults to 10 seconds if not set */
     struct ifreq                *if_name;                   /*!< The name of interface for data to go through. Use the default interface without setting */
+    int                         memory_type;
 } esp_websocket_client_config_t;
 
 /**


### PR DESCRIPTION
Create a way to enable the usage of external or any other kind of memory allowed in heap_caps_malloc and heap_caps_calloc to be used in the websocket.

The memory_type directive was included in the esp_websocket_client_config_t structure and all functions was update to use the memory type defined, if not defined ot wrong type/bitwise it will use the MALLOC_CAP_INTERNAL, otherwise will use it.

Also the http_auth_basic function was also update to use the correct memory region set.
