### PR TITLE
Add Delay on CMUX Terminal Disconnect (IDFGH-13120)

### DIFF
--- a/components/esp_modem/Kconfig
+++ b/components/esp_modem/Kconfig
@@ -36,6 +36,14 @@ menu "esp-modem"
             The typical reason for failing SABM request without a delay is that
             some devices (SIM800) send MSC requests just after opening a new DLCI.
 
+    config ESP_MODEM_CMUX_DELAY_AFTER_DLCI_DISCONNECT
+        int "Delay in ms to wait after closing virtual terminal"
+        default 0
+        help
+            Some devices might need a pause before sending disconnect command that closes
+            virtual terminal. This delay applies only to close DLCI in CMUX mode.
+
+
     config ESP_MODEM_CMUX_USE_SHORT_PAYLOADS_ONLY
         bool "CMUX to support only short payloads (<128 bytes)"
         default n

--- a/components/esp_modem/src/esp_modem_cmux.cpp
+++ b/components/esp_modem/src/esp_modem_cmux.cpp
@@ -94,6 +94,7 @@ void CMux::send_disconnect(size_t i)
         frame[4] = 0xFF - fcs_crc(frame);
         term->write(frame, sizeof(frame));
     }
+    usleep(CONFIG_ESP_MODEM_CMUX_DELAY_AFTER_DLCI_DISCONNECT * 1'000);
 }
 
 void CMux::send_sabm(size_t i)


### PR DESCRIPTION
some Modems require additional delay after sending DISC frame. Adding an option in Config to allow adding appropriate delay when needed