### PR TITLE
ci(common): Ignore ethernet warning

### DIFF
--- a/ci/ignore_build_warnings.txt
+++ b/ci/ignore_build_warnings.txt
@@ -4,3 +4,4 @@ Warning: Deprecated: Option '--flash_mode' is deprecated. Use '--flash-mode' ins
 Warning: Deprecated: Option '--flash_freq' is deprecated. Use '--flash-freq' instead.
 Warning: Deprecated: Command 'sign_data' is deprecated. Use 'sign-data' instead.
 Warning: Deprecated: Command 'extract_public_key' is deprecated. Use 'extract-public-key' instead.
+warning: unknown kconfig symbol 'EXAMPLE_ETH_PHY_IP101'

--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -6,3 +6,4 @@ dpkt
 pytest
 idf_build_apps
 netifaces
+esptool>=5.1.0


### PR DESCRIPTION

<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description
 - Currently the "latest" docker image is outdated causing some warnings regarding the eth driver configs.

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

