### PR TITLE
[lws]: Fix many file-not-found errors on clang-tidy job

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: 'true'
+          submodules: recursive
       - name: Install esp-clang
         run: |
           ${IDF_PATH}/tools/idf_tools.py --non-interactive install esp-clang


### PR DESCRIPTION
Address some of the code-scanning issues reported in https://github.com/espressif/esp-protocols/security/code-scanning