### PR TITLE
fix(websocket): Fix asprintf return value handling in websocket client

### DIFF
--- a/components/esp_websocket_client/esp_websocket_client.c
+++ b/components/esp_websocket_client/esp_websocket_client.c
@@ -727,10 +727,16 @@ esp_websocket_client_handle_t esp_websocket_client_init(const esp_websocket_clie
     ESP_WS_CLIENT_MEM_CHECK(TAG, client->config, goto _websocket_init_fail);
 
     if (config->transport == WEBSOCKET_TRANSPORT_OVER_TCP) {
-        asprintf(&client->config->scheme, WS_OVER_TCP_SCHEME);
+        if (asprintf(&client->config->scheme, WS_OVER_TCP_SCHEME) == -1) {
+            ESP_LOGE(TAG, "Failed to allocate memory for scheme");
+            goto _websocket_init_fail;
+        }
         ESP_WS_CLIENT_MEM_CHECK(TAG, client->config->scheme, goto _websocket_init_fail);
     } else if (config->transport == WEBSOCKET_TRANSPORT_OVER_SSL) {
-        asprintf(&client->config->scheme, WS_OVER_TLS_SCHEME);
+        if (asprintf(&client->config->scheme, WS_OVER_TLS_SCHEME) == -1) {
+            ESP_LOGE(TAG, "Failed to allocate memory for scheme");
+            goto _websocket_init_fail;
+        }
         ESP_WS_CLIENT_MEM_CHECK(TAG, client->config->scheme, goto _websocket_init_fail);
     }
 
@@ -775,7 +781,10 @@ esp_websocket_client_handle_t esp_websocket_client_init(const esp_websocket_clie
     }
 
     if (client->config->scheme == NULL) {
-        asprintf(&client->config->scheme, WS_OVER_TCP_SCHEME);
+        if (asprintf(&client->config->scheme, WS_OVER_TCP_SCHEME) == -1) {
+            ESP_LOGE(TAG, "Failed to allocate memory for scheme");
+            goto _websocket_init_fail;
+        }
         ESP_WS_CLIENT_MEM_CHECK(TAG, client->config->scheme, goto _websocket_init_fail);
     }
 
@@ -852,13 +861,19 @@ esp_err_t esp_websocket_client_set_uri(esp_websocket_client_handle_t client, con
     }
     if (puri.field_data[UF_SCHEMA].len) {
         free(client->config->scheme);
-        asprintf(&client->config->scheme, "%.*s", puri.field_data[UF_SCHEMA].len, uri + puri.field_data[UF_SCHEMA].off);
+        if (asprintf(&client->config->scheme, "%.*s", puri.field_data[UF_SCHEMA].len, uri + puri.field_data[UF_SCHEMA].off) == -1) {
+            ESP_LOGE(TAG, "Failed to allocate memory for scheme");
+            return ESP_ERR_NO_MEM;
+        }
         ESP_WS_CLIENT_MEM_CHECK(TAG, client->config->scheme, return ESP_ERR_NO_MEM);
     }
 
     if (puri.field_data[UF_HOST].len) {
         free(client->config->host);
-        asprintf(&client->config->host, "%.*s", puri.field_data[UF_HOST].len, uri + puri.field_data[UF_HOST].off);
+        if (asprintf(&client->config->host, "%.*s", puri.field_data[UF_HOST].len, uri + puri.field_data[UF_HOST].off) == -1) {
+            ESP_LOGE(TAG, "Failed to allocate memory for host");
+            return ESP_ERR_NO_MEM;
+        }
         ESP_WS_CLIENT_MEM_CHECK(TAG, client->config->host, return ESP_ERR_NO_MEM);
     }
 
@@ -866,12 +881,21 @@ esp_err_t esp_websocket_client_set_uri(esp_websocket_client_handle_t client, con
     if (puri.field_data[UF_PATH].len || puri.field_data[UF_QUERY].len) {
         free(client->config->path);
         if (puri.field_data[UF_QUERY].len == 0) {
-            asprintf(&client->config->path, "%.*s", puri.field_data[UF_PATH].len, uri + puri.field_data[UF_PATH].off);
+            if (asprintf(&client->config->path, "%.*s", puri.field_data[UF_PATH].len, uri + puri.field_data[UF_PATH].off) == -1) {
+                ESP_LOGE(TAG, "Failed to allocate memory for path");
+                return ESP_ERR_NO_MEM;
+            }
         } else if (puri.field_data[UF_PATH].len == 0)  {
-            asprintf(&client->config->path, "/?%.*s", puri.field_data[UF_QUERY].len, uri + puri.field_data[UF_QUERY].off);
+            if (asprintf(&client->config->path, "/?%.*s", puri.field_data[UF_QUERY].len, uri + puri.field_data[UF_QUERY].off) == -1) {
+                ESP_LOGE(TAG, "Failed to allocate memory for path");
+                return ESP_ERR_NO_MEM;
+            }
         } else {
-            asprintf(&client->config->path, "%.*s?%.*s", puri.field_data[UF_PATH].len, uri + puri.field_data[UF_PATH].off,
-                     puri.field_data[UF_QUERY].len, uri + puri.field_data[UF_QUERY].off);
+            if (asprintf(&client->config->path, "%.*s?%.*s", puri.field_data[UF_PATH].len, uri + puri.field_data[UF_PATH].off,
+                         puri.field_data[UF_QUERY].len, uri + puri.field_data[UF_QUERY].off) == -1) {
+                ESP_LOGE(TAG, "Failed to allocate memory for path");
+                return ESP_ERR_NO_MEM;
+            }
         }
         ESP_WS_CLIENT_MEM_CHECK(TAG, client->config->path, return ESP_ERR_NO_MEM);
     }
@@ -881,7 +905,10 @@ esp_err_t esp_websocket_client_set_uri(esp_websocket_client_handle_t client, con
 
     if (puri.field_data[UF_USERINFO].len) {
         char *user_info = NULL;
-        asprintf(&user_info, "%.*s", puri.field_data[UF_USERINFO].len, uri + puri.field_data[UF_USERINFO].off);
+        if (asprintf(&user_info, "%.*s", puri.field_data[UF_USERINFO].len, uri + puri.field_data[UF_USERINFO].off) == -1) {
+            ESP_LOGE(TAG, "Failed to allocate memory for user info");
+            return ESP_ERR_NO_MEM;
+        }
         if (user_info) {
             char *pass = strchr(user_info, ':');
             if (pass) {


### PR DESCRIPTION
## Description

The websocket client code was calling asprintf() functions without checking their return values, which triggered -Werror=unused-result compiler warnings. The asprintf() function returns -1 on memory allocation failure, but the original code ignored this return value, potentially leading to potential crashes or undefined behavior

## Testing
`esp-protocols` CI pipeline execution 

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
