### PR TITLE
Feat/websocket: begin end thread events (IDFGH-13507)

### DIFF
--- a/components/esp_websocket_client/esp_websocket_client.c
+++ b/components/esp_websocket_client/esp_websocket_client.c
@@ -970,6 +970,7 @@ static void esp_websocket_client_task(void *pv)
 
     client->state = WEBSOCKET_STATE_INIT;
     xEventGroupClearBits(client->status_bits, STOPPED_BIT | CLOSE_FRAME_SENT_BIT);
+    esp_websocket_client_dispatch_event(client, WEBSOCKET_EVENT_BEGIN, NULL, 0);
     int read_select = 0;
     while (client->run) {
         if (xSemaphoreTakeRecursive(client->lock, lock_timeout) != pdPASS) {
@@ -1104,6 +1105,7 @@ static void esp_websocket_client_task(void *pv)
         }
     }
 
+    esp_websocket_client_dispatch_event(client, WEBSOCKET_EVENT_FINISH, NULL, 0);
     esp_transport_close(client->transport);
     xEventGroupSetBits(client->status_bits, STOPPED_BIT);
     client->state = WEBSOCKET_STATE_UNKNOW;

--- a/components/esp_websocket_client/examples/linux/main/websocket_linux.c
+++ b/components/esp_websocket_client/examples/linux/main/websocket_linux.c
@@ -25,6 +25,9 @@ static void websocket_event_handler(void *handler_args, esp_event_base_t base, i
 {
     esp_websocket_event_data_t *data = (esp_websocket_event_data_t *)event_data;
     switch (event_id) {
+    case WEBSOCKET_EVENT_BEGIN:
+        ESP_LOGI(TAG, "WEBSOCKET_EVENT_BEGIN");
+        break;
     case WEBSOCKET_EVENT_CONNECTED:
         ESP_LOGI(TAG, "WEBSOCKET_EVENT_CONNECTED");
         break;
@@ -58,6 +61,9 @@ static void websocket_event_handler(void *handler_args, esp_event_base_t base, i
             log_error_if_nonzero("reported from tls stack", data->error_handle.esp_tls_stack_err);
             log_error_if_nonzero("captured as transport's socket errno",  data->error_handle.esp_transport_sock_errno);
         }
+        break;
+    case WEBSOCKET_EVENT_FINISH:
+        ESP_LOGI(TAG, "WEBSOCKET_EVENT_FINISH");
         break;
     }
 }

--- a/components/esp_websocket_client/examples/target/main/websocket_example.c
+++ b/components/esp_websocket_client/examples/target/main/websocket_example.c
@@ -74,6 +74,9 @@ static void websocket_event_handler(void *handler_args, esp_event_base_t base, i
 {
     esp_websocket_event_data_t *data = (esp_websocket_event_data_t *)event_data;
     switch (event_id) {
+    case WEBSOCKET_EVENT_BEGIN:
+        ESP_LOGI(TAG, "WEBSOCKET_EVENT_BEGIN");
+        break;
     case WEBSOCKET_EVENT_CONNECTED:
         ESP_LOGI(TAG, "WEBSOCKET_EVENT_CONNECTED");
         break;
@@ -121,6 +124,9 @@ static void websocket_event_handler(void *handler_args, esp_event_base_t base, i
             log_error_if_nonzero("reported from tls stack", data->error_handle.esp_tls_stack_err);
             log_error_if_nonzero("captured as transport's socket errno",  data->error_handle.esp_transport_sock_errno);
         }
+        break;
+    case WEBSOCKET_EVENT_FINISH:
+        ESP_LOGI(TAG, "WEBSOCKET_EVENT_FINISH");
         break;
     }
 }

--- a/components/esp_websocket_client/include/esp_websocket_client.h
+++ b/components/esp_websocket_client/include/esp_websocket_client.h
@@ -36,6 +36,8 @@ typedef enum {
     WEBSOCKET_EVENT_DATA,           /*!< When receiving data from the server, possibly multiple portions of the packet */
     WEBSOCKET_EVENT_CLOSED,         /*!< The connection has been closed cleanly */
     WEBSOCKET_EVENT_BEFORE_CONNECT, /*!< The event occurs before connecting */
+    WEBSOCKET_EVENT_BEGIN,          /*!< The event occurs once after thread creation, before event loop */
+    WEBSOCKET_EVENT_FINISH,         /*!< The event occurs once after event loop, before thread destruction */
     WEBSOCKET_EVENT_MAX
 } esp_websocket_event_id_t;
 

--- a/docs/esp_websocket_client/en/index.rst
+++ b/docs/esp_websocket_client/en/index.rst
@@ -91,10 +91,12 @@ For more options on :cpp:type:`esp_websocket_client_config_t`, please refer to A
 
 Events
 ------
+* `WEBSOCKET_EVENT_BEFORE_CONNECT`: The client is about to connect.
 * `WEBSOCKET_EVENT_CONNECTED`: The client has successfully established a connection to the server. The client is now ready to send and receive data. Contains no event data.
-* `WEBSOCKET_EVENT_DISCONNECTED`: The client has aborted the connection due to the transport layer failing to read data, e.g. because the server is unavailable. Contains no event data.
 * `WEBSOCKET_EVENT_DATA`: The client has successfully received and parsed a WebSocket frame. The event data contains a pointer to the payload data, the length of the payload data as well as the opcode of the received frame. A message may be fragmented into multiple events if the length exceeds the buffer size. This event will also be posted for non-payload frames, e.g. pong or connection close frames.
-* `WEBSOCKET_EVENT_ERROR`: Not used in the current implementation of the client.
+* `WEBSOCKET_EVENT_ERROR`: The client has experienced an error. Examples include transport write or read failures.
+* `WEBSOCKET_EVENT_DISCONNECTED`: The client has aborted the connection due to the transport layer failing to read data, e.g. because the server is unavailable. Contains no event data.
+* `WEBSOCKET_EVENT_CLOSED`: The connection has been closed cleanly.
 
 If the client handle is needed in the event handler it can be accessed through the pointer passed to the event handler:
 

--- a/docs/esp_websocket_client/en/index.rst
+++ b/docs/esp_websocket_client/en/index.rst
@@ -91,12 +91,14 @@ For more options on :cpp:type:`esp_websocket_client_config_t`, please refer to A
 
 Events
 ------
+* `WEBSOCKET_EVENT_BEGIN': The client thread is running.
 * `WEBSOCKET_EVENT_BEFORE_CONNECT`: The client is about to connect.
 * `WEBSOCKET_EVENT_CONNECTED`: The client has successfully established a connection to the server. The client is now ready to send and receive data. Contains no event data.
 * `WEBSOCKET_EVENT_DATA`: The client has successfully received and parsed a WebSocket frame. The event data contains a pointer to the payload data, the length of the payload data as well as the opcode of the received frame. A message may be fragmented into multiple events if the length exceeds the buffer size. This event will also be posted for non-payload frames, e.g. pong or connection close frames.
 * `WEBSOCKET_EVENT_ERROR`: The client has experienced an error. Examples include transport write or read failures.
 * `WEBSOCKET_EVENT_DISCONNECTED`: The client has aborted the connection due to the transport layer failing to read data, e.g. because the server is unavailable. Contains no event data.
 * `WEBSOCKET_EVENT_CLOSED`: The connection has been closed cleanly.
+* `WEBSOCKET_EVENT_FINISH': The client thread is about to exit.
 
 If the client handle is needed in the event handler it can be accessed through the pointer passed to the event handler:
 


### PR DESCRIPTION
Add two new events to signal the start and end of websocket thread operation.

Also update the websocket event handler documentation, as it was missing a few.