### PR TITLE
fix: drop newlib from PRIV_REQUIRES

### DIFF
--- a/components/mosquitto/CMakeLists.txt
+++ b/components/mosquitto/CMakeLists.txt
@@ -82,7 +82,7 @@ idf_component_register(SRCS ${m_srcs}
                                       ${m_incl_dir} ${m_lib_dir} ${m_deps_dir}
                     INCLUDE_DIRS ${m_incl_dir} port/include
                     REQUIRES esp-tls
-                    PRIV_REQUIRES newlib sock_utils esp_timer)
+                    PRIV_REQUIRES sock_utils esp_timer)
 
 target_compile_definitions(${COMPONENT_LIB} PRIVATE "WITH_BROKER")
 if (CONFIG_MOSQ_ENABLE_SYS)

--- a/components/mosquitto/examples/broker/main/CMakeLists.txt
+++ b/components/mosquitto/examples/broker/main/CMakeLists.txt
@@ -1,3 +1,3 @@
 idf_component_register(SRCS "example_broker.c"
-                       PRIV_REQUIRES newlib nvs_flash esp_netif esp_event mqtt
+                       PRIV_REQUIRES nvs_flash esp_netif esp_event mqtt
                        EMBED_TXTFILES servercert.pem serverkey.pem cacert.pem)


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description
`newlib` component is going to be renamed to `esp_libc`
I don't see reasons for adding the component via PRIV_REQUIRES because it is already in g1_components

If you lack some private `newlib` headers, I believe they should be made public.

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

- ESP-IDF MR !41584
<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
