### PR TITLE
[sock-utils]: Bump 0.1 -> 0.2

### DIFF
--- a/components/sock_utils/.cz.yaml
+++ b/components/sock_utils/.cz.yaml
@@ -3,6 +3,6 @@ commitizen:
   bump_message: 'bump(sockutls): $current_version -> $new_version'
   pre_bump_hooks: python ../../ci/changelog.py sock_utils
   tag_format: sock_utils-v$version
-  version: 0.1.0
+  version: 0.2.0
   version_files:
   - idf_component.yml

--- a/components/sock_utils/CHANGELOG.md
+++ b/components/sock_utils/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.2.0](https://github.com/espressif/esp-protocols/commits/sock_utils-v0.2.0)
+
+### Features
+
+- Declare socketpair and gai_strerror via standard headers ([b090a3cb](https://github.com/espressif/esp-protocols/commit/b090a3cb))
+- Add support for gethostname() ([f7c0b756](https://github.com/espressif/esp-protocols/commit/f7c0b756))
+
 ## [0.1.0](https://github.com/espressif/esp-protocols/commits/sock_utils-v0.1.0)
 
 ### Features

--- a/components/sock_utils/CMakeLists.txt
+++ b/components/sock_utils/CMakeLists.txt
@@ -5,3 +5,12 @@ idf_component_register(SRCS "src/getnameinfo.c"
                             "src/gethostname.c"
                        INCLUDE_DIRS "include"
                        PRIV_REQUIRES lwip esp_netif)
+
+# To support declarations from standard headers in lwip component
+# - socket pair from lwip/sockets.h
+# - gai_strerror from lwip/netdb.h
+# also need to make lwip depend on the sock_utils lib
+idf_component_get_property(lwip lwip COMPONENT_LIB)
+target_compile_definitions(${lwip} PUBLIC LWIP_SOCKET_HAS_SOCKETPAIR=1)
+target_compile_definitions(${lwip} PUBLIC LWIP_NETDB_HAS_GAI_STRERROR=1)
+target_link_libraries(${lwip} PUBLIC ${COMPONENT_LIB})

--- a/components/sock_utils/README.md
+++ b/components/sock_utils/README.md
@@ -6,13 +6,17 @@ This component provides simplified implementations of common socket-related util
 ## Supported Functions
 
 
-| API              | Description                                                 | Limitations                                                       |
-|------------------|-------------------------------------------------------------|-------------------------------------------------------------------|
-| `ifaddrs()`      | Retrieves interface addresses using `esp_netif`             | IPv4 addresses only                                               |
-| `socketpair()`   | Creates a pair of connected sockets using `lwIP` loopback stream sockets | IPv4 sockets only                                    |
-| `pipe()`         | Wraps `socketpair()` to provide unidirectional pipe-like functionality | Uses bidirectional sockets in place of true pipes  |
-| `getnameinfo()`  | Converts IP addresses to human-readable form using `lwIP`'s `inet_ntop()` | IPv4 only; supports `NI_NUMERICHOST` and `NI_NUMERICSERV` flags only |
-| `gai_strerror()` | Returns error code as a string                              | Simple numeric string representation only                         |
-| `gethostname()`  | Returns lwip netif hostname                                 | Not a system-wide hostname, but interface specific hostname       |
+| API                | Description                                                 | Limitations                                                       | Declared in                            |
+|--------------------|-------------------------------------------------------------|-------------------------------------------------------------------|----------------------------------------|
+| `ifaddrs()`        | Retrieves interface addresses using `esp_netif`             | IPv4 addresses only                                               | `ifaddrs.h`                            |
+| `socketpair()` *)  | Creates a pair of connected sockets using `lwIP` loopback stream sockets | IPv4 sockets only                                    | `socketpair.h`, `sys/socket.h` **)     |
+| `pipe()`       *) | Wraps `socketpair()` to provide unidirectional pipe-like functionality | Uses bidirectional sockets in place of true pipes  | `socketpair.h`, `unistd.h` ***)        |
+| `getnameinfo()`    | Converts IP addresses to human-readable form using `lwIP`'s `inet_ntop()` | IPv4 only; supports `NI_NUMERICHOST` and `NI_NUMERICSERV` flags only | `getnameinfo.h`, `netdb.h` in ESP-IDF  |
+| `gai_strerror()`   | Returns error code as a string                              | Simple numeric string representation only                         | `gai_strerror.h`, `netdb.h` **)        |
+| `gethostname()`    | Returns lwip netif hostname                                 | Not a system-wide hostname, but interface specific hostname       | `gethostname.h`, `unistd.h` in ESP-IDF |
 
-**Note**: `socketpair()` and `pipe()` are built on top of `lwIP` TCP sockets, inheriting the same characteristics. For instance, the maximum transmit buffer size is based on the `TCP_SND_BUF` setting.
+**Notes**:
+
+- **`*)`** `socketpair()` and `pipe()` are built on top of `lwIP` TCP sockets, inheriting the same characteristics. For instance, the maximum transmit buffer size is based on the `TCP_SND_BUF` setting.
+- **`**)`** `socketpair()` and `gai_strerror()` are declared in sock_utils header files, the declaration is propagated to ESP-IDF from v5.5 to the official header files. If you're using older IDF version, you need to manually pre-include related header files from the sock_utils public include directory.
+- **`***)`** `pipe()` is declared in compiler's `sys/unistd.h`.

--- a/components/sock_utils/idf_component.yml
+++ b/components/sock_utils/idf_component.yml
@@ -1,4 +1,4 @@
-version: 0.1.0
+version: 0.2.0
 description: The component provides helper implementation of common system/socket utilities
 url: https://github.com/espressif/esp-protocols/tree/master/components/sock_utils
 dependencies:

--- a/components/sock_utils/include/netdb_macros.h
+++ b/components/sock_utils/include/netdb_macros.h
@@ -32,3 +32,10 @@
 #ifndef AF_UNIX
 #define AF_UNIX         1
 #endif
+
+#ifndef PF_LOCAL
+/*
+ * In POSIX, AF_UNIX and PF_LOCAL are essentially synonymous.
+ */
+#define PF_LOCAL        AF_UNIX
+#endif


### PR DESCRIPTION
## [0.2.0](https://github.com/espressif/esp-protocols/commits/sock_utils-v0.2.0)

### Features

- Declare socketpar and gai-error via standard headers ([7f103572](https://github.com/espressif/esp-protocols/commit/7f103572))
- Add support for gethostname() ([f7c0b756](https://github.com/espressif/esp-protocols/commit/f7c0b756))
