### PR TITLE
bump(asio): Publish 1.32.0 to component manager

### DIFF
--- a/components/asio/idf_component.yml
+++ b/components/asio/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.28.2~0"
+version: "1.32.0"
 description: Cross-platform C++ library for network and I/O programming
 url: https://github.com/espressif/esp-protocols/tree/master/components/asio
 issues: https://github.com/espressif/esp-protocols/issues


### PR DESCRIPTION
This publishes ASIO-1.32-0~0

Related to the bump-commit: ac6a388cdd7f31e113faa9cf132b8c57f1ff4df4 but missed to update idf_component.yml

Used commitizen automation, which refused to update `idf_component.yml` due to invalid sem-ver (`~0` suffix)

