### PR TITLE
fix(modem): handle nullptr in DTE constructors to prevent invalid access (IDFGH-14688)

### DIFF
--- a/components/esp_modem/src/esp_modem_dte.cpp
+++ b/components/esp_modem/src/esp_modem_dte.cpp
@@ -14,37 +14,52 @@ using namespace esp_modem;
 
 static const size_t dte_default_buffer_size = 1000;
 
-DTE::DTE(const esp_modem_dte_config *config, std::unique_ptr<Terminal> terminal):
-    buffer(config->dte_buffer_size),
-    cmux_term(nullptr), primary_term(std::move(terminal)), secondary_term(primary_term),
-    mode(modem_mode::UNDEF)
+DTE::DTE(const esp_modem_dte_config *config, std::unique_ptr<Terminal> terminal)
+    : buffer(config->dte_buffer_size),
+      cmux_term(nullptr),
+      primary_term(std::move(terminal)),
+      secondary_term(primary_term),
+      mode(modem_mode::UNDEF)
 {
+    ESP_MODEM_THROW_IF_FALSE(primary_term != nullptr, "Invalid argument: terminal cannot be null");
     set_command_callbacks();
 }
 
-DTE::DTE(std::unique_ptr<Terminal> terminal):
-    buffer(dte_default_buffer_size),
-    cmux_term(nullptr), primary_term(std::move(terminal)), secondary_term(primary_term),
-    mode(modem_mode::UNDEF)
+DTE::DTE(std::unique_ptr<Terminal> terminal)
+    : buffer(dte_default_buffer_size),
+      cmux_term(nullptr),
+      primary_term(std::move(terminal)),
+      secondary_term(primary_term),
+      mode(modem_mode::UNDEF)
 {
+    ESP_MODEM_THROW_IF_FALSE(primary_term != nullptr, "Invalid argument: terminal cannot be null");
     set_command_callbacks();
 }
 
-DTE::DTE(const esp_modem_dte_config *config, std::unique_ptr<Terminal> t, std::unique_ptr<Terminal> s):
-    buffer(config->dte_buffer_size),
-    cmux_term(nullptr), primary_term(std::move(t)), secondary_term(std::move(s)),
-    mode(modem_mode::DUAL_MODE)
+DTE::DTE(const esp_modem_dte_config *config, std::unique_ptr<Terminal> t, std::unique_ptr<Terminal> s)
+    : buffer(config->dte_buffer_size),
+      cmux_term(nullptr),
+      primary_term(std::move(t)),
+      secondary_term(std::move(s)),
+      mode(modem_mode::DUAL_MODE)
 {
+    ESP_MODEM_THROW_IF_FALSE(primary_term != nullptr, "Invalid argument: primary terminal cannot be null");
+    ESP_MODEM_THROW_IF_FALSE(secondary_term != nullptr, "Invalid argument: secondary terminal cannot be null");
     set_command_callbacks();
 }
 
-DTE::DTE(std::unique_ptr<Terminal> t, std::unique_ptr<Terminal> s):
-    buffer(dte_default_buffer_size),
-    cmux_term(nullptr), primary_term(std::move(t)), secondary_term(std::move(s)),
-    mode(modem_mode::DUAL_MODE)
+DTE::DTE(std::unique_ptr<Terminal> t, std::unique_ptr<Terminal> s)
+    : buffer(dte_default_buffer_size),
+      cmux_term(nullptr),
+      primary_term(std::move(t)),
+      secondary_term(std::move(s)),
+      mode(modem_mode::DUAL_MODE)
 {
+    ESP_MODEM_THROW_IF_FALSE(primary_term != nullptr, "Invalid argument: primary terminal cannot be null");
+    ESP_MODEM_THROW_IF_FALSE(secondary_term != nullptr, "Invalid argument: secondary terminal cannot be null");
     set_command_callbacks();
 }
+
 
 void DTE::set_command_callbacks()
 {


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

The issue can be reproduced by setting a timeout for waiting for a USB connection (esp_modem_usb_term_config.timeou_ms). When the timeout occurs, the value of `primary_term` becomes null.

If either primary_term or secondary_term is `nullptr`, the set_command_callbacks function attempts to access invalid values. For example, in the first line of the function, `primary_term->set_read_cb([this](uint8_t *data, size_t len)`, the program tries to dereference primary_term, leading to a `LoadProhibited` exception and crashing the application.

To address this, I added a validation check in the DTE constructor to ensure the values are valid. Additionally, I handled the exception in the standard exception handler.


## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing
I test the changes in a ESP32S3.
<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
