### PR TITLE
fix(websocket): don't fetch transport from the list if external transport is set

### DIFF
--- a/components/esp_websocket_client/esp_websocket_client.c
+++ b/components/esp_websocket_client/esp_websocket_client.c
@@ -955,7 +955,9 @@ static void esp_websocket_client_task(void *pv)
     client->run = true;
 
     //get transport by scheme
-    client->transport = esp_transport_list_get_transport(client->transport_list, client->config->scheme);
+    if (client->transport == NULL && client->config->ext_transport == NULL) {
+        client->transport = esp_transport_list_get_transport(client->transport_list, client->config->scheme);
+    }
 
     if (client->transport == NULL) {
         ESP_LOGE(TAG, "There are no transports valid, stop websocket client");
@@ -1135,6 +1137,7 @@ esp_err_t esp_websocket_client_start(esp_websocket_client_handle_t client)
         return ESP_FAIL;
     }
     xEventGroupClearBits(client->status_bits, STOPPED_BIT | CLOSE_FRAME_SENT_BIT);
+    ESP_LOGI(TAG, "Started");
     return ESP_OK;
 }
 


### PR DESCRIPTION
Hi @gabsuren @euripedesrocha 

Sorry I found I made a bug with this PR: https://github.com/espressif/esp-protocols/pull/573

Basically what happened is that it won't work again if I destroy the client, set `ext_transport` in the config to null and initialise the client with the new config, it will stop with error message `There are no transports valid, stop websocket client` when I call the start API.

Anyway here the fix. Sorry for the trouble!

Regards,
Jackson