### PR TITLE
fix(modem): Consume buffer after handled URC (IDFGH-15245)

### DIFF
--- a/components/esp_modem/src/esp_modem_dte.cpp
+++ b/components/esp_modem/src/esp_modem_dte.cpp
@@ -370,7 +370,9 @@ bool DTE::command_cb::process_line(uint8_t *data, size_t consumed, size_t len)
 {
 #ifdef CONFIG_ESP_MODEM_URC_HANDLER
     if (urc_handler) {
-        urc_handler(data, consumed + len);
+        if (urc_handler(data, consumed + len) == command_result::OK) {
+            return true;
+        }
     }
     if (result != command_result::TIMEOUT || got_line == nullptr) {
         return false;   // this line has been processed already (got OK or FAIL previously)


### PR DESCRIPTION
- return DTE::command_cb::process_line true if urc_handler command_result::OK

After getting URC event it was still in the buffer and after calling next AT command it was analyzing it again, which was causing doubled call of urc_handler.