### PR TITLE
[modem]: Fixes clang-tidy warnings

### DIFF
--- a/.github/workflows/run-host-tests.yml
+++ b/.github/workflows/run-host-tests.yml
@@ -87,8 +87,10 @@ jobs:
           shell: bash
           if: ${{ inputs.run_coverage }}
           run: |
-            apt-get update && apt-get install -y python3-pip rsync
-            python -m pip install gcovr
+            apt-get update && apt-get install -y rsync
+            python3 -m venv .venv
+            source .venv/bin/activate
+            python3 -m pip install gcovr
             cd $GITHUB_WORKSPACE/${{inputs.component_path}}
             component=$(basename ${{ inputs.component_path }})
             gcov `find . -name "$component*gcda"`

--- a/components/esp_modem/include/cxx_include/esp_modem_cmux.hpp
+++ b/components/esp_modem/include/cxx_include/esp_modem_cmux.hpp
@@ -142,7 +142,6 @@ private:
     size_t frame_header_offset;
     uint8_t *payload_start;
     size_t total_payload_size;
-    int instance;
     int sabm_ack;
 
     /**

--- a/components/esp_modem/include/cxx_include/esp_modem_netif.hpp
+++ b/components/esp_modem/include/cxx_include/esp_modem_netif.hpp
@@ -65,7 +65,6 @@ private:
     static void on_ppp_changed(void *arg, esp_event_base_t event_base, int32_t event_id, void *event_data);
 
     std::shared_ptr<DTE> ppp_dte;
-    esp_netif_t *netif;
     struct ppp_netif_driver driver {};
     SignalGroup signal;
     static const size_t PPP_STARTED = SignalGroup::bit0;

--- a/components/esp_modem/src/esp_modem_cmux.cpp
+++ b/components/esp_modem/src/esp_modem_cmux.cpp
@@ -150,7 +150,7 @@ bool CMux::data_available(uint8_t *data, size_t len)
             return false;
         }
     } else if ((type & FT_UIH) == FT_UIH && dlci == 0) { // notify the internal DISC command
-        if ((len > 0 && (data[0] & 0xE1) == 0xE1) || (data == nullptr)) {
+        if ((data == nullptr) || (len > 0 && (data[0] & 0xE1) == 0xE1)) {
             // Not a DISC, ignore (MSC frame)
             return true;
         }
@@ -345,6 +345,9 @@ bool CMux::on_cmux_data(uint8_t *data, size_t actual_len)
         data = buffer.get();
         actual_len = term->read(data, buffer.size);
 #endif
+    }
+    if (data == nullptr) {
+        return false;
     }
     ESP_LOG_BUFFER_HEXDUMP("CMUX Received", data, actual_len, ESP_LOG_VERBOSE);
     CMuxFrame frame = { .ptr = data, .len = actual_len };

--- a/components/esp_modem/src/esp_modem_netif.cpp
+++ b/components/esp_modem/src/esp_modem_netif.cpp
@@ -69,7 +69,7 @@ void Netif::receive(uint8_t *data, size_t len)
 }
 
 Netif::Netif(std::shared_ptr<DTE> e, esp_netif_t *ppp_netif) :
-    ppp_dte(std::move(e)), netif(ppp_netif)
+    ppp_dte(std::move(e))
 {
     driver.base.netif = ppp_netif;
     driver.ppp = this;

--- a/components/esp_modem/src/esp_modem_netif_linux.cpp
+++ b/components/esp_modem/src/esp_modem_netif_linux.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021-2022 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2021-2024 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -29,11 +29,15 @@ esp_err_t Netif::esp_modem_post_attach(esp_netif_t *esp_netif, void *args)
 
 void Netif::receive(uint8_t *data, size_t len)
 {
-    esp_netif_receive(netif, data, len);
+    esp_netif_receive(driver.base.netif, data, len);
 }
 
 Netif::Netif(std::shared_ptr<DTE> e, esp_netif_t *ppp_netif) :
-    ppp_dte(std::move(e)), netif(ppp_netif) {}
+    ppp_dte(std::move(e))
+{
+    driver.base.netif = ppp_netif;
+    driver.ppp = this;
+}
 
 void Netif::start()
 {
@@ -41,8 +45,8 @@ void Netif::start()
         receive(data, len);
         return true;
     });
-    netif->transmit = esp_modem_dte_transmit;
-    netif->ctx = (void *)this;
+    driver.base.netif->transmit = esp_modem_dte_transmit;
+    driver.base.netif->ctx = (void *)this;
     signal.set(PPP_STARTED);
 }
 

--- a/components/esp_modem/src/esp_modem_term_fs.cpp
+++ b/components/esp_modem/src/esp_modem_term_fs.cpp
@@ -155,7 +155,7 @@ int FdTerminal::write(uint8_t *data, size_t len)
 
 FdTerminal::~FdTerminal()
 {
-    stop();
+    FdTerminal::stop();
 }
 
 } // namespace esp_modem

--- a/components/esp_modem/src/esp_modem_vfs_uart_creator.cpp
+++ b/components/esp_modem/src/esp_modem_vfs_uart_creator.cpp
@@ -14,7 +14,7 @@
 #include "uart_resource.hpp"
 #include "vfs_resource/vfs_create.hpp"
 
-constexpr const char *TAG = "vfs_uart_creator";
+[[maybe_unused]] constexpr const char *TAG = "vfs_uart_creator";
 
 
 struct esp_modem_vfs_resource {


### PR DESCRIPTION
## Fixes clang-tidy warnings related to `esp_modem`

* [private field 'netif' is not used [clang-diagnostic-unused-private-field]](https://github.com/espressif/esp-protocols/security/code-scanning/1)
* [private field 'instance' is not used [clang-diagnostic-unused-private-field]](https://github.com/espressif/esp-protocols/security/code-scanning/2)
* [Call to virtual method 'FdTerminal::stop' during destruction bypasses virtual dispatch [clang-analyzer-optin.cplusplus.VirtualCall]](https://github.com/espressif/esp-protocols/security/code-scanning/3)
* [unused variable 'TAG' [clang-diagnostic-unused-const-variable]
](https://github.com/espressif/esp-protocols/security/code-scanning/15)
* [Null pointer passed as 2nd argument to memory copy function [clang-analyzer-unix.cstring.NullArg]](https://github.com/espressif/esp-protocols/security/code-scanning/104)
* [Array access (from variable 'data') results in a null pointer dereference [clang-analyzer-core.NullDereference]](https://github.com/espressif/esp-protocols/security/code-scanning/103)


## Fixes `esp_modem` host tests

* by running the gcov module in python virtual environment


## Test run of clang-tidy job

* https://github.com/espressif/esp-protocols/security/code-scanning?page=4&query=is%3Aopen+branch%3Atest_clang_tidy