### PR TITLE
Add esp_driver_uart dependency for new esp-idf (IDFGH-16663)

### DIFF
--- a/components/esp_modem/CMakeLists.txt
+++ b/components/esp_modem/CMakeLists.txt
@@ -11,7 +11,7 @@ else()
                       src/esp_modem_uart.cpp
                       src/esp_modem_term_uart.cpp
                       src/esp_modem_netif.cpp)
-    set(dependencies driver esp_event esp_netif)
+    set(dependencies driver esp_driver_uart esp_event esp_netif)
 endif()
 
 


### PR DESCRIPTION
newest esp-idf version requires additional dependencies to be added, otherwise it doesnt cmake anymore