### PR TITLE
[mdns]: Fixed some minor bugs

### DIFF
--- a/components/mdns/include/mdns.h
+++ b/components/mdns/include/mdns.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2015-2022 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -10,6 +10,7 @@
 extern "C" {
 #endif
 
+#include "sdkconfig.h"
 #include <esp_netif.h>
 
 #define MDNS_TYPE_A                 0x0001
@@ -20,6 +21,13 @@ extern "C" {
 #define MDNS_TYPE_OPT               0x0029
 #define MDNS_TYPE_NSEC              0x002F
 #define MDNS_TYPE_ANY               0x00FF
+
+#if defined(CONFIG_LWIP_IPV6) && defined(CONFIG_MDNS_RESPOND_REVERSE_QUERIES)
+#define MDNS_NAME_MAX_LEN           (64+4)                  // Need to account for IPv6 reverse queries (64 char address  + ".ip6" )
+#else
+#define MDNS_NAME_MAX_LEN           64                      // Maximum string length of hostname, instance, service and proto
+#endif
+#define MDNS_NAME_BUF_LEN           (MDNS_NAME_MAX_LEN+1)   // Maximum char buffer size to hold hostname, instance, service or proto
 
 /**
  * @brief   Asynchronous query handle

--- a/components/mdns/mdns.c
+++ b/components/mdns/mdns.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2015-2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -334,6 +334,9 @@ static mdns_host_item_t *mdns_get_host_item(const char *hostname)
 
 static bool _mdns_can_add_more_services(void)
 {
+#if MDNS_MAX_SERVICES == 0
+    return false;
+#else
     mdns_srv_item_t *s = _mdns_server->services;
     uint16_t service_num = 0;
     while (s) {
@@ -343,8 +346,8 @@ static bool _mdns_can_add_more_services(void)
             return false;
         }
     }
-
     return true;
+#endif
 }
 
 esp_err_t _mdns_send_rx_action(mdns_rx_packet_t *packet)
@@ -5901,7 +5904,8 @@ esp_err_t mdns_service_add_for_host(const char *instance, const char *service, c
     const char *hostname = host ? host : _mdns_server->hostname;
     mdns_service_t *s = NULL;
 
-    ESP_GOTO_ON_FALSE(_mdns_can_add_more_services(), ESP_ERR_NO_MEM, err, TAG, "Cannot add more services");
+    ESP_GOTO_ON_FALSE(_mdns_can_add_more_services(), ESP_ERR_NO_MEM, err, TAG,
+                      "Cannot add more services, please increase CONFIG_MDNS_MAX_SERVICES (%d)", CONFIG_MDNS_MAX_SERVICES);
 
     mdns_srv_item_t *item = _mdns_get_service_item_instance(instance, service, proto, hostname);
     ESP_GOTO_ON_FALSE(!item, ESP_ERR_INVALID_ARG, err, TAG, "Service already exists");

--- a/components/mdns/mdns.c
+++ b/components/mdns/mdns.c
@@ -4479,10 +4479,11 @@ void mdns_preset_if_handle_system_event(void *arg, esp_event_base_t event_base,
                 case IP_EVENT_GOT_IP6: {
                     ip_event_got_ip6_t *event = (ip_event_got_ip6_t *) event_data;
                     mdns_if_t mdns_if = _mdns_get_if_from_esp_netif(event->esp_netif);
-                    if (mdns_if < MDNS_MAX_INTERFACES) {
-                        post_mdns_enable_pcb(mdns_if, MDNS_IP_PROTOCOL_V6);
-                        post_mdns_announce_pcb(mdns_if, MDNS_IP_PROTOCOL_V4);
+                    if (mdns_if >= MDNS_MAX_INTERFACES) {
+                        return;
                     }
+                    post_mdns_enable_pcb(mdns_if, MDNS_IP_PROTOCOL_V6);
+                    post_mdns_announce_pcb(mdns_if, MDNS_IP_PROTOCOL_V4);
                     mdns_browse_t *browse = _mdns_server->browse;
                     while (browse) {
                         _mdns_browse_send(browse, mdns_if);

--- a/components/mdns/mdns.c
+++ b/components/mdns/mdns.c
@@ -3486,8 +3486,9 @@ static void _mdns_result_txt_create(const uint8_t *data, size_t len, mdns_txt_it
     uint16_t i = 0, y;
     size_t partLen = 0;
     int num_items = _mdns_txt_items_count_get(data, len);
-    if (num_items < 0) {
-        return;//error
+    if (num_items < 0 || num_items > SIZE_MAX / sizeof(mdns_txt_item_t)) {
+        // Error: num_items is incorrect (or too large to allocate)
+        return;
     }
 
     if (!num_items) {

--- a/components/mdns/mdns.c
+++ b/components/mdns/mdns.c
@@ -5895,7 +5895,7 @@ esp_err_t mdns_instance_name_set(const char *instance)
 esp_err_t mdns_service_add_for_host(const char *instance, const char *service, const char *proto, const char *host,
                                     uint16_t port, mdns_txt_item_t txt[], size_t num_items)
 {
-    if (!_mdns_server || _str_null_or_empty(service) || _str_null_or_empty(proto) || !port || !_mdns_server->hostname) {
+    if (!_mdns_server || _str_null_or_empty(service) || _str_null_or_empty(proto) || !_mdns_server->hostname) {
         return ESP_ERR_INVALID_ARG;
     }
 

--- a/components/mdns/mdns.c
+++ b/components/mdns/mdns.c
@@ -5,19 +5,17 @@
  */
 
 #include <string.h>
-#include <sys/param.h>
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "freertos/queue.h"
 #include "freertos/semphr.h"
 #include "esp_log.h"
 #include "esp_event.h"
+#include "esp_random.h"
+#include "esp_check.h"
 #include "mdns.h"
 #include "mdns_private.h"
 #include "mdns_networking.h"
-#include "esp_log.h"
-#include "esp_random.h"
-#include "esp_check.h"
 
 static void _mdns_browse_item_free(mdns_browse_t *browse);
 static esp_err_t _mdns_send_browse_action(mdns_action_type_t type, mdns_browse_t *browse);

--- a/components/mdns/mdns_networking_lwip.c
+++ b/components/mdns/mdns_networking_lwip.c
@@ -288,7 +288,7 @@ typedef struct {
 static err_t _mdns_pcb_init_api(struct tcpip_api_call_data *api_call_msg)
 {
     mdns_api_call_t *msg = (mdns_api_call_t *)api_call_msg;
-    msg->err = _udp_pcb_init(msg->tcpip_if, msg->ip_protocol);
+    msg->err = _udp_pcb_init(msg->tcpip_if, msg->ip_protocol) == ESP_OK ? ERR_OK : ERR_IF;
     return msg->err;
 }
 

--- a/components/mdns/private_include/mdns_private.h
+++ b/components/mdns/private_include/mdns_private.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2015-2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -103,12 +103,6 @@
 #define MDNS_PACKET_QUEUE_LEN       16                      // Maximum packets that can be queued for parsing
 #define MDNS_ACTION_QUEUE_LEN       CONFIG_MDNS_ACTION_QUEUE_LEN  // Maximum actions pending to the server
 #define MDNS_TXT_MAX_LEN            1024                    // Maximum string length of text data in TXT record
-#if defined(CONFIG_LWIP_IPV6) && defined(CONFIG_MDNS_RESPOND_REVERSE_QUERIES)
-#define MDNS_NAME_MAX_LEN           (64+4)                  // Need to account for IPv6 reverse queries (64 char address  + ".ip6" )
-#else
-#define MDNS_NAME_MAX_LEN           64                      // Maximum string length of hostname, instance, service and proto
-#endif
-#define MDNS_NAME_BUF_LEN           (MDNS_NAME_MAX_LEN+1)   // Maximum char buffer size to hold hostname, instance, service or proto
 #define MDNS_MAX_PACKET_SIZE        1460                    // Maximum size of mDNS  outgoing packet
 
 #define MDNS_HEAD_LEN               12

--- a/components/mdns/tests/test_afl_fuzz_host/esp32_mock.c
+++ b/components/mdns/tests/test_afl_fuzz_host/esp32_mock.c
@@ -117,6 +117,10 @@ void esp_log_write(esp_log_level_t level, const char *tag, const char *format, .
 {
 }
 
+void esp_log(esp_log_config_t config, const char *tag, const char *format, ...)
+{
+}
+
 uint32_t esp_log_timestamp(void)
 {
     return 0;


### PR DESCRIPTION
## Github issues

* 9270a1ae fix(mdns): Move MDNS_NAME_BUF_LEN to public headers
* 77532f98 fix(mdns): Cleanup includes in mdns.c
* 5eddc9c8 fix(mdns): Allow advertizing service with port==0
* 980f3d36 fix(mdns): Fixed complier warning if MDNS_MAX_SERVICES==0

## Coverity issues

* a69123de fix(mdns): Fixed potential out-of-bound interface error
* 80a7b1fd fix(mdns): Fixed incorrect error conversion
* 411dee47 fix(mdns): Fixed potential overflow when allocating txt data

