### PR TITLE
[common]: Fix esp-docs dependencies

### DIFF
--- a/.github/workflows/mosq__build.yml
+++ b/.github/workflows/mosq__build.yml
@@ -75,6 +75,7 @@ jobs:
           done
 
   check_consistency:
+    if: contains(github.event.pull_request.labels.*.name, 'mosquitto') || github.event_name == 'push'
     name: Checks that API docs and versions are consistent
     runs-on: ubuntu-latest
     steps:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,8 +1,1 @@
-sphinxcontrib-applehelp==1.0.4
-sphinxcontrib_devhelp==1.0.2
-sphinxcontrib-htmlhelp==2.0.1
-sphinxcontrib-serializinghtml==1.1.5
-sphinxcontrib-qthelp==1.0.3
-breathe==4.35
-recommonmark==0.7.1
-esp-docs==1.7.1
+esp-docs>=2.0.0


### PR DESCRIPTION
`+` one minor fix in mosqutto CI

---
Job passed in https://github.com/david-cermak/esp-protocols/actions/runs/12867211883/job/35871360425