### PR TITLE
[modem]: Add ability to change ESP_MODEM_C_API_STR_MAX from Kconfig (IDFGH-13668)

### DIFF
--- a/components/esp_modem/Kconfig
+++ b/components/esp_modem/Kconfig
@@ -63,4 +63,11 @@ menu "esp-modem"
             dce_factory::Factory::create_unique_dce_from<CustomModule, DCE*>(dce_config, std::move(dte), netif)
             Please refer to the pppos_client example for more details.
 
+    config ESP_MODEM_C_API_STR_MAX
+        int "Size in bytes for response from AT commands returning textual values (C-API)"
+        default 128
+        help
+            Some AT commands returns textrual values which C-API copy as c-string to user allocated space,
+            it also truncates the output data to this size. Increase this if some AT answers are truncated.
+
 endmenu

--- a/components/esp_modem/examples/pppos_client/main/custom_module.hpp
+++ b/components/esp_modem/examples/pppos_client/main/custom_module.hpp
@@ -56,7 +56,7 @@ DCE *esp_modem_create_custom_dce(const esp_modem_dce_config_t *dce_config, std::
 /**
  * @brief This API is only needed for extending standard C-API, since we added get_time() method to our CustomModule
  *
- * @note This header is included from esp_modem_c_api.cpp, so it could use ESP_MODEM_C_API_STR_MAX macro
+ * @note This header is included from esp_modem_c_api.cpp, so it could use CONFIG_ESP_MODEM_C_API_STR_MAX macro
  * indicating maximum C-API string size
  *
  * @note In order to access the newly added API get_time(), we have to static_cast<> the GenericModule from DCE
@@ -70,10 +70,10 @@ extern "C" esp_err_t esp_modem_get_time(esp_modem_dce_t *dce_wrap, char *p_time)
     if (dce_wrap == nullptr || dce_wrap->dce == nullptr) {
         return ESP_ERR_INVALID_ARG;
     }
-    std::string time{ESP_MODEM_C_API_STR_MAX};
+    std::string time{CONFIG_ESP_MODEM_C_API_STR_MAX};
     auto ret = command_response_to_esp_err(static_cast<SIM7600_WITH_TIME *>(dce_wrap->dce->get_module())->get_time(time));
     if (ret == ESP_OK && !time.empty()) {
-        strlcpy(p_time, time.c_str(), ESP_MODEM_C_API_STR_MAX);
+        strlcpy(p_time, time.c_str(), CONFIG_ESP_MODEM_C_API_STR_MAX);
     }
     return ret;
 }

--- a/components/esp_modem/src/esp_modem_c_api.cpp
+++ b/components/esp_modem/src/esp_modem_c_api.cpp
@@ -16,10 +16,6 @@
 #include "exception_stub.hpp"
 #include "esp_private/c_api_wrapper.hpp"
 
-#ifndef ESP_MODEM_C_API_STR_MAX
-#define ESP_MODEM_C_API_STR_MAX 128
-#endif
-
 #ifndef HAVE_STRLCPY
 size_t strlcpy(char *dest, const char *src, size_t len);
 #endif
@@ -180,7 +176,7 @@ extern "C" esp_err_t esp_modem_at(esp_modem_dce_t *dce_wrap, const char *at, cha
     std::string at_str(at);
     auto ret = command_response_to_esp_err(dce_wrap->dce->at(at_str, out, timeout));
     if ((p_out != NULL) && (!out.empty())) {
-        strlcpy(p_out, out.c_str(), ESP_MODEM_C_API_STR_MAX);
+        strlcpy(p_out, out.c_str(), CONFIG_ESP_MODEM_C_API_STR_MAX);
     }
     return ret;
 }
@@ -201,7 +197,7 @@ extern "C" esp_err_t esp_modem_get_imsi(esp_modem_dce_t *dce_wrap, char *p_imsi)
     std::string imsi;
     auto ret = command_response_to_esp_err(dce_wrap->dce->get_imsi(imsi));
     if (ret == ESP_OK && !imsi.empty()) {
-        strlcpy(p_imsi, imsi.c_str(), ESP_MODEM_C_API_STR_MAX);
+        strlcpy(p_imsi, imsi.c_str(), CONFIG_ESP_MODEM_C_API_STR_MAX);
     }
     return ret;
 }
@@ -214,7 +210,7 @@ extern "C" esp_err_t esp_modem_at_raw(esp_modem_dce_t *dce_wrap, const char *cmd
     std::string out;
     auto ret = command_response_to_esp_err(dce_wrap->dce->at_raw(cmd, out, pass, fail, timeout));
     if ((p_out != NULL) && (!out.empty())) {
-        strlcpy(p_out, out.c_str(), ESP_MODEM_C_API_STR_MAX);
+        strlcpy(p_out, out.c_str(), CONFIG_ESP_MODEM_C_API_STR_MAX);
     }
     return ret;
 }
@@ -244,7 +240,7 @@ extern "C" esp_err_t esp_modem_get_imei(esp_modem_dce_t *dce_wrap, char *p_imei)
     std::string imei;
     auto ret = command_response_to_esp_err(dce_wrap->dce->get_imei(imei));
     if (ret == ESP_OK && !imei.empty()) {
-        strlcpy(p_imei, imei.c_str(), ESP_MODEM_C_API_STR_MAX);
+        strlcpy(p_imei, imei.c_str(), CONFIG_ESP_MODEM_C_API_STR_MAX);
     }
     return ret;
 }
@@ -258,7 +254,7 @@ extern "C" esp_err_t esp_modem_get_operator_name(esp_modem_dce_t *dce_wrap, char
     int act;
     auto ret = command_response_to_esp_err(dce_wrap->dce->get_operator_name(name, act));
     if (ret == ESP_OK && !name.empty()) {
-        strlcpy(p_name, name.c_str(), ESP_MODEM_C_API_STR_MAX);
+        strlcpy(p_name, name.c_str(), CONFIG_ESP_MODEM_C_API_STR_MAX);
         *p_act = act;
     }
     return ret;
@@ -272,7 +268,7 @@ extern "C" esp_err_t esp_modem_get_module_name(esp_modem_dce_t *dce_wrap, char *
     std::string name;
     auto ret = command_response_to_esp_err(dce_wrap->dce->get_module_name(name));
     if (ret == ESP_OK && !name.empty()) {
-        strlcpy(p_name, name.c_str(), ESP_MODEM_C_API_STR_MAX);
+        strlcpy(p_name, name.c_str(), CONFIG_ESP_MODEM_C_API_STR_MAX);
     }
     return ret;
 }

--- a/docs/esp_modem/en/api_docs.rst
+++ b/docs/esp_modem/en/api_docs.rst
@@ -43,7 +43,7 @@ These functions are the actual commands to communicate with the modem using AT c
 
 Note that the functions which implement AT commands returning textual values use plain ``char *``
 pointer as the return value. The API expects the output data to point to user allocated space of at least
-``ESP_MODEM_C_API_STR_MAX`` (64 by default) bytes, it also truncates the output data to this size.
+``CONFIG_ESP_MODEM_C_API_STR_MAX`` (128 by default) bytes, it also truncates the output data to this size.
 
 .. doxygenfile:: esp_modem_api_commands.h
 


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description
This PR introduce ability to change ESP_MODEM_C_API_STR_MAX from Kconfig (idf.py menuconfig).

In esp_modem in C-API there is ESP_MODEM_C_API_STR_MAX which defines max size of AT response returned to user.
There is no obvious way to increase this size. Some workaround was found in #184, but I think use Kconfig option is more clear and straightforward.

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related
#184
#624
<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
