### PR TITLE
[mdns]: fix incorrect memory free for mdns browse

### DIFF
--- a/components/mdns/mdns.c
+++ b/components/mdns/mdns.c
@@ -4298,6 +4298,7 @@ void mdns_parse_packet(mdns_rx_packet_t *packet)
         } else {
             free(out_sync_browse);
         }
+        out_sync_browse = NULL;
     }
 
 clear_rx_packet:


### PR DESCRIPTION
## Description

When parsing an mDNS packet, for `mDNS browse`:

1. If `_mdns_sync_browse_action(ACTION_BROWSE_SYNC, out_sync_browse)` is called, the memory allocated for the browse will be freed by `_mdns_sync_browse_result_link_free` after processing `ACTION_BROWSE_SYNC` in `_mdns_execute_action`. Therefore, the memory should not be freed prematurely at the end of mDNS packet parsing.
2. If `_mdns_sync_browse_action` is not called but free the `out_sync_browse`, it should not be freed again at the end of mDNS packet parsing.

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] ~~Documentation is updated as needed.~~ (no functional change)
- [ ] ~~Tests are updated or added as necessary.~~(no functional change)
- [x] Git history is clean — commits are squashed to the minimum necessary.