### PR TITLE
fix(mosq): include config.h before any system header

### DIFF
--- a/components/mosquitto/port/files.c
+++ b/components/mosquitto/port/files.c
@@ -3,11 +3,11 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
- * SPDX-FileContributor: 2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileContributor: 2024-2025 Espressif Systems (Shanghai) CO LTD
  */
-#include <ctype.h>
-#include "mosquitto.h"
 #include "mosquitto_broker_internal.h"
+#include "mosquitto.h"
+#include <ctype.h>
 
 // Dummy implementation of file access
 // This needs to be implemented if we need to load/store config from files

--- a/components/mosquitto/port/priv_include/config.h
+++ b/components/mosquitto/port/priv_include/config.h
@@ -1,15 +1,23 @@
 /*
- * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2024-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
+#include_next "config.h"
+
+/*
+ * =======================================================================
+ *  Do NOT include any other header before this comment.
+ *  config.h header configures critical macros that must be set before any
+ *  system or standard library headers are included.
+ * =======================================================================
+ */
+
 #include <ctype.h>
 #include "net/if.h"
 
 #undef  isspace
 #define isspace(__c) (__ctype_lookup((int)__c)&_S)
-
-#include_next "config.h"
 
 #define VERSION "v2.0.20~2"


### PR DESCRIPTION
## Description

config.h file must be included before any system header file

## Related

- https://github.com/eclipse-mosquitto/mosquitto/pull/3268

## Testing

Built a project with latest newlib version.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
