### PR TITLE
[mosquitto]: Fix minor CI issue

### DIFF
--- a/.github/workflows/mosq__build.yml
+++ b/.github/workflows/mosq__build.yml
@@ -103,6 +103,9 @@ jobs:
           echo "Versions are consistent: $CONFIG_VERSION"
 
   build_idf_tests_with_mosq:
+    if: |
+      github.repository == 'espressif/esp-protocols' &&
+      ( contains(github.event.pull_request.labels.*.name, 'mosquitto') || github.event_name == 'push' )
     name: Build IDF tests
     strategy:
       matrix:


### PR DESCRIPTION
IDF-test was executed even if no `mosq` label added.

---
* with reverted fix and no label: https://github.com/espressif/esp-protocols/actions/runs/13070794874/job/36471822367?pr=753
* after applying the fix (and no lable): The job is skipped: https://github.com/espressif/esp-protocols/actions/runs/13070879813/job/36472073405?pr=753