### PR TITLE
fix(asio): Fix docs to link examples correctly

### DIFF
--- a/docs/asio/en/index.rst
+++ b/docs/asio/en/index.rst
@@ -31,13 +31,13 @@ Internal asio settings for ESP include
 
 Application Example
 -------------------
-ESP examples are based on standard asio :example:`examples <../../../components/asio/examples>`:
+ESP examples are based on standard asio :component:`asio/examples`:
 
-- :example:`asio_chat <../../../components/asio/examples/asio_chat>`
-- :example:`async_request <../../../components/asio/examples/async_request>`
-- :example:`socks4 <../../../components/asio/examples/socks4>`
-- :example:`ssl_client_server <../../../components/asio/examples/ssl_client_server>`
-- :example:`tcp_echo_server <../../../components/asio/examples/tcp_echo_server>`
-- :example:`udp_echo_server <../../../components/asio/examples/udp_echo_server>`
+- :component:`asio/examples/asio_chat`
+- :component:`asio/examples/async_request`
+- :component:`asio/examples/socks4`
+- :component:`asio/examples/ssl_client_server`
+- :component:`asio/examples/tcp_echo_server`
+- :component:`asio/examples/udp_echo_server`
 
 Please refer to the specific example README.md for details

--- a/docs/asio/generate_docs
+++ b/docs/asio/generate_docs
@@ -2,7 +2,7 @@
 
 rm -rf docs
 
-build-docs --target esp32 --language en
+build-docs --target esp32 --language en --project-path ../../
 
 mkdir -p docs/generic
 mv _build/en/esp32/html docs/generic


### PR DESCRIPTION
Reported by Michael: Links to examples do not work: https://docs.espressif.com/projects/esp-protocols/asio/docs/latest/index.html#application-example

Note: there's a minor bug in `esp-docs`, otherwise I'd just set the project dir to `components/asio` and use `:example:` tags directly (I'll post the fix to esp-docs if I have time)