### PR TITLE
Add config to enable SYS on mosquito and bump version

### DIFF
--- a/components/mosquitto/.cz.yaml
+++ b/components/mosquitto/.cz.yaml
@@ -3,6 +3,6 @@ commitizen:
   bump_message: 'bump(mosq): $current_version -> $new_version'
   pre_bump_hooks: python ../../ci/changelog.py mosquitto
   tag_format: mosq-v$version
-  version: 2.0.20~1
+  version: 2.0.20~2
   version_files:
   - idf_component.yml

--- a/components/mosquitto/CHANGELOG.md
+++ b/components/mosquitto/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [2.0.20~2](https://github.com/espressif/esp-protocols/commits/mosq-v2.0.20_2)
+
+### Features
+
+- Allow user to enable SYS topic ([905b84fb](https://github.com/espressif/esp-protocols/commit/905b84fb))
+
+### Bug Fixes
+
+- Remove temp modification of IDF files ([9162de11](https://github.com/espressif/esp-protocols/commit/9162de11))
+- Add a note about stack size ([dbd164dd](https://github.com/espressif/esp-protocols/commit/dbd164dd))
+
 ## [2.0.20~1](https://github.com/espressif/esp-protocols/commits/mosq-v2.0.20_1)
 
 ### Bug Fixes

--- a/components/mosquitto/CMakeLists.txt
+++ b/components/mosquitto/CMakeLists.txt
@@ -21,7 +21,6 @@ set(m_srcs
         ${m_lib_dir}/handle_pubrec.c
         ${m_lib_dir}/handle_pubrel.c
         ${m_lib_dir}/handle_ping.c
-        ${m_lib_dir}/time_mosq.c
         ${m_lib_dir}/utf8_mosq.c
 
         ${m_src_dir}/bridge.c
@@ -75,6 +74,7 @@ idf_component_register(SRCS ${m_srcs}
                             port/config.c
                             port/signals.c
                             port/broker.c
+                            port/mosq_time.c
                             port/files.c
                             port/net__esp_tls.c
                             port/sysconf.c
@@ -82,9 +82,12 @@ idf_component_register(SRCS ${m_srcs}
                                       ${m_incl_dir} ${m_lib_dir} ${m_deps_dir}
                     INCLUDE_DIRS ${m_incl_dir} port/include
                     REQUIRES esp-tls
-                    PRIV_REQUIRES newlib sock_utils)
+                    PRIV_REQUIRES newlib sock_utils esp_timer)
 
 target_compile_definitions(${COMPONENT_LIB} PRIVATE "WITH_BROKER")
+if (CONFIG_MOSQ_ENABLE_SYS)
+    target_compile_definitions(${COMPONENT_LIB} PRIVATE "WITH_SYS_TREE")
+endif()
 target_compile_options(${COMPONENT_LIB} PRIVATE "-Wno-format")
 
 # Some mosquitto source unconditionally define `_GNU_SOURCE` which collides with IDF build system

--- a/components/mosquitto/Kconfig
+++ b/components/mosquitto/Kconfig
@@ -1,0 +1,15 @@
+menu "Mosquitto"
+
+    config MOSQ_ENABLE_SYS
+        bool "Enable $SYS topics"
+        default n
+        help
+            Enable the $SYS topics for the broker
+
+    config MOSQ_SYS_UPDATE_INTERVAL
+        int "Update interval for the SYS topic"
+        default 10
+        depends on MOSQ_ENABLE_SYS
+        help
+            Time in seconds for the update of the $SYS topics for the broker
+endmenu

--- a/components/mosquitto/idf_component.yml
+++ b/components/mosquitto/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.0.20~1"
+version: "2.0.20~2"
 url: https://github.com/espressif/esp-protocols/tree/master/components/mosquitto
 description: The component provides a simple ESP32 port of mosquitto broker
 dependencies:

--- a/components/mosquitto/port/config.c
+++ b/components/mosquitto/port/config.c
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
- * SPDX-FileContributor: 2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileContributor: 2024-2025 Espressif Systems (Shanghai) CO LTD
  */
 #include "mosquitto_internal.h"
 #include "mosquitto_broker.h"
@@ -14,6 +14,7 @@
 #include "utlist.h"
 #include "lib_load.h"
 #include "syslog.h"
+#include "sdkconfig.h"
 
 
 void config__init(struct mosquitto__config *config)
@@ -66,7 +67,7 @@ void config__init(struct mosquitto__config *config)
     config->log_file = NULL;
 
     config->log_facility = LOG_DAEMON;
-    config->log_dest = MQTT3_LOG_STDERR | MQTT3_LOG_DLT;
+    config->log_dest = MQTT3_LOG_STDERR | MQTT3_LOG_TOPIC;
     if (db.verbose) {
         config->log_type = UINT_MAX;
     } else {
@@ -91,7 +92,9 @@ void config__init(struct mosquitto__config *config)
     config->queue_qos0_messages = false;
     config->retain_available = true;
     config->set_tcp_nodelay = false;
-    config->sys_interval = 10;
+#if defined(WITH_SYS_TREE)
+    config->sys_interval = CONFIG_MOSQ_SYS_UPDATE_INTERVAL;
+#endif
     config->upgrade_outgoing_qos = false;
 
     config->daemon = false;
@@ -236,7 +239,7 @@ char *misc__trimblanks(char *str)
 
 // Dummy definition of fork() to work around IDF warning: " warning: _fork is not implemented and will always fail"
 // fork() is used in mosquitto.c to deamonize the broker, which we do not call.
-pid_t fork (void)
+pid_t fork(void)
 {
     abort();
     return 0;

--- a/components/mosquitto/port/mosq_time.c
+++ b/components/mosquitto/port/mosq_time.c
@@ -1,7 +1,9 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2024 Roger Light <roger@atchoo.org>
  *
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * SPDX-FileContributor: 2025 Espressif Systems (Shanghai) CO LTD
  */
 
 #include <time.h>

--- a/components/mosquitto/port/mosq_time.c
+++ b/components/mosquitto/port/mosq_time.c
@@ -1,0 +1,19 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <time.h>
+#include "time_mosq.h"
+
+#include "esp_timer.h"
+
+void mosquitto_time_init(void)
+{
+}
+
+time_t mosquitto_time(void)
+{
+    return esp_timer_get_time() / 1000000; // Convert microseconds to seconds
+}

--- a/components/mosquitto/port/priv_include/config.h
+++ b/components/mosquitto/port/priv_include/config.h
@@ -12,4 +12,4 @@
 
 #include_next "config.h"
 
-#define VERSION "v2.0.20~1"
+#define VERSION "v2.0.20~2"


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

- Allow user to enable $SYS/# topics
- Provide a port layer for mosquitto get time functions. 


<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

Run the example with the new Kconfig options enabled.
<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
