### PR TITLE
fix(websocket): avoid long waiting time when waiting to auto-reconnect

### DIFF
--- a/components/esp_websocket_client/esp_websocket_client.c
+++ b/components/esp_websocket_client/esp_websocket_client.c
@@ -64,6 +64,7 @@ static const char *TAG = "websocket_client";
 const static int STOPPED_BIT = BIT0;
 const static int CLOSE_FRAME_SENT_BIT = BIT1;   // Indicates that a close frame was sent by the client
 // and we are waiting for the server to continue with clean close
+const static int REQUESTED_STOP_BIT = BIT2;     // Indicates that a client stop has been requested
 
 ESP_EVENT_DEFINE_BASE(WEBSOCKET_EVENTS);
 
@@ -1087,8 +1088,8 @@ static void esp_websocket_client_task(void *pv)
                 xSemaphoreGiveRecursive(client->lock);
             }
         } else if (WEBSOCKET_STATE_WAIT_TIMEOUT == client->state) {
-            // waiting for reconnecting...
-            vTaskDelay(client->wait_timeout_ms / 2 / portTICK_PERIOD_MS);
+            // waiting for reconnection or a request to stop the client...
+            xEventGroupWaitBits(client->status_bits, REQUESTED_STOP_BIT, false, true, client->wait_timeout_ms / 2 / portTICK_PERIOD_MS);
         } else if (WEBSOCKET_STATE_CLOSING == client->state &&
                    (CLOSE_FRAME_SENT_BIT & xEventGroupGetBits(client->status_bits))) {
             ESP_LOGD(TAG, " Waiting for TCP connection to be closed by the server");
@@ -1139,7 +1140,7 @@ esp_err_t esp_websocket_client_start(esp_websocket_client_handle_t client)
         ESP_LOGE(TAG, "Error create websocket task");
         return ESP_FAIL;
     }
-    xEventGroupClearBits(client->status_bits, STOPPED_BIT | CLOSE_FRAME_SENT_BIT);
+    xEventGroupClearBits(client->status_bits, STOPPED_BIT | CLOSE_FRAME_SENT_BIT | REQUESTED_STOP_BIT);
     ESP_LOGI(TAG, "Started");
     return ESP_OK;
 }
@@ -1163,6 +1164,7 @@ esp_err_t esp_websocket_client_stop(esp_websocket_client_handle_t client)
 
 
     client->run = false;
+    xEventGroupSetBits(client->status_bits, REQUESTED_STOP_BIT);
     xEventGroupWaitBits(client->status_bits, STOPPED_BIT, false, true, portMAX_DELAY);
     client->state = WEBSOCKET_STATE_UNKNOW;
     return ESP_OK;
@@ -1218,6 +1220,7 @@ static esp_err_t esp_websocket_client_close_with_optional_body(esp_websocket_cli
 
     // If could not close gracefully within timeout, stop the client and disconnect
     client->run = false;
+    xEventGroupSetBits(client->status_bits, REQUESTED_STOP_BIT);
     xEventGroupWaitBits(client->status_bits, STOPPED_BIT, false, true, portMAX_DELAY);
     client->state = WEBSOCKET_STATE_UNKNOW;
     return ESP_OK;


### PR DESCRIPTION
## Description

This fixes an issue that occurred when auto-reconnection is enabled, and the client is disconnected from the server. In this situation, if the `esp_websocket_client_stop() `method is called, the caller could remain stuck waiting for a maximum time equal to half of `reconnect_timeout_ms`.

This fix allows the `esp_websocket_client_task` to be woken up when it is waiting to reconnect, so it can be closed promptly when requested by `esp_websocket_client_stop() `.

## Testing

Procedure:

1. Start the client using a bad server url/IP, configuring `disable_auto_reconnect = false` and `reconnect_timeout_ms = 180000`
2. When the client is in `WEBSOCKET_STATE_WAIT_TIMEOUT`, call `esp_websocket_client_stop()`


Before these changes, the `esp_websocket_client_stop() `method could remain stuck for up to 90000 ms, half of `reconnect_timeout_ms`. With the implementation of this fix, the internal client task is woken up and stopped

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
