### PR TITLE
[mosquitto]: Fix incorrect upstream mosqutto submodule path

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "components/asio/asio"]
 	path = components/asio/asio
 	url = https://github.com/espressif/asio
-[submodule "components/mosq/mosquitto"]
+[submodule "components/mosquitto/mosquitto"]
 	path = components/mosquitto/mosquitto
 	url = https://github.com/eclipse/mosquitto


### PR DESCRIPTION
Fixing CI docs build https://github.com/espressif/esp-protocols/actions/runs/11051203708/job/30700593570
caused by moving `mosq` -> `mosquitto`