### PR TITLE
[mdns]: Fix parsing incorrect txt records

### DIFF
--- a/components/mdns/.cz.yaml
+++ b/components/mdns/.cz.yaml
@@ -3,6 +3,6 @@ commitizen:
   bump_message: 'bump(mdns): $current_version -> $new_version'
   pre_bump_hooks: python ../../ci/changelog.py mdns
   tag_format: mdns-v$version
-  version: 1.8.1
+  version: 1.8.2
   version_files:
   - idf_component.yml

--- a/components/mdns/CHANGELOG.md
+++ b/components/mdns/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.8.2](https://github.com/espressif/esp-protocols/commits/mdns-v1.8.2)
+
+### Bug Fixes
+
+- Fix parsing incorrect txt records ([8fd2c99f](https://github.com/espressif/esp-protocols/commit/8fd2c99f))
+
 ## [1.8.1](https://github.com/espressif/esp-protocols/commits/mdns-v1.8.1)
 
 ### Bug Fixes

--- a/components/mdns/idf_component.yml
+++ b/components/mdns/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.8.1"
+version: "1.8.2"
 description: "Multicast UDP service used to provide local network service and host discovery."
 url: "https://github.com/espressif/esp-protocols/tree/master/components/mdns"
 issues: "https://github.com/espressif/esp-protocols/issues"

--- a/components/mdns/mdns.c
+++ b/components/mdns/mdns.c
@@ -3593,7 +3593,7 @@ static void _mdns_result_txt_create(const uint8_t *data, size_t len, mdns_txt_it
         }
 
         int name_len = _mdns_txt_item_name_get_len(data + i, partLen);
-        if (name_len < 0) {//invalid item (no name)
+        if (name_len < 0 || txt_num >= num_items) {//invalid item (no name or more items than expected)
             i += partLen;
             continue;
         }
@@ -3602,7 +3602,6 @@ static void _mdns_result_txt_create(const uint8_t *data, size_t len, mdns_txt_it
             HOOK_MALLOC_FAILED;
             goto handle_error;//error
         }
-
         mdns_txt_item_t *t = &txt[txt_num];
         uint8_t *value_len = &txt_value_len[txt_num];
         txt_num++;
@@ -3624,6 +3623,8 @@ static void _mdns_result_txt_create(const uint8_t *data, size_t len, mdns_txt_it
             *value_len = new_value_len;
             i += new_value_len;
             t->value = value;
+        } else {
+            t->value = NULL;
         }
     }
 


### PR DESCRIPTION
Issue discovered when fuzzing packet parser,
received packet with inconsistent txt section caused issues on final cleanup
