### PR TITLE
[wifi_remote]: Bump 0.3.0 -> 0.4.0

### DIFF
--- a/components/esp_wifi_remote/.cz.yaml
+++ b/components/esp_wifi_remote/.cz.yaml
@@ -3,6 +3,6 @@ commitizen:
   bump_message: 'bump(wifi_remote): $current_version -> $new_version'
   pre_bump_hooks: python ../../ci/changelog.py esp_wifi_remote
   tag_format: wifi_remote-v$version
-  version: 0.3.0
+  version: 0.4.0
   version_files:
   - idf_component.yml

--- a/components/esp_wifi_remote/CHANGELOG.md
+++ b/components/esp_wifi_remote/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [0.4.0](https://github.com/espressif/esp-protocols/commits/wifi_remote-v0.4.0)
+
+### Features
+
+- Make esp_hosted default RPC library ([1b62adbd](https://github.com/espressif/esp-protocols/commit/1b62adbd))
+- Add build test for current IDF examples ([50c113e4](https://github.com/espressif/esp-protocols/commit/50c113e4))
+- Support for IDF v5.3 in a separate directory ([bde97203](https://github.com/espressif/esp-protocols/commit/bde97203))
+- Support for IDF v5.4 via a separate dir ([e9ac41e1](https://github.com/espressif/esp-protocols/commit/e9ac41e1))
+- Add slave selection and peview targets ([345c4577](https://github.com/espressif/esp-protocols/commit/345c4577))
+
+### Bug Fixes
+
+- Fix CMake to use inherent IDF build vars ([c454ec09](https://github.com/espressif/esp-protocols/commit/c454ec09))
+- Update per v5.4 espressif/esp-idf@97e42349 ([ff5dac70](https://github.com/espressif/esp-protocols/commit/ff5dac70))
+- Fix CI builds to generate configs per slave selection ([8795d164](https://github.com/espressif/esp-protocols/commit/8795d164))
+- Depend on esp_hosted only on targets with no WiFi ([7ca5ed1d](https://github.com/espressif/esp-protocols/commit/7ca5ed1d))
+- Update per espressif/esp-idf@27f61966 ([2e53b81f](https://github.com/espressif/esp-protocols/commit/2e53b81f))
+- Fix checking API compat against reference dir ([1a57a878](https://github.com/espressif/esp-protocols/commit/1a57a878))
+
 ## [0.3.0](https://github.com/espressif/esp-protocols/commits/wifi_remote-v0.3.0)
 
 ### Features

--- a/components/esp_wifi_remote/idf_component.yml
+++ b/components/esp_wifi_remote/idf_component.yml
@@ -1,4 +1,4 @@
-version: 0.3.0
+version: 0.4.0
 url: https://github.com/espressif/esp-protocols/tree/master/components/esp_wifi_remote
 description: Utility wrapper for esp_wifi functionality on remote targets
 dependencies:


### PR DESCRIPTION
## 0.4.0

### Features

- Make esp_hosted default RPC library (1b62adbd)
- Add build test for current IDF examples (50c113e4)
- Support for IDF v5.3 in a separate directory (bde97203)
- Support for IDF v5.4 via a separate dir (e9ac41e1)
- Add slave selection and peview targets (345c4577)

### Bug Fixes

- Fix CMake to use inherent IDF build vars (c454ec09)
- Update per v5.4 espressif/esp-idf@97e42349 (ff5dac70)
- Fix CI builds to generate configs per slave selection (8795d164)
- Depend on esp_hosted only on targets with no WiFi (7ca5ed1d)
- Update per espressif/esp-idf@27f61966 (2e53b81f)
- Fix checking API compat against reference dir (1a57a878)
