### PR TITLE
[modem]: Support esp-modem use without PPP

### DIFF
--- a/components/esp_modem/Kconfig
+++ b/components/esp_modem/Kconfig
@@ -103,4 +103,14 @@ menu "esp-modem"
             Set this to 'y' if you're making changes to the actual sources of
             the AT command definitions (typically in esp_modem_command_declare.inc)
 
+    config ESP_MODEM_USE_PPP_MODE
+        bool "Use PPP mode"
+        default y
+        select LWIP_PPP_SUPPORT
+        help
+            If enabled, the library can use PPP netif from lwip.
+            This is the default and most common setting.
+            But it's possible to disable it and use only AT commands,
+            in this case it's not required to enable LWIP_PPP_SUPPORT.
+
 endmenu

--- a/components/esp_modem/include/cxx_include/esp_modem_dce_factory.hpp
+++ b/components/esp_modem/include/cxx_include/esp_modem_dce_factory.hpp
@@ -62,12 +62,16 @@ class Creator {
 public:
     Creator(std::shared_ptr<DTE> dte, esp_netif_t *esp_netif): dte(std::move(dte)), device(nullptr), netif(esp_netif)
     {
+#ifdef CONFIG_ESP_MODEM_USE_PPP_MODE
         ESP_MODEM_THROW_IF_FALSE(netif != nullptr, "Null netif");
+#endif
     }
 
     Creator(std::shared_ptr<DTE> dte, esp_netif_t *esp_netif, std::shared_ptr<T_Module> dev): dte(std::move(dte)), device(std::move(dev)), netif(esp_netif)
     {
+#ifdef CONFIG_ESP_MODEM_USE_PPP_MODE
         ESP_MODEM_THROW_IF_FALSE(netif != nullptr, "Null netif");
+#endif
     }
 
     explicit Creator(std::shared_ptr<DTE> dte): dte(std::move(dte)), device(nullptr), netif(nullptr)


### PR DESCRIPTION
* Closes https://github.com/espressif/esp-protocols/issues/851

Supports building (and using) modem library without PPP mode.
It is already possible (see the [tcp-client](https://github.com/espressif/esp-protocols/tree/master/components/esp_modem/examples/modem_tcp_client) examples), but it only works with C++ interface.
This is more straight-forward approach.
It also assures PPP mode is "selected" for new projects that pull `esp_modem` component.

