### PR TITLE
bump(mdns): 1.3.1 -> 1.3.2

### DIFF
--- a/components/mdns/.cz.yaml
+++ b/components/mdns/.cz.yaml
@@ -3,6 +3,6 @@ commitizen:
   bump_message: 'bump(mdns): $current_version -> $new_version'
   pre_bump_hooks: python ../../ci/changelog.py mdns
   tag_format: mdns-v$version
-  version: 1.3.1
+  version: 1.3.2
   version_files:
   - idf_component.yml

--- a/components/mdns/CHANGELOG.md
+++ b/components/mdns/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [1.3.2](https://github.com/espressif/esp-protocols/commits/mdns-v1.3.2)
+
+### Features
+
+- add check of instance when handling PTR query ([6af6ca5](https://github.com/espressif/esp-protocols/commit/6af6ca5))
+
+### Bug Fixes
+
+- Fix of mdns afl tests ([139166c](https://github.com/espressif/esp-protocols/commit/139166c))
+- remove same protocol services with different instances ([042533a](https://github.com/espressif/esp-protocols/commit/042533a))
+
 ## [1.3.1](https://github.com/espressif/esp-protocols/commits/mdns-v1.3.1)
 
 ### Bug Fixes

--- a/components/mdns/idf_component.yml
+++ b/components/mdns/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.3.1"
+version: "1.3.2"
 description: mDNS
 url: https://github.com/espressif/esp-protocols/tree/master/components/mdns
 dependencies:


### PR DESCRIPTION
1.3.2
Features
- add check of instance when handling PTR query (6af6ca5) 
Bug Fixes
- Fix of mdns afl tests (139166c)
- remove same protocol services with different instances (042533a)