### PR TITLE
[modem] Minor change to exit_cmux behavior (IDFGH-13724) (IDFGH-13734)

### DIFF
--- a/components/esp_modem/src/esp_modem_dte.cpp
+++ b/components/esp_modem/src/esp_modem_dte.cpp
@@ -156,12 +156,10 @@ bool DTE::exit_cmux()
     if (!cmux_term) {
         return false;
     }
-    if (!cmux_term->deinit()) {
-        return false;
-    }
+    const bool success = cmux_term->deinit();
     exit_cmux_internal();
     cmux_term.reset();
-    return true;
+    return success;
 }
 
 void DTE::exit_cmux_internal()


### PR DESCRIPTION
Fix to support forced transitions from CMUX mode to command mode as per the issue "Force exit CMUX does not actually work (IDFGH-13724) #650"