### PR TITLE
[mdns]: More console tests

### DIFF
--- a/components/mdns/mdns.c
+++ b/components/mdns/mdns.c
@@ -6079,7 +6079,7 @@ esp_err_t mdns_instance_name_set(const char *instance)
 esp_err_t mdns_service_add_for_host(const char *instance, const char *service, const char *proto, const char *hostname,
                                     uint16_t port, mdns_txt_item_t txt[], size_t num_items)
 {
-    if (!_mdns_server || _str_null_or_empty(service) || _str_null_or_empty(proto) || !port || !hostname) {
+    if (!_mdns_server || _str_null_or_empty(service) || _str_null_or_empty(proto) || !port || !_mdns_server->hostname) {
         return ESP_ERR_INVALID_ARG;
     }
 
@@ -6087,6 +6087,10 @@ esp_err_t mdns_service_add_for_host(const char *instance, const char *service, c
     if (!_mdns_can_add_more_services()) {
         MDNS_SERVICE_UNLOCK();
         return ESP_ERR_NO_MEM;
+    }
+
+    if (!hostname) {
+        hostname = _mdns_server->hostname;
     }
 
     mdns_srv_item_t *item = _mdns_get_service_item_instance(instance, service, proto, hostname);

--- a/components/mdns/tests/host_test/components/esp_netif_linux/esp_netif_linux.c
+++ b/components/mdns/tests/host_test/components/esp_netif_linux/esp_netif_linux.c
@@ -182,3 +182,16 @@ const char *esp_netif_get_ifkey(esp_netif_t *esp_netif)
 {
     return esp_netif->if_key;
 }
+
+esp_err_t esp_netif_str_to_ip4(const char *src, esp_ip4_addr_t *dst)
+{
+    if (src == NULL || dst == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    struct in_addr addr;
+    if (inet_pton(AF_INET, src, &addr) != 1) {
+        return ESP_FAIL;
+    }
+    dst->addr = addr.s_addr;
+    return ESP_OK;
+}

--- a/components/mdns/tests/host_test/dnsfixture.py
+++ b/components/mdns/tests/host_test/dnsfixture.py
@@ -85,14 +85,16 @@ class DnsPythonWrapper:
                         answers.append(full_answer)
         return answers
 
-    def check_record(self, name, query_type, expected=True):
+    def check_record(self, name, query_type, expected=True, expect=None):
         output = self.run_query(name, query_type=query_type)
         answers = self.parse_answer_section(output, query_type)
         logger.info(f'answers: {answers}')
+        if expect is None:
+            expect = name
         if expected:
-            assert any(name in answer for answer in answers), f"Expected service '{name}' not found in answer section"
+            assert any(expect in answer for answer in answers), f"Expected record '{expect}' not found in answer section"
         else:
-            assert not any(name in answer for answer in answers), f"Unexpected service '{name}' found in answer section"
+            assert not any(expect in answer for answer in answers), f"Unexpected record '{expect}' found in answer section"
 
 
 if __name__ == '__main__':

--- a/components/mdns/tests/host_test/pytest_mdns.py
+++ b/components/mdns/tests/host_test/pytest_mdns.py
@@ -104,5 +104,20 @@ def test_remove_delegated_service(mdns_console, dig_app):
     dig_app.check_record('_test2._tcp.local', query_type='PTR', expected=False)
 
 
+def test_update_txt(mdns_console, dig_app):
+    mdns_console.send_input('mdns_service_txt_set _test _tcp key1 value1')
+    dig_app.check_record('local._test._tcp.local', query_type='SRV', expected=True)
+    dig_app.check_record('_test._tcp.local', query_type='TXT', expected=True, expect='key1=value1')
+    mdns_console.send_input('mdns_service_txt_set _test _tcp key2 value2')
+    dig_app.check_record('_test._tcp.local', query_type='TXT', expected=True, expect='key2=value2')
+    mdns_console.send_input('mdns_service_txt_remove _test _tcp key2')
+    dig_app.check_record('_test._tcp.local', query_type='TXT', expected=False, expect='key2=value2')
+    dig_app.check_record('_test._tcp.local', query_type='TXT', expected=True, expect='key1=value1')
+    mdns_console.send_input('mdns_service_txt_replace _test _tcp key3=value3 key4=value4')
+    dig_app.check_record('_test._tcp.local', query_type='TXT', expected=False, expect='key1=value1')
+    dig_app.check_record('_test._tcp.local', query_type='TXT', expected=True, expect='key3=value3')
+    dig_app.check_record('_test._tcp.local', query_type='TXT', expected=True, expect='key4=value4')
+
+
 if __name__ == '__main__':
     pytest.main(['-s', 'test_mdns.py'])

--- a/components/mdns/tests/host_test/pytest_mdns.py
+++ b/components/mdns/tests/host_test/pytest_mdns.py
@@ -72,5 +72,15 @@ def test_remove_service(mdns_console, dig_app):
     dig_app.check_record('_http._tcp.local', query_type='PTR', expected=False)
 
 
+def test_delegate_host(mdns_console, dig_app):
+    mdns_console.send_input('mdns_delegate_host delegated 1.2.3.4')
+    dig_app.check_record('delegated.local', query_type='A', expected=True)
+
+
+def test_undelegate_host(mdns_console, dig_app):
+    mdns_console.send_input('mdns_undelegate_host delegated')
+    dig_app.check_record('delegated.local', query_type='A', expected=False)
+
+
 if __name__ == '__main__':
     pytest.main(['-s', 'test_mdns.py'])

--- a/components/mdns/tests/host_test/pytest_mdns.py
+++ b/components/mdns/tests/host_test/pytest_mdns.py
@@ -155,5 +155,26 @@ def test_service_subtype(mdns_console, dig_app):
     dig_app.check_record('_subtest2._sub._test2._tcp.local', query_type='PTR', expected=True)
 
 
+def test_service_set_instance(mdns_console, dig_app):
+    dig_app.check_record('local._test._tcp.local', query_type='SRV', expected=True)
+    mdns_console.send_input('mdns_service_instance_set _test _tcp local2')
+    dig_app.check_record('local2._test._tcp.local', query_type='SRV', expected=True)
+    mdns_console.send_input('mdns_service_instance_set _test2 _tcp extern2 -h delegated')
+    mdns_console.send_input('mdns_service_lookup _test2 _tcp -d')
+    mdns_console.get_output('PTR : extern2')
+    dig_app.check_record('extern2._test2._tcp.local', query_type='SRV', expected=True)
+    mdns_console.send_input('mdns_service_instance_set _test2 _tcp extern3 -h delegated -i extern')
+    mdns_console.get_output('ESP_ERR_NOT_FOUND')
+
+
+def test_service_remove_all(mdns_console, dig_app):
+    mdns_console.send_input('mdns_service_remove_all')
+    mdns_console.send_input('mdns_service_lookup _test2 _tcp -d')
+    mdns_console.get_output('No results found!')
+    mdns_console.send_input('mdns_service_lookup _test _tcp')
+    mdns_console.get_output('No results found!')
+    dig_app.check_record('_test._tcp.local', query_type='PTR', expected=False)
+
+
 if __name__ == '__main__':
     pytest.main(['-s', 'test_mdns.py'])

--- a/components/mdns/tests/host_test/pytest_mdns.py
+++ b/components/mdns/tests/host_test/pytest_mdns.py
@@ -147,5 +147,13 @@ def test_service_port_set(mdns_console, dig_app):
     dig_app.check_record('extern._test2._tcp.local', query_type='SRV', expected=True, expect='83')
 
 
+def test_service_subtype(mdns_console, dig_app):
+    dig_app.check_record('local._test._tcp.local', query_type='SRV', expected=True)
+    mdns_console.send_input('mdns_service_subtype _test _tcp _subtest -i local')
+    dig_app.check_record('_subtest._sub._test._tcp.local', query_type='PTR', expected=True)
+    mdns_console.send_input('mdns_service_subtype _test2 _tcp _subtest2 -i extern -h delegated')
+    dig_app.check_record('_subtest2._sub._test2._tcp.local', query_type='PTR', expected=True)
+
+
 if __name__ == '__main__':
     pytest.main(['-s', 'test_mdns.py'])

--- a/components/mdns/tests/host_test/pytest_mdns.py
+++ b/components/mdns/tests/host_test/pytest_mdns.py
@@ -60,11 +60,15 @@ def test_mdns_init(mdns_console, dig_app):
 def test_add_service(mdns_console, dig_app):
     mdns_console.send_input('mdns_service_add _http _tcp 80 -i test_service')
     mdns_console.get_output('MDNS: Service Instance: test_service')
+    mdns_console.send_input('mdns_service_lookup _http _tcp')
+    mdns_console.get_output('PTR : test_service')
     dig_app.check_record('_http._tcp.local', query_type='PTR', expected=True)
 
 
 def test_remove_service(mdns_console, dig_app):
     mdns_console.send_input('mdns_service_remove _http _tcp')
+    mdns_console.send_input('mdns_service_lookup _http _tcp')
+    mdns_console.get_output('No results found!')
     dig_app.check_record('_http._tcp.local', query_type='PTR', expected=False)
 
 


### PR DESCRIPTION
Followup on https://github.com/espressif/esp-protocols/pull/617 for easier reviewing.
Adds simple functional tests for all the below APIs, one commit per item.

## Added

- [x] mdns_service_lookup()
- [x] mdns_delegate_hostname_add()
- [x] mdns_delegate_hostname_remove()
- [x] mdns_lookup_selfhosted_service()
- [x] mdns_service_add_for_host()
- [x] mdns_lookup_delegated_service
- [x] mdns_service_remove_for_host
- [x] mdns_service_txt_set_for_host
- [x] mdns_service_txt_item_remove_for_host
- [x] mdns_service_port_set_for_host
- [x] mdns_service_subtype_add_for_host
- [x] mdns_service_instance_name_set_for_host
- [x] mdns_service_remove_all

