### PR TITLE
Support for CONSOLE_USB_CDC and CONSOLE_USB_SERIAL_JTAG in modem_console example. (IDFGH-13937)

### DIFF
--- a/components/esp_modem/examples/modem_console/main/console_helper.cpp
+++ b/components/esp_modem/examples/modem_console/main/console_helper.cpp
@@ -68,7 +68,11 @@ void ConsoleCommand::RegisterCommand(const char *command, const char *help, cons
         .help = help,
         .hint = nullptr,
         .func = command_func_pts[last_command],
-        .argtable = &arg_table[0]
+        .argtable = &arg_table[0],
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)
+        .func_w_context = nullptr,
+        .context = nullptr
+#endif
     };
     ESP_ERROR_CHECK(esp_console_cmd_register(&command_def));
     last_command++;

--- a/components/esp_modem/examples/modem_console/main/modem_console_main.cpp
+++ b/components/esp_modem/examples/modem_console/main/modem_console_main.cpp
@@ -205,8 +205,24 @@ extern "C" void app_main(void)
 
     // init console REPL environment
     esp_console_repl_config_t repl_config = ESP_CONSOLE_REPL_CONFIG_DEFAULT();
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)
+#if defined(CONFIG_ESP_CONSOLE_UART_DEFAULT) || defined(CONFIG_ESP_CONSOLE_UART_CUSTOM)
+#endif
+
     esp_console_dev_uart_config_t uart_config = ESP_CONSOLE_DEV_UART_CONFIG_DEFAULT();
     ESP_ERROR_CHECK(esp_console_new_repl_uart(&uart_config, &repl_config, &s_repl));
+
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)
+#elif defined(CONFIG_ESP_CONSOLE_USB_CDC)
+    esp_console_dev_usb_cdc_config_t hw_config = ESP_CONSOLE_DEV_CDC_CONFIG_DEFAULT();
+    ESP_ERROR_CHECK(esp_console_new_repl_usb_cdc(&hw_config, &repl_config, &s_repl));
+#elif defined(CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG)
+    esp_console_dev_usb_serial_jtag_config_t hw_config = ESP_CONSOLE_DEV_USB_SERIAL_JTAG_CONFIG_DEFAULT();
+    ESP_ERROR_CHECK(esp_console_new_repl_usb_serial_jtag(&hw_config, &repl_config, &s_repl));
+#else
+#error Unsupported console type
+#endif
+#endif // ESP_IDF_VERSION
 
     switch (esp_sleep_get_wakeup_cause()) {
     case ESP_SLEEP_WAKEUP_TIMER:


### PR DESCRIPTION
## Description

Added support for CONFIG_ESP_CONSOLE_USB_CDC and CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG

added support for CONSOLE_USB_CDC and CONSOLE_USB_SERIAL_JTAG to modem_console example.

## Related

As requested in https://github.com/espressif/esp-protocols/issues/669#issuecomment-2431010503 by @david-cermak .

## Testing

Tested on an ESP32-s3 with a SIM 7670G.

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
