### PR TITLE
fix(common): Fix pre-commit hook to use released astyle_py

### DIFF
--- a/.github/workflows/pre_commit_check.yml
+++ b/.github/workflows/pre_commit_check.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Python environment
         uses: actions/setup-python@master
         with:
-          python-version: v3.7
+          python-version: v3.8
       - name: Install python packages
         run: |
           pip install pre-commit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,7 +48,7 @@ repos:
       - id: check-copyright
         args: ['--ignore', 'ci/check_copyright_ignore.txt', '--config', 'ci/check_copyright_config.yaml']
   - repo: https://github.com/igrr/astyle_py.git
-    rev: c0013808882a15a0c0c2c1a9b5c903866c53a653
+    rev: v1.0.5
     hooks:
     -   id: astyle_py
         args: ['--style=otbs', '--attach-namespaces', '--attach-classes', '--indent=spaces=4', '--convert-tabs', '--align-pointer=name', '--align-reference=name', '--keep-one-line-statements', '--pad-header', '--pad-oper', '--exclude-list=ci/ignore_astyle.txt']


### PR DESCRIPTION
The previous version (c00138088) required pyyaml 3.0.0 which is broken on certain plafroms (e.g. Fedora 39)

Closes https://github.com/espressif/esp-protocols/issues/592