### PR TITLE
Introduce async websocket stop

### DIFF
--- a/components/esp_websocket_client/include/esp_websocket_client.h
+++ b/components/esp_websocket_client/include/esp_websocket_client.h
@@ -213,6 +213,38 @@ esp_err_t esp_websocket_client_start(esp_websocket_client_handle_t client);
 esp_err_t esp_websocket_client_stop(esp_websocket_client_handle_t client);
 
 /**
+ * @brief      Initiate an asynchronus stop of the WebSocket connection without
+ *             websocket closing handshake
+ *
+ * This API initiates a non-blocking asynchronus stop of ws client. This will
+ * close TCP connection later directly without sending close frames. This is
+ * method is similar to esp_websocket_client_stop() but does not block the calling
+ * task. It is required to then later periodically call
+ * esp_websocket_client_is_already_stopped() to find out when its done and to
+ * finalize the closing of the websocket client.
+ *
+ *  Notes:
+ *  - Cannot be called from the websocket event handler
+ *
+ * @param[in]  client  The client
+ *
+ * @return     esp_err_t
+ */
+esp_err_t esp_websocket_client_initiate_stop(esp_websocket_client_handle_t client);
+
+/**
+ * @brief      After an asynchronus stop was initiated, this method returns if it is done already.
+ *             If this method returns true, it also performed some final cleanup. It should then not
+ *             be called anymore unless esp_websocket_client_initiate_stop() is called again.
+ *
+ * @param[in]  client  The client
+ *
+ * @return
+ *     - bool if it is done or not
+ */
+bool esp_websocket_client_is_already_stopped(esp_websocket_client_handle_t client);
+
+/**
  * @brief      Destroy the WebSocket connection and free all resources.
  *             This function must be the last function to call for an session.
  *             It is the opposite of the esp_websocket_client_init function and must be called with the same handle as input that a esp_websocket_client_init call returned.


### PR DESCRIPTION
We were experiencing long main task hangups, when we call the stop method on the websocket_client, because it waits until the receiving thread finally reaches its timeout of 10-20 seconds.

This new async stop method allows us to continue our work in the main task and keep the led animations going for example.

Let me know what you think about this improvement :)