### PR TITLE
fix(websocket): fix relying on asprintf() to NULL strp on failure (IDFGH-16595)

### DIFF
--- a/components/esp_websocket_client/esp_websocket_client.c
+++ b/components/esp_websocket_client/esp_websocket_client.c
@@ -727,10 +727,14 @@ esp_websocket_client_handle_t esp_websocket_client_init(const esp_websocket_clie
     ESP_WS_CLIENT_MEM_CHECK(TAG, client->config, goto _websocket_init_fail);
 
     if (config->transport == WEBSOCKET_TRANSPORT_OVER_TCP) {
-        asprintf(&client->config->scheme, WS_OVER_TCP_SCHEME);
+        if (asprintf(&client->config->scheme, WS_OVER_TCP_SCHEME) < 0) {
+            client->config->scheme = NULL;
+        }
         ESP_WS_CLIENT_MEM_CHECK(TAG, client->config->scheme, goto _websocket_init_fail);
     } else if (config->transport == WEBSOCKET_TRANSPORT_OVER_SSL) {
-        asprintf(&client->config->scheme, WS_OVER_TLS_SCHEME);
+        if (asprintf(&client->config->scheme, WS_OVER_TLS_SCHEME) < 0) {
+            client->config->scheme = NULL;
+        }
         ESP_WS_CLIENT_MEM_CHECK(TAG, client->config->scheme, goto _websocket_init_fail);
     }
 
@@ -775,7 +779,9 @@ esp_websocket_client_handle_t esp_websocket_client_init(const esp_websocket_clie
     }
 
     if (client->config->scheme == NULL) {
-        asprintf(&client->config->scheme, WS_OVER_TCP_SCHEME);
+        if (asprintf(&client->config->scheme, WS_OVER_TCP_SCHEME) < 0) {
+            client->config->scheme = NULL;
+        }
         ESP_WS_CLIENT_MEM_CHECK(TAG, client->config->scheme, goto _websocket_init_fail);
     }
 
@@ -852,26 +858,34 @@ esp_err_t esp_websocket_client_set_uri(esp_websocket_client_handle_t client, con
     }
     if (puri.field_data[UF_SCHEMA].len) {
         free(client->config->scheme);
-        asprintf(&client->config->scheme, "%.*s", puri.field_data[UF_SCHEMA].len, uri + puri.field_data[UF_SCHEMA].off);
+        if (asprintf(&client->config->scheme, "%.*s", puri.field_data[UF_SCHEMA].len, uri + puri.field_data[UF_SCHEMA].off) < 0) {
+            client->config->scheme = NULL;
+        }
         ESP_WS_CLIENT_MEM_CHECK(TAG, client->config->scheme, return ESP_ERR_NO_MEM);
     }
 
     if (puri.field_data[UF_HOST].len) {
         free(client->config->host);
-        asprintf(&client->config->host, "%.*s", puri.field_data[UF_HOST].len, uri + puri.field_data[UF_HOST].off);
+        if (asprintf(&client->config->host, "%.*s", puri.field_data[UF_HOST].len, uri + puri.field_data[UF_HOST].off) < 0) {
+            client->config->host = NULL;
+        }
         ESP_WS_CLIENT_MEM_CHECK(TAG, client->config->host, return ESP_ERR_NO_MEM);
     }
 
 
     if (puri.field_data[UF_PATH].len || puri.field_data[UF_QUERY].len) {
         free(client->config->path);
+        int aret = -1;
         if (puri.field_data[UF_QUERY].len == 0) {
-            asprintf(&client->config->path, "%.*s", puri.field_data[UF_PATH].len, uri + puri.field_data[UF_PATH].off);
+            aret = asprintf(&client->config->path, "%.*s", puri.field_data[UF_PATH].len, uri + puri.field_data[UF_PATH].off);
         } else if (puri.field_data[UF_PATH].len == 0)  {
-            asprintf(&client->config->path, "/?%.*s", puri.field_data[UF_QUERY].len, uri + puri.field_data[UF_QUERY].off);
+            aret = asprintf(&client->config->path, "/?%.*s", puri.field_data[UF_QUERY].len, uri + puri.field_data[UF_QUERY].off);
         } else {
-            asprintf(&client->config->path, "%.*s?%.*s", puri.field_data[UF_PATH].len, uri + puri.field_data[UF_PATH].off,
-                     puri.field_data[UF_QUERY].len, uri + puri.field_data[UF_QUERY].off);
+            aret = asprintf(&client->config->path, "%.*s?%.*s", puri.field_data[UF_PATH].len, uri + puri.field_data[UF_PATH].off,
+                            puri.field_data[UF_QUERY].len, uri + puri.field_data[UF_QUERY].off);
+        }
+        if (aret < 0) {
+            client->config->path = NULL;
         }
         ESP_WS_CLIENT_MEM_CHECK(TAG, client->config->path, return ESP_ERR_NO_MEM);
     }
@@ -881,7 +895,9 @@ esp_err_t esp_websocket_client_set_uri(esp_websocket_client_handle_t client, con
 
     if (puri.field_data[UF_USERINFO].len) {
         char *user_info = NULL;
-        asprintf(&user_info, "%.*s", puri.field_data[UF_USERINFO].len, uri + puri.field_data[UF_USERINFO].off);
+        if (asprintf(&user_info, "%.*s", puri.field_data[UF_USERINFO].len, uri + puri.field_data[UF_USERINFO].off) < 0) {
+            user_info = NULL;
+        }
         if (user_info) {
             char *pass = strchr(user_info, ':');
             if (pass) {


### PR DESCRIPTION
## Description

Fixes "error: ignoring return value of ‘asprintf’ declared with attribute ‘warn_unused_result’ [-Werror=unused-result]"

## Related

Blocking CI run of https://github.com/espressif/esp-protocols/issues/715

## Testing

I don't have a great way to test this - it's a fix to allocation failure handling, but those allocation failures don't often occur on our products.

On the current FreeRTOS + newlib-libc, failing asprintf() sets strp=NULL, so this patch isn't expected to have a functional impact today, just fix the compiler errors and would improve portability on potential future platforms.

I did test by backporting and flashing onto our products - no functional impact.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [X] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [X] Documentation is updated as needed.
- [X] Tests are updated or added as necessary.
- [X] Code is well-commented, especially in complex areas.
- [X] Git history is clean — commits are squashed to the minimum necessary.
