### PR TITLE
bump(eppp): 0.1.1 -> 0.2.0

### DIFF
--- a/components/eppp_link/.cz.yaml
+++ b/components/eppp_link/.cz.yaml
@@ -3,6 +3,6 @@ commitizen:
   bump_message: 'bump(eppp): $current_version -> $new_version'
   pre_bump_hooks: python ../../ci/changelog.py eppp_link
   tag_format: eppp-v$version
-  version: 0.1.1
+  version: 0.2.0
   version_files:
   - idf_component.yml

--- a/components/eppp_link/CHANGELOG.md
+++ b/components/eppp_link/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.2.0](https://github.com/espressif/esp-protocols/commits/eppp-v0.2.0)
+
+### Features
+
+- Add support for SDIO transport ([085dd790](https://github.com/espressif/esp-protocols/commit/085dd790))
+
+### Bug Fixes
+
+- Fixed strict prototype API decl issue in SDIO ([eb09e426](https://github.com/espressif/esp-protocols/commit/eb09e426))
+- Fix SIDO host to check/clear interrupts atomically ([402176c9](https://github.com/espressif/esp-protocols/commit/402176c9))
+
 ## [0.1.1](https://github.com/espressif/esp-protocols/commits/eppp-v0.1.1)
 
 ### Bug Fixes

--- a/components/eppp_link/eppp_sdio_host.c
+++ b/components/eppp_link/eppp_sdio_host.c
@@ -168,7 +168,7 @@ esp_err_t eppp_sdio_host_rx(esp_netif_t *netif)
     return ESP_OK;
 }
 
-void eppp_sdio_host_deinit()
+void eppp_sdio_host_deinit(void)
 {
     essl_sdio_deinit_dev(s_essl);
     sdmmc_host_deinit();
@@ -189,11 +189,11 @@ esp_err_t eppp_sdio_host_rx(esp_netif_t *netif)
     return ESP_ERR_NOT_SUPPORTED;
 }
 
-void eppp_sdio_host_deinit()
+void eppp_sdio_host_deinit(void)
 {
 }
 
-esp_err_t eppp_sdio_host_init()
+esp_err_t eppp_sdio_host_init(struct eppp_config_sdio_s *config)
 {
     return ESP_ERR_NOT_SUPPORTED;
 }

--- a/components/eppp_link/eppp_sdio_slave.c
+++ b/components/eppp_link/eppp_sdio_slave.c
@@ -162,7 +162,7 @@ esp_err_t eppp_sdio_slave_rx(esp_netif_t *netif)
     return ESP_ERR_NOT_SUPPORTED;
 }
 
-void eppp_sdio_slave_deinit()
+void eppp_sdio_slave_deinit(void)
 {
 }
 

--- a/components/eppp_link/idf_component.yml
+++ b/components/eppp_link/idf_component.yml
@@ -1,4 +1,4 @@
-version: 0.1.1
+version: 0.2.0
 url: https://github.com/espressif/esp-protocols/tree/master/components/eppp_link
 description: The component provides a general purpose PPP connectivity, typically used as WiFi-PPP router
 dependencies:


### PR DESCRIPTION
### 0.2.0

####    Features

    - Add support for SDIO transport (085dd790)

####    Bug Fixes
    - Fixed strict prototype API decl issue in SDIO (452e4614)
    - Fix SIDO host to check/clear interrupts atomically (402176c9)
