### PR TITLE
[mdns]: Bump v1.5.2

### DIFF
--- a/components/mdns/.cz.yaml
+++ b/components/mdns/.cz.yaml
@@ -3,6 +3,6 @@ commitizen:
   bump_message: 'bump(mdns): $current_version -> $new_version'
   pre_bump_hooks: python ../../ci/changelog.py mdns
   tag_format: mdns-v$version
-  version: 1.5.1
+  version: 1.5.2
   version_files:
   - idf_component.yml

--- a/components/mdns/CHANGELOG.md
+++ b/components/mdns/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.5.2](https://github.com/espressif/esp-protocols/commits/mdns-v1.5.2)
+
+### Bug Fixes
+
+- Fix potential NULL deref when sending sub-buy ([e7273c46](https://github.com/espressif/esp-protocols/commit/e7273c46))
+- Fix _mdns_append_fqdn excessive stack usage ([bd23c233](https://github.com/espressif/esp-protocols/commit/bd23c233))
+
 ## [1.5.1](https://github.com/espressif/esp-protocols/commits/mdns-v1.5.1)
 
 ### Bug Fixes

--- a/components/mdns/idf_component.yml
+++ b/components/mdns/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.5.1"
+version: "1.5.2"
 description: "Multicast UDP service used to provide local network service and host discovery."
 url: "https://github.com/espressif/esp-protocols/tree/master/components/mdns"
 issues: "https://github.com/espressif/esp-protocols/issues"

--- a/components/mdns/mdns.c
+++ b/components/mdns/mdns.c
@@ -2399,6 +2399,9 @@ static void _mdns_send_bye_subtype(mdns_srv_item_t *service, const char *instanc
         for (j = 0; j < MDNS_IP_PROTOCOL_MAX; j++) {
             if (mdns_is_netif_ready(i, j)) {
                 mdns_tx_packet_t *packet = _mdns_alloc_packet_default((mdns_if_t)i, (mdns_ip_protocol_t)j);
+                if (packet == NULL) {
+                    return;
+                }
                 packet->flags = MDNS_FLAGS_QR_AUTHORITATIVE;
                 if (!_mdns_alloc_answer(&packet->answers, MDNS_TYPE_PTR, service->service, NULL, true, true)) {
                     _mdns_free_tx_packet(packet);


### PR DESCRIPTION
### Fix potential NULL deref when sending sub buy

Closes coverity reported issue: 473829 Dereference null return value

---

# Bump 1.5.1 -> 1.5.2

## [1.5.2](https://github.com/espressif/esp-protocols/commits/mdns-v1.5.2)

### Bug Fixes

- Fix potential NULL deref when sending sub-buy ([e7273c46](https://github.com/espressif/esp-protocols/commit/e7273c46))
- Fix _mdns_append_fqdn excessive stack usage ([bd23c233](https://github.com/espressif/esp-protocols/commit/bd23c233))
