### PR TITLE
feat(websocket): support per-message compression (RFC7692) (IDFGH-16651)

### DIFF
--- a/components/esp_websocket_client/CMakeLists.txt
+++ b/components/esp_websocket_client/CMakeLists.txt
@@ -8,14 +8,20 @@ if(NOT CONFIG_WS_TRANSPORT AND NOT CMAKE_BUILD_EARLY_EXPANSION)
     return()
 endif()
 
+set(PRIV_INCLUDE_LIST esp_timer)
+
+if(CONFIG_ESP_WS_CLIENT_ENABLE_COMPRESSION AND NOT CMAKE_BUILD_EARLY_EXPANSION)
+    set(PRIV_INCLUDE_LIST ${PRIV_INCLUDE_LIST} zlib)
+endif ()
+
 if(${IDF_TARGET} STREQUAL "linux")
 	idf_component_register(SRCS "esp_websocket_client.c"
                     INCLUDE_DIRS "include"
                     REQUIRES esp-tls tcp_transport http_parser esp_event nvs_flash esp_stubs json
-                    PRIV_REQUIRES esp_timer)
+                    PRIV_REQUIRES ${PRIV_INCLUDE_LIST})
 else()
     idf_component_register(SRCS "esp_websocket_client.c"
                     INCLUDE_DIRS "include"
                     REQUIRES lwip esp-tls tcp_transport http_parser esp_event
-                    PRIV_REQUIRES esp_timer)
+                    PRIV_REQUIRES ${PRIV_INCLUDE_LIST})
 endif()

--- a/components/esp_websocket_client/Kconfig
+++ b/components/esp_websocket_client/Kconfig
@@ -20,4 +20,11 @@ menu "ESP WebSocket client"
         default 2000
         help
             Timeout for acquiring the TX lock when using separate TX lock.
+
+    config ESP_WS_CLIENT_ENABLE_COMPRESSION
+        bool "Enable per-message compression support (RFC7692)"
+        default n
+        help
+            Enable this option will build with zlib, and support RFC7692 per-message DEFLATE compression.
+
 endmenu

--- a/components/esp_websocket_client/idf_component.yml
+++ b/components/esp_websocket_client/idf_component.yml
@@ -1,6 +1,8 @@
-version: "1.5.0"
+version: 1.5.0
 description: WebSocket protocol client for ESP-IDF
-url: https://github.com/espressif/esp-protocols/tree/master/components/esp_websocket_client
+url:
+  https://github.com/espressif/esp-protocols/tree/master/components/esp_websocket_client
 dependencies:
   idf:
-    version: ">=5.0"
+    version: '>=5.0'
+  espressif/zlib: ^1.3.1

--- a/components/esp_websocket_client/include/esp_websocket_client.h
+++ b/components/esp_websocket_client/include/esp_websocket_client.h
@@ -49,7 +49,10 @@ typedef enum {
     WEBSOCKET_ERROR_TYPE_TCP_TRANSPORT,
     WEBSOCKET_ERROR_TYPE_PONG_TIMEOUT,
     WEBSOCKET_ERROR_TYPE_HANDSHAKE,
-    WEBSOCKET_ERROR_TYPE_SERVER_CLOSE
+    WEBSOCKET_ERROR_TYPE_SERVER_CLOSE,
+#ifdef CONFIG_ESP_WS_CLIENT_ENABLE_COMPRESSION
+    WEBSOCKET_ERROR_TYPE_COMPRESSION,
+#endif
 } esp_websocket_error_type_t;
 
 /**
@@ -136,6 +139,19 @@ typedef struct {
     size_t                      ping_interval_sec;          /*!< Websocket ping interval, defaults to 10 seconds if not set */
     struct ifreq                *if_name;                   /*!< The name of interface for data to go through. Use the default interface without setting */
     esp_transport_handle_t      ext_transport;              /*!< External WebSocket tcp_transport handle to the client; or if null, the client will create its own transport handle. */
+
+#ifdef CONFIG_ESP_WS_CLIENT_ENABLE_COMPRESSION
+    bool                        per_msg_compress;                   /*!< Enable per-message compression (RFC7692) */
+    int                         per_msg_client_deflate_window_bit;  /*!< Hint the server Per-message deflate window bit 8 to 15; or leave 0 to let server decide */
+    int                         per_msg_server_deflate_window_bit;  /*!< Hint the server Per-message deflate window bit 8 to 15; or leave 0 to let server decide */
+    bool                        per_msg_server_no_ctx_takeover;     /*!< Hint the server to reset the compression stream on every WS frame on server side
+                                                                     *   True for a safer transfer, false for better performance */
+    bool                        per_msg_client_no_ctx_takeover;     /*!< Hint the server to reset the compression stream on every WS frame on client side
+                                                                     *   True for a safer transfer, false for better performance */
+    int                         per_msg_compress_level;             /*!< Compression level for zlib DEFLATE, from 0 to 9
+                                                                     *   0 means no compression (just copy), 1 means fastest compression, 9 means best compression */
+#endif
+
 } esp_websocket_client_config_t;
 
 /**


### PR DESCRIPTION
## Description

This PR is for add the support for per-message compression (deflate) for websocket client. 

Please note that this PR is depends on its parent PR in ESP-IDF: https://github.com/espressif/esp-idf/pull/17746

## Related

See:

- https://github.com/espressif/esp-idf/pull/17746
- https://github.com/espressif/esp-protocols/issues/912

## Testing

I will test with a Node.js and/or Bun.js server and see if it actually works or not. 

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
