### PR TITLE
fix(modem): CEREG parsing fails due to incorrect state index (IDFGH-16681) (IDFGH-16682)

### DIFF
--- a/components/esp_modem/src/esp_modem_command_library.cpp
+++ b/components/esp_modem/src/esp_modem_command_library.cpp
@@ -641,6 +641,8 @@ command_result get_network_registration_state(CommandableIf *t, int &state)
         return command_result::FAIL;
     }
 
+    state_pos_start += 1; // move past the comma
+
     if (out.find(pattern) == std::string::npos || (state_pos_end = out.find(',', state_pos_start)) == std::string::npos) {
         if (std::from_chars(out.data() + state_pos_start, out.data() + out.size(), state).ec == std::errc::invalid_argument) {
             return command_result::FAIL;


### PR DESCRIPTION
## Description
This PR fixes a bug in get_network_registration_state where parsing the AT command response +CEREG: <mode>,<stat>,... failed because std::from_chars was attempting to parse the number starting at the preceding comma.

The fix involves incrementing the start position by one (+ 1) before calling std::from_chars to correctly skip the leading comma delimiter.

## Related

Fixes #923 

## Testing

Verified that the function now correctly extracts the <stat> integer from typical responses like +CEREG: 2,1