### PR TITLE
fix(lws): Remove clang tidy checks

### DIFF
--- a/test_app/CMakeLists.txt
+++ b/test_app/CMakeLists.txt
@@ -15,7 +15,6 @@ set(EXTRA_COMPONENT_DIRS
     ../components/console_simple_init
     ../components/mbedtls_cxx
     ../components/sock_utils
-    ../components/libwebsockets
     ../components/mdns)
 
 


### PR DESCRIPTION
Since lws hardcodes some flags in CMakeLists.txt, which causes compilation issues with:
* mbedtls, 
* generated lws_config.h
* flags `-mlongcalls`

see: https://github.com/warmcat/libwebsockets/blob/a74362ffdd17b7f6293f675edef6d602096a1e29/CMakeLists.txt#L898
