### PR TITLE
feat(esp_websocket_client): allow updating reconnect timeout for retry backoffs (IDFGH-13016)

### DIFF
--- a/components/esp_websocket_client/esp_websocket_client.c
+++ b/components/esp_websocket_client/esp_websocket_client.c
@@ -1278,6 +1278,43 @@ esp_err_t esp_websocket_client_set_ping_interval_sec(esp_websocket_client_handle
     return ESP_OK;
 }
 
+int esp_websocket_client_get_reconnect_timeout(esp_websocket_client_handle_t client)
+{
+    if (client == NULL) {
+        ESP_LOGW(TAG, "Client was not initialized");
+        return -1;
+    }
+
+    if (!client->config->auto_reconnect) {
+        ESP_LOGW(TAG, "Automatic reconnect is disabled");
+        return -1;
+    }
+
+    return client->wait_timeout_ms;
+}
+
+esp_err_t esp_websocket_client_set_reconnect_timeout(esp_websocket_client_handle_t client, int reconnect_timeout_ms)
+{
+    if (client == NULL) {
+        ESP_LOGW(TAG, "Client was not initialized");
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    if (reconnect_timeout_ms <= 0) {
+        ESP_LOGW(TAG, "Invalid reconnect timeout");
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    if (!client->config->auto_reconnect) {
+        ESP_LOGW(TAG, "Automatic reconnect is disabled");
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    client->wait_timeout_ms = reconnect_timeout_ms;
+
+    return ESP_OK;
+}
+
 esp_err_t esp_websocket_register_events(esp_websocket_client_handle_t client,
                                         esp_websocket_event_id_t event,
                                         esp_event_handler_t event_handler,

--- a/components/esp_websocket_client/include/esp_websocket_client.h
+++ b/components/esp_websocket_client/include/esp_websocket_client.h
@@ -417,6 +417,29 @@ size_t esp_websocket_client_get_ping_interval_sec(esp_websocket_client_handle_t 
 esp_err_t esp_websocket_client_set_ping_interval_sec(esp_websocket_client_handle_t client, size_t ping_interval_sec);
 
 /**
+ * @brief      Get the next reconnect timeout for client. Returns -1 when client is not initialized or automatic reconnect is disabled.
+ *
+ * @param[in]  client             The client
+ *
+ * @return     Reconnect timeout in msec
+ */
+int esp_websocket_client_get_reconnect_timeout(esp_websocket_client_handle_t client);
+
+/**
+ * @brief      Set next reconnect timeout for client.
+ *
+ *  Notes:
+ *  - Changing this value when reconnection delay is already active does not immediately affect the active delay and may have unexpected result.
+ *  - Good place to change this value is when handling WEBSOCKET_EVENT_DISCONNECTED or WEBSOCKET_EVENT_ERROR events.
+ *
+ * @param[in]  client             The client
+ * @param[in]  reconnect_timeout_ms  The new timeout
+ *
+ * @return     esp_err_t
+ */
+esp_err_t esp_websocket_client_set_reconnect_timeout(esp_websocket_client_handle_t client, int reconnect_timeout_ms);
+
+/**
  * @brief Register the Websocket Events
  *
  * @param client            The client handle


### PR DESCRIPTION
Currently automatic reconnect interval can only be configured when initializing `esp_websocket_client` and cannot be changed later. This makes it impossible to implement connection retry back-off, for example.

This pull request adds `esp_websocket_client_get_reconnect_timeout()` and `esp_websocket_client_set_reconnect_timeout()` functions.