### PR TITLE
Allow to add Delay to CMUX DISC (IDFGH-15937)

### DIFF
--- a/components/esp_modem/Kconfig
+++ b/components/esp_modem/Kconfig
@@ -36,6 +36,13 @@ menu "esp-modem"
             The typical reason for failing SABM request without a delay is that
             some devices (SIM800) send MSC requests just after opening a new DLCI.
 
+    config ESP_MODEM_CMUX_DELAY_AFTER_DLCI_DISCONNECT
+        int "Delay in ms to wait after closing virtual terminal"
+        default 0
+        help
+            Some devices might need a pause before sending disconnect command that closes
+            virtual terminal. This delay applies only to close DLCI in CMUX mode.
+
     config ESP_MODEM_CMUX_USE_SHORT_PAYLOADS_ONLY
         bool "CMUX to support only short payloads (<128 bytes)"
         default n

--- a/components/esp_modem/src/esp_modem_cmux.cpp
+++ b/components/esp_modem/src/esp_modem_cmux.cpp
@@ -81,6 +81,7 @@ uint8_t CMux::fcs_crc(const uint8_t frame[6])
 
 void CMux::send_disconnect(size_t i)
 {
+    usleep(CONFIG_ESP_MODEM_CMUX_DELAY_AFTER_DLCI_DISCONNECT * 1'000);
     if (i == 0) {   // control terminal
         uint8_t frame[] = {
             SOF_MARKER, 0x3, 0xEF, 0x5, 0xC3, 0x1, 0xF2, SOF_MARKER


### PR DESCRIPTION
Some Modems require a delay before sending disconnect, added OPTION ESP_MODEM_CMUX_DELAY_AFTER_DLCI_DISCONNECT to allow configuring that