### PR TITLE
[mdns]: Bump to v1.4.2

### DIFF
--- a/components/mdns/.cz.yaml
+++ b/components/mdns/.cz.yaml
@@ -3,6 +3,6 @@ commitizen:
   bump_message: 'bump(mdns): $current_version -> $new_version'
   pre_bump_hooks: python ../../ci/changelog.py mdns
   tag_format: mdns-v$version
-  version: 1.4.1
+  version: 1.4.2
   version_files:
   - idf_component.yml

--- a/components/mdns/CHANGELOG.md
+++ b/components/mdns/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [1.4.2](https://github.com/espressif/esp-protocols/commits/mdns-v1.4.2)
+
+### Features
+
+- support update subtype ([062b8dca](https://github.com/espressif/esp-protocols/commit/062b8dca))
+
+### Updated
+
+- chore(mdns): Add more info to idf_component.yml ([4a1cb65c](https://github.com/espressif/esp-protocols/commit/4a1cb65c))
+
 ## [1.4.1](https://github.com/espressif/esp-protocols/commits/mdns-v1.4.1)
 
 ### Features

--- a/components/mdns/idf_component.yml
+++ b/components/mdns/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.4.1"
+version: "1.4.2"
 description: "Multicast UDP service used to provide local network service and host discovery."
 url: "https://github.com/espressif/esp-protocols/tree/master/components/mdns"
 issues: "https://github.com/espressif/esp-protocols/issues"

--- a/components/mdns/idf_component.yml
+++ b/components/mdns/idf_component.yml
@@ -1,6 +1,9 @@
 version: "1.4.1"
-description: mDNS
-url: https://github.com/espressif/esp-protocols/tree/master/components/mdns
+description: "Multicast UDP service used to provide local network service and host discovery."
+url: "https://github.com/espressif/esp-protocols/tree/master/components/mdns"
+issues: "https://github.com/espressif/esp-protocols/issues"
+documentation: "https://docs.espressif.com/projects/esp-protocols/mdns/docs/latest/en/index.html"
+repository: "https://github.com/espressif/esp-protocols.git"
 dependencies:
   idf:
     version: ">=5.0"


### PR DESCRIPTION
* Publishes recent changes from https://github.com/espressif/esp-protocols/pull/693
* Addresses component manager warnings from https://github.com/espressif/esp-protocols/actions/runs/11834499548/job/32975304348
---

## [1.4.2](https://github.com/espressif/esp-protocols/commits/mdns-v1.4.2)

### Features

- support update subtype ([062b8dca](https://github.com/espressif/esp-protocols/commit/062b8dca))

### Updated

- chore(mdns): Add more info to idf_component.yml ([4a1cb65c](https://github.com/espressif/esp-protocols/commit/4a1cb65c))
