### PR TITLE
[mosq]: Fix pytest to use latest embedded packages

### DIFF
--- a/.github/workflows/mosq__build.yml
+++ b/.github/workflows/mosq__build.yml
@@ -169,7 +169,7 @@ jobs:
       - name: Run Test
         working-directory: ${{ env.TEST_DIR }}
         run: |
-          python -m pip install pytest-embedded-serial-esp pytest-embedded-idf pytest-rerunfailures pytest-timeout pytest-ignore-test-results "paho-mqtt<2"
+          python -m pip install pytest-embedded-serial-esp pytest-embedded-idf pytest-rerunfailures pytest-timeout pytest-ignore-test-results "paho-mqtt<2"  --upgrade
           unzip ci/artifacts.zip -d ci
           for dir in `ls -d ci/build_*`; do
           rm -rf build sdkconfig.defaults


### PR DESCRIPTION
* Per changes in https://github.com/espressif/esp-idf/commit/daf2d31008446592c66479e11484d79b94ef1d92