### PR TITLE
fix(websocket): fix example buffer leak

### DIFF
--- a/components/esp_websocket_client/examples/target/main/websocket_example.c
+++ b/components/esp_websocket_client/examples/target/main/websocket_example.c
@@ -222,6 +222,7 @@ static void websocket_app_start(void)
     char *long_data = malloc(size);
     memset(long_data, 'a', size);
     esp_websocket_client_send_text(client, long_data, size, portMAX_DELAY);
+    free(long_data);
 
     xSemaphoreTake(shutdown_sema, portMAX_DELAY);
     esp_websocket_client_close(client, portMAX_DELAY);


### PR DESCRIPTION
## Description

Free allocated buffer in websocket client example application to balance heap-trace.

## Testing

TODO: in-progress

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [X] Documentation is updated as needed.
- [X] Tests are updated or added as necessary.
- [X] Code is well-commented, especially in complex areas.
- [X] Git history is clean — commits are squashed to the minimum necessary.
