### PR TITLE
[lws]: Adds missing license info

### DIFF
--- a/components/libwebsockets/LICENSE.txt
+++ b/components/libwebsockets/LICENSE.txt
@@ -1,0 +1,9 @@
+Libwebsockets and included programs are provided under the terms of the
+MIT license, with the exception that some sources are under
+a similar permissive license like BSD, or are explicitly CC0 / public
+domain to remove any obstacles from basing differently-licensed code on
+them.
+Please refer to the LWS LICENSE for more details.
+
+Espressif port files are licensed under Apache-2.0 license.
+Espressif examples and tests are distributed under Unlicense/CC0.


### PR DESCRIPTION
## Adds:

Libwebsockets and included programs are provided under the terms of the
MIT license shown below, with the exception that some sources are under
a similar permissive license like BSD, or are explicitly CC0 / public
domain to remove any obstacles from basing differently-licensed code on
them.

* Please refer to the LWS LICENSE for more details.
* Espressif port files are licensed under Apache-2.0 license.
* Espressif examples and tests are distributed under Unlicense/CC0.

## Fixes:

* https://github.com/espressif/esp-protocols/actions/runs/13414903602/job/37473259829
