### PR TITLE
fix(websocket): use proper interface to delete semaphore

### DIFF
--- a/components/esp_websocket_client/esp_websocket_client.c
+++ b/components/esp_websocket_client/esp_websocket_client.c
@@ -434,7 +434,7 @@ static void destroy_and_free_resources(esp_websocket_client_handle_t client)
     if (client->transport_list) {
         esp_transport_list_destroy(client->transport_list);
     }
-    vQueueDelete(client->lock);
+    vSemaphoreDelete(client->lock);
     free(client->tx_buffer);
     free(client->rx_buffer);
     free(client->errormsg_buffer);


### PR DESCRIPTION
## Description

Switch WebSocket client to use vSemaphoreDelete() to delete its mutex.

## Testing

No testing was done.

## Checklist

Before submitting a Pull Request, please ensure the following:

- [X] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [X] Documentation is updated as needed.
- [X] Tests are updated or added as necessary.
- [X] Code is well-commented, especially in complex areas.
- [X] Git history is clean — commits are squashed to the minimum necessary.
