### PR TITLE
[eppp]: Bump 1.0.1 -> 1.1.0

### DIFF
--- a/components/eppp_link/.cz.yaml
+++ b/components/eppp_link/.cz.yaml
@@ -3,6 +3,6 @@ commitizen:
   bump_message: 'bump(eppp): $current_version -> $new_version'
   pre_bump_hooks: python ../../ci/changelog.py eppp_link
   tag_format: eppp-v$version
-  version: 1.0.1
+  version: 1.1.0
   version_files:
   - idf_component.yml

--- a/components/eppp_link/CHANGELOG.md
+++ b/components/eppp_link/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [1.1.0](https://github.com/espressif/esp-protocols/commits/eppp-v1.1.0)
+
+### Features
+
+- Add support for UART flow control ([cd57f1bb](https://github.com/espressif/esp-protocols/commit/cd57f1bb), [#870](https://github.com/espressif/esp-protocols/issues/870))
+
+### Bug Fixes
+
+- Fix SPI transport to allow already init GPIO ISR ([497ee2d6](https://github.com/espressif/esp-protocols/commit/497ee2d6), [#868](https://github.com/espressif/esp-protocols/issues/868))
+- Fix stack-overflow in ping task for TUN netif ([b2568a3d](https://github.com/espressif/esp-protocols/commit/b2568a3d), [#867](https://github.com/espressif/esp-protocols/issues/867))
+
+### Updated
+
+- ci(common): Update test component dir for IDFv6.0 ([18418c83](https://github.com/espressif/esp-protocols/commit/18418c83))
+
 ## [1.0.1](https://github.com/espressif/esp-protocols/commits/eppp-v1.0.1)
 
 ### Bug Fixes

--- a/components/eppp_link/idf_component.yml
+++ b/components/eppp_link/idf_component.yml
@@ -1,4 +1,4 @@
-version: 1.0.1
+version: 1.1.0
 url: https://github.com/espressif/esp-protocols/tree/master/components/eppp_link
 description: The component provides a general purpose PPP connectivity, typically used as WiFi-PPP router
 dependencies:


### PR DESCRIPTION
## [1.1.0](https://github.com/espressif/esp-protocols/commits/eppp-v1.1.0)

### Features

- Add support for UART flow control ([cd57f1bb](https://github.com/espressif/esp-protocols/commit/cd57f1bb), [#870](https://github.com/espressif/esp-protocols/issues/870))

### Bug Fixes

- Fix SPI transport to allow already init GPIO ISR ([497ee2d6](https://github.com/espressif/esp-protocols/commit/497ee2d6), [#868](https://github.com/espressif/esp-protocols/issues/868))
- Fix stack-overflow in ping task for TUN netif ([b2568a3d](https://github.com/espressif/esp-protocols/commit/b2568a3d), [#867](https://github.com/espressif/esp-protocols/issues/867))