### PR TITLE
[mdns]: Bump 1.5.0 -> 1.5.1

### DIFF
--- a/components/mdns/.cz.yaml
+++ b/components/mdns/.cz.yaml
@@ -3,6 +3,6 @@ commitizen:
   bump_message: 'bump(mdns): $current_version -> $new_version'
   pre_bump_hooks: python ../../ci/changelog.py mdns
   tag_format: mdns-v$version
-  version: 1.5.0
+  version: 1.5.1
   version_files:
   - idf_component.yml

--- a/components/mdns/CHANGELOG.md
+++ b/components/mdns/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.5.1](https://github.com/espressif/esp-protocols/commits/mdns-v1.5.1)
+
+### Bug Fixes
+
+- Fix incorrect memory free for mdns browse ([4451a8c5](https://github.com/espressif/esp-protocols/commit/4451a8c5))
+
 ## [1.5.0](https://github.com/espressif/esp-protocols/commits/mdns-v1.5.0)
 
 ### Features

--- a/components/mdns/idf_component.yml
+++ b/components/mdns/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.5.0"
+version: "1.5.1"
 description: "Multicast UDP service used to provide local network service and host discovery."
 url: "https://github.com/espressif/esp-protocols/tree/master/components/mdns"
 issues: "https://github.com/espressif/esp-protocols/issues"


### PR DESCRIPTION
## [1.5.1](https://github.com/espressif/esp-protocols/commits/mdns-v1.5.1)

### Bug Fixes

- Fix incorrect memory free for mdns browse ([4451a8c5](https://github.com/espressif/esp-protocols/commit/4451a8c5))
