### PR TITLE
[eppp]: Fix NETIF_PPP_STATUS link issue if PPP disabled in lwip

### DIFF
--- a/components/eppp_link/.cz.yaml
+++ b/components/eppp_link/.cz.yaml
@@ -3,6 +3,6 @@ commitizen:
   bump_message: 'bump(eppp): $current_version -> $new_version'
   pre_bump_hooks: python ../../ci/changelog.py eppp_link
   tag_format: eppp-v$version
-  version: 0.3.0
+  version: 0.3.1
   version_files:
   - idf_component.yml

--- a/components/eppp_link/CHANGELOG.md
+++ b/components/eppp_link/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.3.1](https://github.com/espressif/esp-protocols/commits/eppp-v0.3.1)
+
+### Bug Fixes
+
+- Fix NETIF_PPP_STATUS link issue if PPP disabled in lwip ([077ea0bb](https://github.com/espressif/esp-protocols/commit/077ea0bb))
+
 ## [0.3.0](https://github.com/espressif/esp-protocols/commits/eppp-v0.3.0)
 
 ### Features

--- a/components/eppp_link/eppp_link.c
+++ b/components/eppp_link/eppp_link.c
@@ -163,6 +163,7 @@ static int get_netif_num(esp_netif_t *netif)
     return  netif_cnt;
 }
 
+#ifdef CONFIG_EPPP_LINK_USES_PPP
 static void on_ppp_event(void *arg, esp_event_base_t base, int32_t event_id, void *data)
 {
     esp_netif_t **netif = data;
@@ -172,6 +173,7 @@ static void on_ppp_event(void *arg, esp_event_base_t base, int32_t event_id, voi
         h->netif_stop = true;
     }
 }
+#endif // CONFIG_EPPP_LINK_USES_PPP
 
 static void on_ip_event(void *arg, esp_event_base_t base, int32_t event_id, void *data)
 {
@@ -222,7 +224,9 @@ static void remove_handlers(void)
         vEventGroupDelete(s_event_group);
         s_event_group = NULL;
         esp_event_handler_unregister(IP_EVENT, ESP_EVENT_ANY_ID, on_ip_event);
+#ifdef CONFIG_EPPP_LINK_USES_PPP
         esp_event_handler_unregister(NETIF_PPP_STATUS, ESP_EVENT_ANY_ID, on_ppp_event);
+#endif
     }
 }
 
@@ -296,11 +300,13 @@ esp_netif_t *eppp_open(eppp_type_t role, eppp_config_t *config, int connect_time
             remove_handlers();
             return NULL;
         }
+#ifdef CONFIG_EPPP_LINK_USES_PPP
         if (esp_event_handler_register(NETIF_PPP_STATUS, ESP_EVENT_ANY_ID, on_ppp_event, NULL) !=  ESP_OK) {
             ESP_LOGE(TAG, "Failed to register PPP status handler");
             remove_handlers();
             return NULL;
         }
+#endif // CONFIG_EPPP_LINK_USES_PPP
     }
     esp_netif_t *netif = eppp_init(role, config);
     if (!netif) {

--- a/components/eppp_link/idf_component.yml
+++ b/components/eppp_link/idf_component.yml
@@ -1,4 +1,4 @@
-version: 0.3.0
+version: 0.3.1
 url: https://github.com/espressif/esp-protocols/tree/master/components/eppp_link
 description: The component provides a general purpose PPP connectivity, typically used as WiFi-PPP router
 dependencies:


### PR DESCRIPTION
Fix build issue: https://github.com/espressif/esp-wifi-remote/actions/runs/15608335998/job/43963036566 since PPP is OFF by default in lwip