### PR TITLE
[websocket]:  Bump 1.3.0 -> 1.4.0

### DIFF
--- a/components/esp_websocket_client/.cz.yaml
+++ b/components/esp_websocket_client/.cz.yaml
@@ -3,6 +3,6 @@ commitizen:
   bump_message: 'bump(websocket): $current_version -> $new_version'
   pre_bump_hooks: python ../../ci/changelog.py esp_websocket_client
   tag_format: websocket-v$version
-  version: 1.3.0
+  version: 1.4.0
   version_files:
   - idf_component.yml

--- a/components/esp_websocket_client/CHANGELOG.md
+++ b/components/esp_websocket_client/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [1.4.0](https://github.com/espressif/esp-protocols/commits/websocket-v1.4.0)
+
+### Features
+
+- Support DS peripheral for mutual TLS ([55385ec3](https://github.com/espressif/esp-protocols/commit/55385ec3))
+
+### Bug Fixes
+
+- wait for task on destroy ([42674b49](https://github.com/espressif/esp-protocols/commit/42674b49))
+- Fix pytest to verify client correctly ([9046af8f](https://github.com/espressif/esp-protocols/commit/9046af8f))
+- propagate error type ([eeeb9006](https://github.com/espressif/esp-protocols/commit/eeeb9006))
+- fix example buffer leak ([5219c39d](https://github.com/espressif/esp-protocols/commit/5219c39d))
+
+### Updated
+
+- chore(websocket): align structure members ([beb6e57e](https://github.com/espressif/esp-protocols/commit/beb6e57e))
+- chore(websocket): remove unused client variable ([15d3a01e](https://github.com/espressif/esp-protocols/commit/15d3a01e))
+
 ## [1.3.0](https://github.com/espressif/esp-protocols/commits/websocket-v1.3.0)
 
 ### Features

--- a/components/esp_websocket_client/idf_component.yml
+++ b/components/esp_websocket_client/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.3.0"
+version: "1.4.0"
 description: WebSocket protocol client for ESP-IDF
 url: https://github.com/espressif/esp-protocols/tree/master/components/esp_websocket_client
 dependencies:


### PR DESCRIPTION
## [1.4.0](https://github.com/espressif/esp-protocols/commits/websocket-v1.4.0)

### Features

- Support DS peripheral for mutual TLS ([55385ec3](https://github.com/espressif/esp-protocols/commit/55385ec3))

### Bug Fixes

- wait for task on destroy ([42674b49](https://github.com/espressif/esp-protocols/commit/42674b49))
- Fix pytest to verify client correctly ([9046af8f](https://github.com/espressif/esp-protocols/commit/9046af8f))
- propagate error type ([eeeb9006](https://github.com/espressif/esp-protocols/commit/eeeb9006))
- fix example buffer leak ([5219c39d](https://github.com/espressif/esp-protocols/commit/5219c39d))

### Updated

- chore(websocket): align structure members ([beb6e57e](https://github.com/espressif/esp-protocols/commit/beb6e57e))
- chore(websocket): remove unused client variable ([15d3a01e](https://github.com/espressif/esp-protocols/commit/15d3a01e))
