### PR TITLE
[mosquitto]: Fix incorrect link to the component url

### DIFF
--- a/components/mosquitto/idf_component.yml
+++ b/components/mosquitto/idf_component.yml
@@ -1,5 +1,5 @@
 version: "2.0.28~0"
-url: https://github.com/espressif/esp-protocols/tree/master/components/mosq
+url: https://github.com/espressif/esp-protocols/tree/master/components/mosquitto
 description: The component provides a simple ESP32 port of mosquitto broker
 dependencies:
   idf: '>=5.1'


### PR DESCRIPTION
followup on the https://github.com/espressif/esp-protocols/pull/610

* the PR didn't produce any `idf_component.yml` changes and thus publishing was skipped
* incorrect link to the development repo
