### PR TITLE
docs: fix esp_websocket_client changelog formatting

### DIFF
--- a/components/esp_websocket_client/CHANGELOG.md
+++ b/components/esp_websocket_client/CHANGELOG.md
@@ -120,7 +120,9 @@
 ### Updated
 
 - esp_websocket_client: Updated version to 1.0.0 Updated tests to run agains release-v5.0 ([996fef7](https://github.com/espressif/esp-protocols/commit/996fef7))
-- esp_websocket_client: * Error handling improved to show status code from server * Added new API `esp_websocket_client_set_headers` * Dispatches 'WEBSOCKET_EVENT_BEFORE_CONNECT' event before tcp connection ([d047ff5](https://github.com/espressif/esp-protocols/commit/d047ff5))
+- esp_websocket_client: Error handling improved to show status code from server ([d047ff5](https://github.com/espressif/esp-protocols/commit/d047ff5))
+- esp_websocket_client: Added new API `esp_websocket_client_set_headers` ([d047ff5](https://github.com/espressif/esp-protocols/commit/d047ff5))
+- esp_websocket_client: Dispatches 'WEBSOCKET_EVENT_BEFORE_CONNECT' event before tcp connection ([d047ff5](https://github.com/espressif/esp-protocols/commit/d047ff5))
 - unite all tags under common structure py test: update tags under common structure ([c6db3ea](https://github.com/espressif/esp-protocols/commit/c6db3ea))
 - websocket: Support HTTP basic authorization ([1b13448](https://github.com/espressif/esp-protocols/commit/1b13448))
 - Add task_name config option ([1d68884](https://github.com/espressif/esp-protocols/commit/1d68884))


### PR DESCRIPTION
## Description

Break up commit text into a line per functional change and fix markdown parsing.

## Testing

Tested by viewing [CHANGELOG.md](https://github.com/bryghtlabs-richard/esp-protocols/blob/docs/websocketChangelog/components/esp_websocket_client/CHANGELOG.md) in github in Chrome.
---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [X] 🚨 This PR does not introduce breaking changes.
- [X] All CI checks (GH Actions) pass.
- [X] Documentation is updated as needed.
- [X] Tests are updated or added as necessary.
- [X] Code is well-commented, especially in complex areas.
- [X] Git history is clean — commits are squashed to the minimum necessary.
