### PR TITLE
[dns]: Fix http event handler to accept default case

### DIFF
--- a/components/esp_dns/esp_dns_doh.c
+++ b/components/esp_dns/esp_dns_doh.c
@@ -177,6 +177,9 @@ esp_err_t esp_dns_http_event_handler(esp_http_client_event_t *evt)
     case HTTP_EVENT_REDIRECT:
         ESP_LOGE(TAG, "HTTP_EVENT_REDIRECT: Not supported(%d)", esp_http_client_get_status_code(evt->client));
         break;
+    default:
+        ESP_LOGD(TAG, "Other HTTP event: %d", evt->event_id);
+        break;
     }
     return ESP_OK;
 }


### PR DESCRIPTION
Fixes https://github.com/espressif/esp-protocols/actions/runs/15843752057/job/44661192291

http-client API added `HTTP_EVENT_ON_HEADERS_COMPLETE` on the latest IDF master