### PR TITLE
[examples]: Make multi-netif example working with DNS_PER_DEFAULT_NETIF

### DIFF
--- a/examples/esp_netif/multiple_netifs/README.md
+++ b/examples/esp_netif/multiple_netifs/README.md
@@ -19,6 +19,14 @@ This example demonstrates working with multiple different interfaces with differ
   * It tries to reconfigure DNS server if host name resolution fails
   * It tries to manually change the default interface if connection fails
 
+### Handling DNS server across interfaces
+
+This example also demonstrates how DNS servers could be handled on network interface level, as lwIP used global DNS server information.
+
+All network interfaces store their DNS info upon acquiring an IP in the internal structure (in the application code) and the DNS servers are restored if host name resolution fails.
+
+This functionality is handled in IDF (supported from v5.3) automatically if `CONFIG_ESP_NETIF_SET_DNS_PER_DEFAULT_NETIF` is enabled, the DNS server info keeps updating per network interface in IDF layers. This examples uses the IDF functionality if `CONFIG_ESP_NETIF_SET_DNS_PER_DEFAULT_NETIF=1`.
+
 ### Hardware Required
 
 To run this example, it's recommended that you have an official ESP32 Ethernet development board - [ESP32-Ethernet-Kit](https://docs.espressif.com/projects/esp-idf/en/latest/hw-reference/get-started-ethernet-kit.html).

--- a/examples/esp_netif/multiple_netifs/main/Kconfig.projbuild
+++ b/examples/esp_netif/multiple_netifs/main/Kconfig.projbuild
@@ -54,4 +54,14 @@ menu "Example Configuration"
             bool "Using simple UART-PPP driver"
     endchoice
 
+    config EXAMPLE_DEMONSTRATE_DNS_CLEAR_CACHE
+        bool "Run DNS clear cache"
+        default n
+        help
+            This example will cleanup the DNS cache
+            every iteration of the demo network operation.
+            This forces the TCP/IP stack to always resolve DNS names,
+            thus exercising potentially invalid DNS configuration.
+            Set this to "y" for testing, but keep as "n" for production.
+
 endmenu

--- a/examples/esp_netif/multiple_netifs/main/ethernet_connect.c
+++ b/examples/esp_netif/multiple_netifs/main/ethernet_connect.c
@@ -95,7 +95,7 @@ static void eth_destroy(iface_info_t *info)
     free(eth_info);
 }
 
-iface_info_t *eth_init(int prio)
+iface_info_t *example_eth_init(int prio)
 {
     struct eth_info_t *eth_info = malloc(sizeof(struct eth_info_t));
     assert(eth_info);
@@ -124,7 +124,7 @@ iface_info_t *eth_init(int prio)
     eth_info->parent.netif = esp_netif_new(&cfg);
     eth_info->glue = esp_eth_new_netif_glue(eth_info->eth_handle);
     // Attach Ethernet driver to TCP/IP stack
-    ESP_ERROR_CHECK(esp_netif_attach(eth_info->parent.netif, eth_info->glue ));
+    ESP_ERROR_CHECK(esp_netif_attach(eth_info->parent.netif, eth_info->glue));
 
     // Register user defined event handers
     ESP_ERROR_CHECK(esp_event_handler_register(ETH_EVENT, ESP_EVENT_ANY_ID, &eth_event_handler, eth_info));

--- a/examples/esp_netif/multiple_netifs/main/ppp_connect.c
+++ b/examples/esp_netif/multiple_netifs/main/ppp_connect.c
@@ -85,7 +85,7 @@ static void ppp_destroy(iface_info_t *info)
     free(info);
 }
 
-iface_info_t *init_ppp(int prio)
+iface_info_t *example_ppp_init(int prio)
 {
     struct ppp_info_t *ppp_info = calloc(1, sizeof(struct ppp_info_t));
     assert(ppp_info);

--- a/examples/esp_netif/multiple_netifs/main/wifi_connect.c
+++ b/examples/esp_netif/multiple_netifs/main/wifi_connect.c
@@ -75,7 +75,7 @@ static void wifi_destroy(iface_info_t *info)
     free(info);
 }
 
-iface_info_t *wifi_init(int prio)
+iface_info_t *example_wifi_init(int prio)
 {
     struct iface_info_t *wifi_info = malloc(sizeof(iface_info_t));
     assert(wifi_info);
@@ -100,9 +100,9 @@ iface_info_t *wifi_init(int prio)
             .password = CONFIG_ESP_WIFI_PASSWORD,
         },
     };
-    ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA) );
-    ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &wifi_config) );
-    ESP_ERROR_CHECK(esp_wifi_start() );
+    ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA));
+    ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &wifi_config));
+    ESP_ERROR_CHECK(esp_wifi_start());
 
     ESP_LOGI(TAG, "wifi_init_sta finished.");
 

--- a/examples/esp_netif/multiple_netifs/sdkconfig.defaults
+++ b/examples/esp_netif/multiple_netifs/sdkconfig.defaults
@@ -1,2 +1,5 @@
+# You can use CONFIG_ESP_NETIF_SET_DNS_PER_DEFAULT_NETIF
+# to perform DNS server updates automatically in esp_netif layers
+# instead of manually as it is demonstrated in this example
 CONFIG_LWIP_PPP_SUPPORT=y
 CONFIG_LWIP_PPP_NOTIFY_PHASE_SUPPORT=y


### PR DESCRIPTION
Latest IDF supports `CONFIG_ESP_NETIF_SET_DNS_PER_DEFAULT_NETIF` config option which restores global DNS server information from "per-netif" records whenever a new netif is selected for routing (set as default).