### PR TITLE
[mdns]: Bump 1.7.0 -> 1.8.0

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -9,10 +9,10 @@ on:
 jobs:
   build:
     name: Run clang-tidy
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container: espressif/idf:latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: 'true'
       - name: Install esp-clang
@@ -50,7 +50,7 @@ jobs:
             results.sarif
             results.sarif.raw
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: results.sarif
           category: clang-tidy

--- a/components/mdns/.cz.yaml
+++ b/components/mdns/.cz.yaml
@@ -3,6 +3,6 @@ commitizen:
   bump_message: 'bump(mdns): $current_version -> $new_version'
   pre_bump_hooks: python ../../ci/changelog.py mdns
   tag_format: mdns-v$version
-  version: 1.7.0
+  version: 1.8.0
   version_files:
   - idf_component.yml

--- a/components/mdns/CHANGELOG.md
+++ b/components/mdns/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [1.8.0](https://github.com/espressif/esp-protocols/commits/mdns-v1.8.0)
+
+### Features
+
+- Add version keys ([e01e67e7](https://github.com/espressif/esp-protocols/commit/e01e67e7))
+
+### Bug Fixes
+
+- Reformat mdns sources per indent-cont=120 ([c7663cde](https://github.com/espressif/esp-protocols/commit/c7663cde))
+
 ## [1.7.0](https://github.com/espressif/esp-protocols/commits/mdns-v1.7.0)
 
 ### Features

--- a/components/mdns/CMakeLists.txt
+++ b/components/mdns/CMakeLists.txt
@@ -34,7 +34,9 @@ if(${target} STREQUAL "linux")
     target_link_libraries(${COMPONENT_LIB} PRIVATE "-lbsd")
 endif()
 
-
 if(CONFIG_ETH_ENABLED)
     idf_component_optional_requires(PRIVATE esp_eth)
 endif()
+
+idf_component_get_property(MDNS_VERSION ${COMPONENT_NAME} COMPONENT_VERSION)
+target_compile_definitions(${COMPONENT_LIB} PUBLIC "-DESP_MDNS_VERSION_NUMBER=\"${MDNS_VERSION}\"")

--- a/components/mdns/examples/query_advertise/main/mdns_example_main.c
+++ b/components/mdns/examples/query_advertise/main/mdns_example_main.c
@@ -314,6 +314,8 @@ void app_main(void)
     ESP_ERROR_CHECK(esp_netif_init());
     ESP_ERROR_CHECK(esp_event_loop_create_default());
 
+    ESP_LOGI(TAG, "mDNS Ver: %s", ESP_MDNS_VERSION_NUMBER);
+
     initialise_mdns();
 
     /* This helper function configures Wi-Fi or Ethernet, as selected in menuconfig.

--- a/components/mdns/examples/query_advertise/main/mdns_example_main.c
+++ b/components/mdns/examples/query_advertise/main/mdns_example_main.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022-2023 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2022-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Unlicense OR CC0-1.0
  */
@@ -44,12 +44,12 @@ static void initialise_mdns(void)
     char *hostname = generate_hostname();
 
     //initialize mDNS
-    ESP_ERROR_CHECK( mdns_init() );
+    ESP_ERROR_CHECK(mdns_init());
     //set mDNS hostname (required if you want to advertise services)
-    ESP_ERROR_CHECK( mdns_hostname_set(hostname) );
+    ESP_ERROR_CHECK(mdns_hostname_set(hostname));
     ESP_LOGI(TAG, "mdns hostname set to: [%s]", hostname);
     //set default mDNS instance name
-    ESP_ERROR_CHECK( mdns_instance_name_set(EXAMPLE_MDNS_INSTANCE) );
+    ESP_ERROR_CHECK(mdns_instance_name_set(EXAMPLE_MDNS_INSTANCE));
 
     //structure with TXT records
     mdns_txt_item_t serviceTxtData[3] = {
@@ -59,10 +59,10 @@ static void initialise_mdns(void)
     };
 
     //initialize service
-    ESP_ERROR_CHECK( mdns_service_add("ESP32-WebServer", "_http", "_tcp", 80, serviceTxtData, 3) );
-    ESP_ERROR_CHECK( mdns_service_subtype_add_for_host("ESP32-WebServer", "_http", "_tcp", NULL, "_server") );
+    ESP_ERROR_CHECK(mdns_service_add("ESP32-WebServer", "_http", "_tcp", 80, serviceTxtData, 3));
+    ESP_ERROR_CHECK(mdns_service_subtype_add_for_host("ESP32-WebServer", "_http", "_tcp", NULL, "_server"));
 #if CONFIG_MDNS_MULTIPLE_INSTANCE
-    ESP_ERROR_CHECK( mdns_service_add("ESP32-WebServer1", "_http", "_tcp", 80, NULL, 0) );
+    ESP_ERROR_CHECK(mdns_service_add("ESP32-WebServer1", "_http", "_tcp", 80, NULL, 0));
 #endif
 
 #if CONFIG_MDNS_PUBLISH_DELEGATE_HOST
@@ -78,15 +78,15 @@ static void initialise_mdns(void)
     addr6.addr.type = ESP_IPADDR_TYPE_V6;
     addr4.next = &addr6;
     addr6.next = NULL;
-    ESP_ERROR_CHECK( mdns_delegate_hostname_add(delegated_hostname, &addr4) );
-    ESP_ERROR_CHECK( mdns_service_add_for_host("test0", "_http", "_tcp", delegated_hostname, 1234, serviceTxtData, 3) );
+    ESP_ERROR_CHECK(mdns_delegate_hostname_add(delegated_hostname, &addr4));
+    ESP_ERROR_CHECK(mdns_service_add_for_host("test0", "_http", "_tcp", delegated_hostname, 1234, serviceTxtData, 3));
     free(delegated_hostname);
 #endif // CONFIG_MDNS_PUBLISH_DELEGATE_HOST
 
     //add another TXT item
-    ESP_ERROR_CHECK( mdns_service_txt_item_set("_http", "_tcp", "path", "/foobar") );
+    ESP_ERROR_CHECK(mdns_service_txt_item_set("_http", "_tcp", "path", "/foobar"));
     //change TXT item value
-    ESP_ERROR_CHECK( mdns_service_txt_item_set_with_explicit_value_len("_http", "_tcp", "u", "admin", strlen("admin")) );
+    ESP_ERROR_CHECK(mdns_service_txt_item_set_with_explicit_value_len("_http", "_tcp", "u", "admin", strlen("admin")));
     free(hostname);
 }
 
@@ -377,12 +377,12 @@ static void  query_mdns_host_with_gethostbyname(char *host)
         while (res->h_addr_list[i] != NULL) {
             ESP_LOGI(TAG, "gethostbyname: %s resolved to: %s", host,
 #if defined(CONFIG_LWIP_IPV6) && defined(CONFIG_LWIP_IPV4)
-                     res->h_addrtype == AF_INET ? inet_ntoa(*(struct in_addr *) (res->h_addr_list[i])) :
-                     inet6_ntoa(*(struct in6_addr *) (res->h_addr_list[i]))
+                     res->h_addrtype == AF_INET ? inet_ntoa(*(struct in_addr *)(res->h_addr_list[i])) :
+                     inet6_ntoa(*(struct in6_addr *)(res->h_addr_list[i]))
 #elif defined(CONFIG_LWIP_IPV6)
-                     inet6_ntoa(*(struct in6_addr *) (res->h_addr_list[i]))
+                     inet6_ntoa(*(struct in6_addr *)(res->h_addr_list[i]))
 #else
-                     inet_ntoa(*(struct in_addr *) (res->h_addr_list[i]))
+                     inet_ntoa(*(struct in_addr *)(res->h_addr_list[i]))
 #endif
                     );
             i++;

--- a/components/mdns/idf_component.yml
+++ b/components/mdns/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.7.0"
+version: "1.8.0"
 description: "Multicast UDP service used to provide local network service and host discovery."
 url: "https://github.com/espressif/esp-protocols/tree/master/components/mdns"
 issues: "https://github.com/espressif/esp-protocols/issues"

--- a/components/mdns/include/mdns.h
+++ b/components/mdns/include/mdns.h
@@ -373,7 +373,7 @@ esp_err_t mdns_service_instance_name_set(const char *service_type, const char *p
  *     - ESP_ERR_NO_MEM memory error
  */
 esp_err_t mdns_service_instance_name_set_for_host(const char *instance_old, const char *service_type, const char *proto, const char *hostname,
-        const char *instance_name);
+                                                  const char *instance_name);
 
 /**
  * @brief  Set service port
@@ -407,7 +407,7 @@ esp_err_t mdns_service_port_set(const char *service_type, const char *proto, uin
  *     - ESP_ERR_NO_MEM memory error
  */
 esp_err_t mdns_service_port_set_for_host(const char *instance, const char *service_type, const char *proto, const char *hostname,
-        uint16_t port);
+                                         uint16_t port);
 
 /**
  * @brief  Replace all TXT items for service
@@ -482,7 +482,7 @@ esp_err_t mdns_service_txt_item_set(const char *service_type, const char *proto,
  *     - ESP_ERR_NO_MEM memory error
  */
 esp_err_t mdns_service_txt_item_set_with_explicit_value_len(const char *service_type, const char *proto,
-        const char *key, const char *value, uint8_t value_len);
+                                                            const char *key, const char *value, uint8_t value_len);
 
 /**
  * @brief  Set/Add TXT item for service TXT record with hostname
@@ -503,7 +503,7 @@ esp_err_t mdns_service_txt_item_set_with_explicit_value_len(const char *service_
  *     - ESP_ERR_NO_MEM memory error
  */
 esp_err_t mdns_service_txt_item_set_for_host(const char *instance, const char *service_type, const char *proto, const char *hostname,
-        const char *key, const char *value);
+                                             const char *key, const char *value);
 
 /**
  * @brief  Set/Add TXT item for service TXT record with hostname and txt value length
@@ -523,8 +523,8 @@ esp_err_t mdns_service_txt_item_set_for_host(const char *instance, const char *s
  *     - ESP_ERR_NO_MEM memory error
  */
 esp_err_t mdns_service_txt_item_set_for_host_with_explicit_value_len(const char *instance, const char *service_type, const char *proto,
-        const char *hostname, const char *key,
-        const char *value, uint8_t value_len);
+                                                                     const char *hostname, const char *key,
+                                                                     const char *value, uint8_t value_len);
 
 /**
  * @brief  Remove TXT item for service TXT record
@@ -557,7 +557,7 @@ esp_err_t mdns_service_txt_item_remove(const char *service_type, const char *pro
  *     - ESP_ERR_NO_MEM memory error
  */
 esp_err_t mdns_service_txt_item_remove_for_host(const char *instance, const char *service_type, const char *proto, const char *hostname,
-        const char *key);
+                                                const char *key);
 
 /**
  * @brief  Add a subtype for service.
@@ -575,7 +575,7 @@ esp_err_t mdns_service_txt_item_remove_for_host(const char *instance, const char
  *     - ESP_ERR_NO_MEM memory error
  */
 esp_err_t mdns_service_subtype_add_for_host(const char *instance_name, const char *service_type, const char *proto,
-        const char *hostname, const char *subtype);
+                                            const char *hostname, const char *subtype);
 
 /**
  * @brief  Remove a subtype for service.
@@ -592,7 +592,7 @@ esp_err_t mdns_service_subtype_add_for_host(const char *instance_name, const cha
  *     - ESP_ERR_NOT_FOUND Service not found
  */
 esp_err_t mdns_service_subtype_remove_for_host(const char *instance_name, const char *service_type, const char *proto,
-        const char *hostname, const char *subtype);
+                                               const char *hostname, const char *subtype);
 
 /**
  * @brief  Add multiple subtypes for service at once.
@@ -611,7 +611,7 @@ esp_err_t mdns_service_subtype_remove_for_host(const char *instance_name, const 
  *     - ESP_ERR_NO_MEM memory error
  */
 esp_err_t mdns_service_subtype_add_multiple_items_for_host(const char *instance_name, const char *service_type, const char *proto,
-        const char *hostname, mdns_subtype_item_t subtype[], uint8_t num_items);
+                                                           const char *hostname, mdns_subtype_item_t subtype[], uint8_t num_items);
 
 /**
  * @brief  Update subtype for service.
@@ -632,7 +632,7 @@ esp_err_t mdns_service_subtype_add_multiple_items_for_host(const char *instance_
  *     - ESP_ERR_NO_MEM memory error
  */
 esp_err_t mdns_service_subtype_update_multiple_items_for_host(const char *instance_name, const char *service_type, const char *proto,
-        const char *hostname, mdns_subtype_item_t subtype[], uint8_t num_items);
+                                                              const char *hostname, mdns_subtype_item_t subtype[], uint8_t num_items);
 /**
  * @brief  Remove and free all services from mDNS server
  *
@@ -686,7 +686,7 @@ bool mdns_query_async_get_results(mdns_search_once_t *search, uint32_t timeout, 
  *         NULL otherwise.
  */
 mdns_search_once_t *mdns_query_async_new(const char *name, const char *service_type, const char *proto, uint16_t type,
-        uint32_t timeout, size_t max_results, mdns_query_notify_t notifier);
+                                         uint32_t timeout, size_t max_results, mdns_query_notify_t notifier);
 
 /**
  * @brief  Generic mDNS query
@@ -825,7 +825,7 @@ esp_err_t mdns_lookup_delegated_service(const char *instance, const char *servic
  *     - ESP_ERR_INVALID_ARG    parameter error
  */
 esp_err_t mdns_lookup_selfhosted_service(const char *instance, const char *service_type, const char *proto, size_t max_results,
-        mdns_result_t **result);
+                                         mdns_result_t **result);
 
 /**
  * @brief  Query mDNS for A record

--- a/components/mdns/tests/host_test/components/esp_netif_linux/esp_netif_linux.c
+++ b/components/mdns/tests/host_test/components/esp_netif_linux/esp_netif_linux.c
@@ -51,7 +51,7 @@ esp_err_t esp_netif_get_ip_info(esp_netif_t *esp_netif, esp_netif_ip_info_t *ip_
         if (tmp->ifa_addr && tmp->ifa_addr->sa_family == AF_INET) {
             char addr[20];
             struct sockaddr_in *pAddr = (struct sockaddr_in *) tmp->ifa_addr;
-            inet_ntop(AF_INET, &pAddr->sin_addr, addr, sizeof(addr) );
+            inet_ntop(AF_INET, &pAddr->sin_addr, addr, sizeof(addr));
             if (strcmp(esp_netif->if_desc, tmp->ifa_name) == 0) {
                 ESP_LOGD(TAG, "AF_INET4: %s: %s\n", tmp->ifa_name, addr);
                 memcpy(&ip_info->ip.addr, &pAddr->sin_addr, 4);
@@ -105,7 +105,7 @@ esp_err_t esp_netif_get_ip6_linklocal(esp_netif_t *esp_netif, esp_ip6_addr_t *if
         if (tmp->ifa_addr && tmp->ifa_addr->sa_family == AF_INET6) {
             char addr[64];
             struct sockaddr_in6 *pAddr = (struct sockaddr_in6 *)tmp->ifa_addr;
-            inet_ntop(AF_INET6, &pAddr->sin6_addr, addr, sizeof(addr) );
+            inet_ntop(AF_INET6, &pAddr->sin6_addr, addr, sizeof(addr));
             if (strcmp(esp_netif->if_desc, tmp->ifa_name) == 0) {
                 ESP_LOGD(TAG, "AF_INET6: %s: %s\n", tmp->ifa_name, addr);
                 memcpy(if_ip6->addr, &pAddr->sin6_addr, 4 * 4);

--- a/components/mdns/tests/host_test/main/main.c
+++ b/components/mdns/tests/host_test/main/main.c
@@ -111,7 +111,7 @@ static void mdns_test_app(esp_netif_t *interface)
         .func = exit_console,
         .argtable = NULL
     };
-    ESP_ERROR_CHECK( esp_console_cmd_register(&cmd_exit) );
+    ESP_ERROR_CHECK(esp_console_cmd_register(&cmd_exit));
     mdns_console_register();
     ESP_ERROR_CHECK(esp_console_start_repl(repl));
     xEventGroupWaitBits(s_exit_signal, 1, pdTRUE, pdFALSE, portMAX_DELAY);

--- a/components/mdns/tests/test_afl_fuzz_host/test.c
+++ b/components/mdns/tests/test_afl_fuzz_host/test.c
@@ -243,7 +243,7 @@ int main(int argc, char **argv)
         //
         // Note: parameter1 is a file (mangled packet) which caused the crash
         file = fopen(argv[1], "r");
-        assert(file >= 0 );
+        assert(file >= 0);
         len = fread(buf, 1, 1460, file);
         fclose(file);
     }

--- a/components/mdns/tests/test_apps/main/main.c
+++ b/components/mdns/tests/test_apps/main/main.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022-2023 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2022-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -55,17 +55,17 @@ static void initialise_mdns(void)
     char *hostname = generate_hostname();
 
     //initialize mDNS
-    ESP_ERROR_CHECK( mdns_init() );
+    ESP_ERROR_CHECK(mdns_init());
 
     //set mDNS hostname (required if you want to advertise services)
-    ESP_ERROR_CHECK( mdns_hostname_set(hostname) );
+    ESP_ERROR_CHECK(mdns_hostname_set(hostname));
 
     ESP_LOGI(TAG, "mdns hostname set to: [%s]", hostname);
     //set default mDNS instance name
-    ESP_ERROR_CHECK( mdns_instance_name_set(CONFIG_TEST_MDNS_INSTANCE) );
+    ESP_ERROR_CHECK(mdns_instance_name_set(CONFIG_TEST_MDNS_INSTANCE));
 
     //initialize service
-    ESP_ERROR_CHECK( mdns_service_add("ESP32-WebServer", "_http", "_tcp", 80, NULL, 0) );
+    ESP_ERROR_CHECK(mdns_service_add("ESP32-WebServer", "_http", "_tcp", 80, NULL, 0));
 
 #if CONFIG_TEST_MDNS_PUBLISH_DELEGATE_HOST
     char *delegated_hostname;
@@ -80,12 +80,12 @@ static void initialise_mdns(void)
     addr6.addr.type = ESP_IPADDR_TYPE_V6;
     addr4.next = &addr6;
     addr6.next = NULL;
-    ESP_ERROR_CHECK( mdns_delegate_hostname_add(delegated_hostname, &addr4) );
-    ESP_ERROR_CHECK( mdns_service_add_for_host("test0", "_http", "_tcp", delegated_hostname, 1234, NULL, 0) );
+    ESP_ERROR_CHECK(mdns_delegate_hostname_add(delegated_hostname, &addr4));
+    ESP_ERROR_CHECK(mdns_service_add_for_host("test0", "_http", "_tcp", delegated_hostname, 1234, NULL, 0));
     free(delegated_hostname);
 #endif // CONFIG_TEST_MDNS_PUBLISH_DELEGATE_HOST
 
-    ESP_ERROR_CHECK( mdns_service_subtype_add_for_host("ESP32-WebServer", "_http", "_tcp", NULL, "_server") );
+    ESP_ERROR_CHECK(mdns_service_subtype_add_for_host("ESP32-WebServer", "_http", "_tcp", NULL, "_server"));
 
     free(hostname);
 }

--- a/components/mdns/tests/unit_test/main/test_mdns.c
+++ b/components/mdns/tests/unit_test/main/test_mdns.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022-2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2022-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Unlicense OR CC0-1.0
  */
@@ -45,17 +45,17 @@ static void yield_to_all_priorities(void)
 
 TEST(mdns, api_fails_with_invalid_state)
 {
-    TEST_ASSERT_NOT_EQUAL(ESP_OK, mdns_init() );
-    TEST_ASSERT_NOT_EQUAL(ESP_OK, mdns_hostname_set(MDNS_HOSTNAME) );
-    TEST_ASSERT_NOT_EQUAL(ESP_OK, mdns_instance_name_set(MDNS_INSTANCE) );
-    TEST_ASSERT_NOT_EQUAL(ESP_OK, mdns_service_add(MDNS_INSTANCE, MDNS_SERVICE_NAME, MDNS_SERVICE_PROTO, MDNS_SERVICE_PORT, NULL, 0) );
+    TEST_ASSERT_NOT_EQUAL(ESP_OK, mdns_init());
+    TEST_ASSERT_NOT_EQUAL(ESP_OK, mdns_hostname_set(MDNS_HOSTNAME));
+    TEST_ASSERT_NOT_EQUAL(ESP_OK, mdns_instance_name_set(MDNS_INSTANCE));
+    TEST_ASSERT_NOT_EQUAL(ESP_OK, mdns_service_add(MDNS_INSTANCE, MDNS_SERVICE_NAME, MDNS_SERVICE_PROTO, MDNS_SERVICE_PORT, NULL, 0));
 }
 
 TEST(mdns, init_deinit)
 {
     test_case_uses_tcpip();
     TEST_ASSERT_EQUAL(ESP_OK, esp_event_loop_create_default());
-    TEST_ASSERT_EQUAL(ESP_OK, mdns_init() );
+    TEST_ASSERT_EQUAL(ESP_OK, mdns_init());
     yield_to_all_priorities(); // Make sure that mdns task has executed to complete initialization
     mdns_free();
     esp_event_loop_delete_default();
@@ -76,33 +76,33 @@ TEST(mdns, api_fails_with_expected_err)
     test_case_uses_tcpip();
     TEST_ASSERT_EQUAL(ESP_OK, esp_event_loop_create_default());
 
-    TEST_ASSERT_EQUAL(ESP_OK, mdns_init() );
-    TEST_ASSERT_EQUAL(ESP_OK, mdns_hostname_set(MDNS_HOSTNAME) );
-    TEST_ASSERT_EQUAL(ESP_OK, mdns_delegate_hostname_add(MDNS_DELEGATE_HOSTNAME, &addr) );
+    TEST_ASSERT_EQUAL(ESP_OK, mdns_init());
+    TEST_ASSERT_EQUAL(ESP_OK, mdns_hostname_set(MDNS_HOSTNAME));
+    TEST_ASSERT_EQUAL(ESP_OK, mdns_delegate_hostname_add(MDNS_DELEGATE_HOSTNAME, &addr));
     yield_to_all_priorities();  // Make sure that mdns task has executed to add the hostname
-    TEST_ASSERT_TRUE(mdns_hostname_exists(MDNS_DELEGATE_HOSTNAME) );
-    TEST_ASSERT_EQUAL(ESP_OK, mdns_instance_name_set(MDNS_INSTANCE) );
-    TEST_ASSERT_EQUAL(ESP_OK, mdns_service_add(MDNS_INSTANCE, MDNS_SERVICE_NAME, MDNS_SERVICE_PROTO, MDNS_SERVICE_PORT, serviceTxtData, CONFIG_MDNS_MAX_SERVICES) );
-    TEST_ASSERT_FALSE(mdns_service_exists(MDNS_SERVICE_NAME, MDNS_SERVICE_PROTO, MDNS_DELEGATE_HOSTNAME) );
+    TEST_ASSERT_TRUE(mdns_hostname_exists(MDNS_DELEGATE_HOSTNAME));
+    TEST_ASSERT_EQUAL(ESP_OK, mdns_instance_name_set(MDNS_INSTANCE));
+    TEST_ASSERT_EQUAL(ESP_OK, mdns_service_add(MDNS_INSTANCE, MDNS_SERVICE_NAME, MDNS_SERVICE_PROTO, MDNS_SERVICE_PORT, serviceTxtData, CONFIG_MDNS_MAX_SERVICES));
+    TEST_ASSERT_FALSE(mdns_service_exists(MDNS_SERVICE_NAME, MDNS_SERVICE_PROTO, MDNS_DELEGATE_HOSTNAME));
     TEST_ASSERT_EQUAL(ESP_OK, mdns_service_add_for_host(MDNS_INSTANCE, MDNS_SERVICE_NAME, MDNS_SERVICE_PROTO, MDNS_DELEGATE_HOSTNAME,
-                      MDNS_SERVICE_PORT, serviceTxtData, CONFIG_MDNS_MAX_SERVICES) );
-    TEST_ASSERT_TRUE(mdns_service_exists(MDNS_SERVICE_NAME, MDNS_SERVICE_PROTO, MDNS_DELEGATE_HOSTNAME) );
-    TEST_ASSERT_EQUAL(ESP_OK, mdns_service_txt_set(MDNS_SERVICE_NAME, MDNS_SERVICE_PROTO, serviceTxtData, CONFIG_MDNS_MAX_SERVICES) );
-    TEST_ASSERT_EQUAL(ESP_OK, mdns_service_txt_item_set(MDNS_SERVICE_NAME, MDNS_SERVICE_PROTO, "key1", "value1") );
-    TEST_ASSERT_EQUAL(ESP_OK, mdns_service_txt_item_remove(MDNS_SERVICE_NAME, MDNS_SERVICE_PROTO, "key1") );
-    TEST_ASSERT_EQUAL(ESP_OK, mdns_service_port_set(MDNS_SERVICE_NAME, MDNS_SERVICE_PROTO, 8080) );
+                                                        MDNS_SERVICE_PORT, serviceTxtData, CONFIG_MDNS_MAX_SERVICES));
+    TEST_ASSERT_TRUE(mdns_service_exists(MDNS_SERVICE_NAME, MDNS_SERVICE_PROTO, MDNS_DELEGATE_HOSTNAME));
+    TEST_ASSERT_EQUAL(ESP_OK, mdns_service_txt_set(MDNS_SERVICE_NAME, MDNS_SERVICE_PROTO, serviceTxtData, CONFIG_MDNS_MAX_SERVICES));
+    TEST_ASSERT_EQUAL(ESP_OK, mdns_service_txt_item_set(MDNS_SERVICE_NAME, MDNS_SERVICE_PROTO, "key1", "value1"));
+    TEST_ASSERT_EQUAL(ESP_OK, mdns_service_txt_item_remove(MDNS_SERVICE_NAME, MDNS_SERVICE_PROTO, "key1"));
+    TEST_ASSERT_EQUAL(ESP_OK, mdns_service_port_set(MDNS_SERVICE_NAME, MDNS_SERVICE_PROTO, 8080));
     yield_to_all_priorities();  // to remove the service with the updated txt records
-    TEST_ASSERT_EQUAL(ESP_OK, mdns_service_remove(MDNS_SERVICE_NAME, MDNS_SERVICE_PROTO) );
+    TEST_ASSERT_EQUAL(ESP_OK, mdns_service_remove(MDNS_SERVICE_NAME, MDNS_SERVICE_PROTO));
     yield_to_all_priorities();  // Make sure that mdns task has executed to remove the service
 
-    TEST_ASSERT_EQUAL(ESP_OK, mdns_service_add(MDNS_INSTANCE, MDNS_SERVICE_NAME, MDNS_SERVICE_PROTO, MDNS_SERVICE_PORT, NULL, 0) );
-    TEST_ASSERT_EQUAL(ESP_OK, mdns_delegate_hostname_remove(MDNS_DELEGATE_HOSTNAME) );
+    TEST_ASSERT_EQUAL(ESP_OK, mdns_service_add(MDNS_INSTANCE, MDNS_SERVICE_NAME, MDNS_SERVICE_PROTO, MDNS_SERVICE_PORT, NULL, 0));
+    TEST_ASSERT_EQUAL(ESP_OK, mdns_delegate_hostname_remove(MDNS_DELEGATE_HOSTNAME));
     yield_to_all_priorities();  // Make sure that mdns task has executed to remove the hostname
-    TEST_ASSERT_FALSE(mdns_service_exists(MDNS_SERVICE_NAME, MDNS_SERVICE_PROTO, MDNS_DELEGATE_HOSTNAME) );
-    TEST_ASSERT_EQUAL(ESP_OK, mdns_service_remove_all() );
+    TEST_ASSERT_FALSE(mdns_service_exists(MDNS_SERVICE_NAME, MDNS_SERVICE_PROTO, MDNS_DELEGATE_HOSTNAME));
+    TEST_ASSERT_EQUAL(ESP_OK, mdns_service_remove_all());
     yield_to_all_priorities();  // Make sure that mdns task has executed to remove all services
 
-    TEST_ASSERT_EQUAL(ESP_ERR_INVALID_ARG, mdns_service_port_set(MDNS_SERVICE_NAME, MDNS_SERVICE_PROTO, 8080) );
+    TEST_ASSERT_EQUAL(ESP_ERR_INVALID_ARG, mdns_service_port_set(MDNS_SERVICE_NAME, MDNS_SERVICE_PROTO, 8080));
 
     mdns_free();
     esp_event_loop_delete_default();
@@ -116,7 +116,7 @@ TEST(mdns, query_api_fails_with_expected_err)
     test_case_uses_tcpip();
     TEST_ASSERT_EQUAL(ESP_OK, esp_event_loop_create_default());
 
-    TEST_ASSERT_EQUAL(ESP_OK, mdns_init() );
+    TEST_ASSERT_EQUAL(ESP_OK, mdns_init());
     // check it is not possible to register a service or set an instance without configuring the hostname
     TEST_ASSERT_EQUAL(ESP_ERR_INVALID_ARG, mdns_service_add(MDNS_INSTANCE, MDNS_SERVICE_NAME, MDNS_SERVICE_PROTO, MDNS_SERVICE_PORT, NULL, 0));
     TEST_ASSERT_EQUAL(ESP_ERR_INVALID_ARG, mdns_instance_name_set(MDNS_INSTANCE));
@@ -125,19 +125,19 @@ TEST(mdns, query_api_fails_with_expected_err)
     TEST_ASSERT_EQUAL(ESP_OK, mdns_service_add(MDNS_INSTANCE, MDNS_SERVICE_NAME, MDNS_SERVICE_PROTO, MDNS_SERVICE_PORT, NULL, 0));
     TEST_ASSERT_EQUAL(ESP_OK, mdns_instance_name_set(MDNS_INSTANCE));
 
-    TEST_ASSERT_EQUAL(ESP_OK, mdns_query_ptr(MDNS_SERVICE_NAME, MDNS_SERVICE_PROTO, 10, CONFIG_MDNS_MAX_SERVICES,  &results) );
+    TEST_ASSERT_EQUAL(ESP_OK, mdns_query_ptr(MDNS_SERVICE_NAME, MDNS_SERVICE_PROTO, 10, CONFIG_MDNS_MAX_SERVICES,  &results));
     mdns_query_results_free(results);
 
-    TEST_ASSERT_EQUAL(ESP_OK, mdns_query_srv(MDNS_INSTANCE, MDNS_SERVICE_NAME, MDNS_SERVICE_PROTO, 10, &results) );
+    TEST_ASSERT_EQUAL(ESP_OK, mdns_query_srv(MDNS_INSTANCE, MDNS_SERVICE_NAME, MDNS_SERVICE_PROTO, 10, &results));
     mdns_query_results_free(results);
 
-    TEST_ASSERT_EQUAL(ESP_OK, mdns_query_txt(MDNS_INSTANCE, MDNS_SERVICE_NAME, MDNS_SERVICE_PROTO, 10, &results) );
+    TEST_ASSERT_EQUAL(ESP_OK, mdns_query_txt(MDNS_INSTANCE, MDNS_SERVICE_NAME, MDNS_SERVICE_PROTO, 10, &results));
     mdns_query_results_free(results);
 
-    TEST_ASSERT_EQUAL(ESP_ERR_NOT_FOUND, mdns_query_a(MDNS_HOSTNAME, 10, &addr4) );
+    TEST_ASSERT_EQUAL(ESP_ERR_NOT_FOUND, mdns_query_a(MDNS_HOSTNAME, 10, &addr4));
     mdns_query_results_free(results);
 
-    TEST_ASSERT_EQUAL(ESP_ERR_NOT_FOUND, mdns_query_aaaa(MDNS_HOSTNAME, 10, &addr6) );
+    TEST_ASSERT_EQUAL(ESP_ERR_NOT_FOUND, mdns_query_aaaa(MDNS_HOSTNAME, 10, &addr6));
     mdns_query_results_free(results);
 
     mdns_free();
@@ -149,7 +149,7 @@ TEST(mdns, add_remove_service)
     mdns_result_t *results = NULL;
     test_case_uses_tcpip();
     TEST_ASSERT_EQUAL(ESP_OK, esp_event_loop_create_default());
-    TEST_ASSERT_EQUAL(ESP_OK, mdns_init() );
+    TEST_ASSERT_EQUAL(ESP_OK, mdns_init());
     TEST_ASSERT_EQUAL(ESP_OK, mdns_hostname_set(MDNS_HOSTNAME));
     TEST_ASSERT_EQUAL(ESP_OK, mdns_service_add(MDNS_INSTANCE, MDNS_SERVICE_NAME, MDNS_SERVICE_PROTO, MDNS_SERVICE_PORT, NULL, 0));
     yield_to_all_priorities();  // Make sure that mdns task has executed to add the hostname
@@ -170,7 +170,7 @@ TEST(mdns, add_remove_service)
     mdns_query_results_free(results);
 
     // Update service properties: instance
-    TEST_ASSERT_EQUAL(ESP_OK, mdns_service_instance_name_set(MDNS_SERVICE_NAME, MDNS_SERVICE_PROTO, MDNS_INSTANCE "1" ));
+    TEST_ASSERT_EQUAL(ESP_OK, mdns_service_instance_name_set(MDNS_SERVICE_NAME, MDNS_SERVICE_PROTO, MDNS_INSTANCE "1"));
     yield_to_all_priorities();  // Make sure that mdns task has executed to add the hostname
     TEST_ASSERT_EQUAL(ESP_OK, mdns_lookup_selfhosted_service(MDNS_INSTANCE "1", MDNS_SERVICE_NAME, MDNS_SERVICE_PROTO, 1, &results));
     TEST_ASSERT_NOT_EQUAL(NULL, results);
@@ -220,9 +220,9 @@ TEST(mdns, add_remove_deleg_service)
     mdns_result_t *results = NULL;
     test_case_uses_tcpip();
     TEST_ASSERT_EQUAL(ESP_OK, esp_event_loop_create_default());
-    TEST_ASSERT_EQUAL(ESP_OK, mdns_init() );
+    TEST_ASSERT_EQUAL(ESP_OK, mdns_init());
     TEST_ASSERT_EQUAL(ESP_OK, mdns_hostname_set(MDNS_HOSTNAME));
-    TEST_ASSERT_EQUAL(ESP_OK, mdns_delegate_hostname_add(MDNS_DELEGATE_HOSTNAME, &addr) );
+    TEST_ASSERT_EQUAL(ESP_OK, mdns_delegate_hostname_add(MDNS_DELEGATE_HOSTNAME, &addr));
 
     TEST_ASSERT_EQUAL(ESP_OK, mdns_service_add_for_host(MDNS_INSTANCE, MDNS_SERVICE_NAME, MDNS_SERVICE_PROTO, MDNS_DELEGATE_HOSTNAME, MDNS_SERVICE_PORT, NULL, 0));
     yield_to_all_priorities();  // Make sure that mdns task has executed to add the hostname
@@ -243,7 +243,7 @@ TEST(mdns, add_remove_deleg_service)
     mdns_query_results_free(results);
 
     // Update service properties: instance
-    TEST_ASSERT_EQUAL(ESP_OK, mdns_service_instance_name_set_for_host(NULL, MDNS_SERVICE_NAME, MDNS_SERVICE_PROTO, MDNS_DELEGATE_HOSTNAME, MDNS_INSTANCE "1" ));
+    TEST_ASSERT_EQUAL(ESP_OK, mdns_service_instance_name_set_for_host(NULL, MDNS_SERVICE_NAME, MDNS_SERVICE_PROTO, MDNS_DELEGATE_HOSTNAME, MDNS_INSTANCE "1"));
     yield_to_all_priorities();  // Make sure that mdns task has executed to add the hostname
     TEST_ASSERT_EQUAL(ESP_OK, mdns_lookup_delegated_service(MDNS_INSTANCE "1", MDNS_SERVICE_NAME, MDNS_SERVICE_PROTO, 1, &results));
     TEST_ASSERT_NOT_EQUAL(NULL, results);


### PR DESCRIPTION
* Brings up https://github.com/espressif/esp-protocols/pull/772
---

## [1.8.0](https://github.com/espressif/esp-protocols/commits/mdns-v1.8.0)

### Features

- Add version keys ([e01e67e7](https://github.com/espressif/esp-protocols/commit/e01e67e7))

### Bug Fixes

- Reformat mdns sources per indent-cont=120 ([c7663cde](https://github.com/espressif/esp-protocols/commit/c7663cde))

