### PR TITLE
[mdns]: Prevent deadlock when deleting a browse request (IDFGH-13947)

### DIFF
--- a/components/mdns/mdns.c
+++ b/components/mdns/mdns.c
@@ -6996,7 +6996,7 @@ static void _mdns_browse_item_free(mdns_browse_t *browse)
     free(browse->service);
     free(browse->proto);
     if (browse->result) {
-        mdns_query_results_free(browse->result);
+        _mdns_query_results_free(browse->result);
     }
     free(browse);
 }


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

With v1.3.0 the mDNS component supports continuous browsing for services by calling `mdns_browse_new()`. In v1.4.0 whenever one wants to stop browsing for a specific service via `mdns_browse_delete()` there is a deadlock resulting in underlying mdns task to block forever, caused by the API locking introduced with the "Fix API race" commits for v1.4.0.

Background:
API requests are generally serialized into the mdns task - this also applies to the ` mdns_browse_...` calls. The request to stop browsing for a service is put into the mdns task queue and is actually handled by the task via `_mdns_execute_action()` -> `_mdns_browse_finish()`. There it performs a linear search through the queue of pending browse requests to find a matching mDNS service/protocol tuple. Upon match it deletes the item via `_mdns_browse_item_free()` what calls `mdns_query_results_free()`. The latter is a public API call that tries to acquire the lock semaphore. Unfortunately the initial call to `_mdns_execute_action()` in the mdns task is already within a locked section. So in result the `mdns_query_results_free()` method waits endlessly for the semaphore getting released.

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

<!--
## Related
-->

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

<!--
## Testing
-->

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] ~~Documentation is updated as needed.~~ (no functional change)
- [ ] ~~Tests are updated or added as necessary.~~ (no functional change)
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
