### PR TITLE
[examples]: Use another public broker for MQTT example

### DIFF
--- a/examples/mqtt/main/Kconfig.projbuild
+++ b/examples/mqtt/main/Kconfig.projbuild
@@ -2,7 +2,7 @@ menu "Example Configuration"
 
     config BROKER_URL
         string "Broker URL"
-        default "mqtt://mqtt.eclipseprojects.io"
+        default "mqtt://test.mosquitto.org"
         help
             URL of the broker to connect to
 


### PR DESCRIPTION
Again `mqtt.eclipseprojects.io` ->  `mqtt://test.mosquitto.org`

Fixes: https://github.com/espressif/esp-protocols/actions/runs/16224632056/job/45813522813
