### PR TITLE
[websocket]: Fix pytest to verify client correctly

### DIFF
--- a/components/esp_websocket_client/examples/target/pytest_websocket.py
+++ b/components/esp_websocket_client/examples/target/pytest_websocket.py
@@ -55,7 +55,7 @@ class Websocket(object):
             ssl_context.load_cert_chain(certfile='main/certs/server/server_cert.pem', keyfile='main/certs/server/server_key.pem')
             if self.client_verify is True:
                 ssl_context.load_verify_locations(cafile='main/certs/ca_cert.pem')
-                ssl_context.verify = ssl.CERT_REQUIRED
+                ssl_context.verify_mode = ssl.CERT_REQUIRED
             ssl_context.check_hostname = False
             self.server = SimpleSSLWebSocketServer('', self.port, WebsocketTestEcho, ssl_context=ssl_context)
         else:


### PR DESCRIPTION
The test code did accept also connections from clients which didn't present a certificate.
Need to use
```python
ssl_context.verify_mode = ssl.CERT_REQUIRED
```
instead of `verify` in python's SSL context
