### PR TITLE
fix Stuck when ‘disable_auto_reconnect = false’ and Call 'esp_websocket_client_close' when the connection fails and automatically reconnects (IDFGH-15854)

### DIFF
--- a/components/esp_websocket_client/esp_websocket_client.c
+++ b/components/esp_websocket_client/esp_websocket_client.c
@@ -1220,6 +1220,7 @@ static int esp_websocket_client_send_close(esp_websocket_client_handle_t client,
 
 static esp_err_t esp_websocket_client_close_with_optional_body(esp_websocket_client_handle_t client, bool send_body, int code, const char *data, int len, TickType_t timeout)
 {
+    int err = ESP_OK;
     if (client == NULL) {
         return ESP_ERR_INVALID_ARG;
     }
@@ -1236,9 +1237,13 @@ static esp_err_t esp_websocket_client_close_with_optional_body(esp_websocket_cli
     }
 
     if (send_body) {
-        esp_websocket_client_send_close(client, code, data, len + 2, portMAX_DELAY); // len + 2 -> always sending the code
+        err = esp_websocket_client_send_close(client, code, data, len + 2, portMAX_DELAY); // len + 2 -> always sending the code
     } else {
-        esp_websocket_client_send_close(client, 0, NULL, 0, portMAX_DELAY); // only opcode frame
+        err = esp_websocket_client_send_close(client, 0, NULL, 0, portMAX_DELAY); // only opcode frame
+    }
+    if (err != ESP_OK) {
+        ESP_LOGW(TAG, "Client was not connected");
+        return ESP_FAIL;
     }
 
     // Set closing bit to prevent from sending PING frames while connected


### PR DESCRIPTION
bug 复现步骤
1. 配置 `disable_auto_reconnect = false` 开启自动重连功能
2. 建立一个无法连接的client，此时后台任务会在后台重连，并且此时 `client->run` is `true`
3. 调用 `esp_websocket_client_close` 关闭此 clent 会堵塞在此函数中。