### PR TITLE
[mdns]: Fix recent issues on v1.4 reported by Coverity

### DIFF
--- a/components/mdns/mdns.c
+++ b/components/mdns/mdns.c
@@ -5956,11 +5956,6 @@ static mdns_txt_item_t *_copy_mdns_txt_items(mdns_txt_linked_item_t *items, uint
     for (mdns_txt_linked_item_t *tmp = items; tmp != NULL; tmp = tmp->next) {
         ret_index++;
     }
-    if (ret_index == 0) {
-        *txt_count = 0;
-        *txt_value_len = NULL;
-        return NULL;
-    }
     *txt_count = ret_index;
     if (ret_index == 0) {   // handle empty TXT
         *txt_value_len = NULL;

--- a/components/mdns/mdns.c
+++ b/components/mdns/mdns.c
@@ -6398,22 +6398,14 @@ esp_err_t mdns_service_remove_for_host(const char *instance, const char *service
             if (_mdns_service_match(a->service, service, proto, hostname)) {
                 if (_mdns_server->services != a) {
                     b->next = a->next;
-                    _mdns_send_bye(&a, 1, false);
-                    _mdns_remove_scheduled_service_packets(a->service);
-                    _mdns_free_service(a->service);
-                    free(a);
-                    a = b->next;
-                    continue;
                 } else {
                     _mdns_server->services = a->next;
-                    _mdns_send_bye(&a, 1, false);
-                    _mdns_remove_scheduled_service_packets(a->service);
-                    _mdns_free_service(a->service);
-                    free(a);
-                    a = _mdns_server->services;
-                    b = a;
-                    continue;
                 }
+                _mdns_send_bye(&a, 1, false);
+                _mdns_remove_scheduled_service_packets(a->service);
+                _mdns_free_service(a->service);
+                free(a);
+                break;
             }
             b = a;
             a = a->next;


### PR DESCRIPTION
##    fix(mdns): Fixed dead-code reported by coverity
    
Fixes CID 467738: Logically dead code in mdns.c, _copy_mdns_txt_items
Introduced by probably by a merge confilict, as the fix was added in
two separate PRs, merging d4da9cb0 first and 8a690503 later

##     fix(mdns): Fix use after free reported by coverity
    
Fixes CID 467739: Use after free in mdns.c, mdns_service_remove_for_host
We should look only for one match in the service list, since if we
assume there could be aliases, we might free one and reference the
other.
