### PR TITLE
[modem]: Fix arguments names when spawn esp_modem_xxx declarations

### DIFF
--- a/components/esp_modem/include/generate/esp_modem_command_declare_helper.inc
+++ b/components/esp_modem/include/generate/esp_modem_command_declare_helper.inc
@@ -3,9 +3,9 @@
 // Parameters
 // * handle different parameters for C++ and C API
 // * make parameter unique names, so they could be easily referenced and forwarded
-#define _ARG(param, name) param
 #define INT_IN(param, name) int  _ARG(param, name)
 #ifdef __cplusplus
+#define _ARG(param, name) param
 #include <string>
 #define STRING_IN(param, name) const std::string& _ARG(param, name)
 #define STRING_OUT(param, name) std::string& _ARG(param, name)
@@ -16,6 +16,7 @@
 
 #define STRUCT_OUT(struct_name, p1)  struct_name& p1
 #else
+#define _ARG(param, name) name
 #define STRING_IN(param, name) const char* _ARG(param, name)
 #define STRING_OUT(param, name) char* _ARG(param, name)
 #define BOOL_IN(param, name) const bool _ARG(param, name)


### PR DESCRIPTION
## Description

This PR fixes arguments names which auto-declared by `DECLARE_ALL_COMMAND_APIS()` (`"include/generate/esp_modem_command_declare.inc"`). This time with clean commit history.

For example, it would be:
`esp_err_t esp_modem_send_sms(esp_modem_dce_t *dce, const char *number, const char *message);`
instead of:
`esp_err_t esp_modem_send_sms(esp_modem_dce_t *dce, const char *p1, const char *p2);`

Also, it does clear auto completions and tips in IDE (VS Code + ESP-IDF):
<img src="https://github.com/user-attachments/assets/83569497-cd62-4daa-9a28-9d3f2afb959f" width=500px>

