### PR TITLE
[sock-utils] Fix potential macro conflict

### DIFF
--- a/components/sock_utils/.cz.yaml
+++ b/components/sock_utils/.cz.yaml
@@ -3,6 +3,6 @@ commitizen:
   bump_message: 'bump(sockutls): $current_version -> $new_version'
   pre_bump_hooks: python ../../ci/changelog.py sock_utils
   tag_format: sock_utils-v$version
-  version: 0.2.0
+  version: 0.2.1
   version_files:
   - idf_component.yml

--- a/components/sock_utils/CHANGELOG.md
+++ b/components/sock_utils/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.2.1](https://github.com/espressif/esp-protocols/commits/sock_utils-v0.2.1)
+
+### Bug Fixes
+
+- Fix potential macro colission including standard headers ([ade9448c](https://github.com/espressif/esp-protocols/commit/ade9448c))
+
 ## [0.2.0](https://github.com/espressif/esp-protocols/commits/sock_utils-v0.2.0)
 
 ### Features

--- a/components/sock_utils/idf_component.yml
+++ b/components/sock_utils/idf_component.yml
@@ -1,4 +1,4 @@
-version: 0.2.0
+version: 0.2.1
 description: The component provides helper implementation of common system/socket utilities
 url: https://github.com/espressif/esp-protocols/tree/master/components/sock_utils
 dependencies:

--- a/components/sock_utils/include/netdb_macros.h
+++ b/components/sock_utils/include/netdb_macros.h
@@ -5,6 +5,17 @@
  */
 #pragma once
 
+#include "sdkconfig.h"
+#ifndef CONFIG_IDF_TARGET_LINUX
+#include <netinet/in.h>   // For network-related definitions
+#include <sys/socket.h>   // For socket-related definitions
+#include <net/if.h>       // For interface flags (e.g., IFF_UP)
+#include <netdb.h>        // For NI_NUMERICHOST, NI_NUMERICSERV, etc.
+#include <errno.h>        // For EAI_BADFLAGS
+#include <sys/un.h>       // For AF_UNIX
+#include <sys/types.h>    // For PF_LOCAL
+#endif
+
 #ifndef NI_NUMERICHOST
 #define NI_NUMERICHOST  0x1
 #endif


### PR DESCRIPTION
Some macros could be defined already in standard  headers (depending on IDF and compiler version).
Need to pre-include the official headers (since the macros are defined unconditionally).