### PR TITLE
[mdns]: Fix host tests by freezing idf-build-apps to 2.10

### DIFF
--- a/.github/workflows/mdns__host-tests.yml
+++ b/.github/workflows/mdns__host-tests.yml
@@ -24,7 +24,7 @@ jobs:
         shell: bash
         run: |
           . ${IDF_PATH}/export.sh
-          python -m pip install idf-build-apps dnspython pytest pytest-embedded pytest-embedded-serial-esp pytest-embedded-idf
+          python -m pip install idf-build-apps==2.10.0 dnspython pytest pytest-embedded pytest-embedded-serial-esp pytest-embedded-idf
           cd $GITHUB_WORKSPACE/protocols
           # Build host tests app (with all configs and targets supported)
           python ./ci/build_apps.py components/mdns/tests/host_test/


### PR DESCRIPTION
Fixes: https://github.com/espressif/esp-protocols/actions/runs/15610323341/job/43969460962

## Root cause

`idf-build-apps` >= v2.11 won't build preview targets

## TODO

In the followup PR: Fix it in our wrapper https://github.com/espressif/esp-protocols/blob/master/ci/build_apps.py