### PR TITLE
fix(mdns): Fix _mdns_append_fqdn excessive stack usage (IDFGH-14506)

### DIFF
--- a/components/mdns/mdns.c
+++ b/components/mdns/mdns.c
@@ -751,12 +751,12 @@ static uint16_t _mdns_append_fqdn(uint8_t *packet, uint16_t *index, const char *
         //empty string so terminate
         return _mdns_append_u8(packet, index, 0);
     }
-    mdns_name_t name;
     static char buf[MDNS_NAME_BUF_LEN];
     uint8_t len = strlen(strings[0]);
     //try to find first the string length in the packet (if it exists)
     uint8_t *len_location = (uint8_t *)memchr(packet, (char)len, *index);
     while (len_location) {
+        mdns_name_t name;
         //check if the string after len_location is the string that we are looking for
         if (memcmp(len_location + 1, strings[0], len)) { //not continuing with our string
 search_next:


### PR DESCRIPTION
Move "mdns_name_t name" declaration inside loop to move it out of scope and reclain stack space before recursion call.

## Description
Move "mdns_name_t name" declaration inside loop to move it out of scope and reclaim stack space before the recursion call.

## Related

Fixes #738 

## Testing

Tested using patched version on product build. Original was triggering a stack overflow. Stack overflow did not occur with patched version.

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
