### PR TITLE
fix(websocket): Update linux build docs on required libs

### DIFF
--- a/components/esp_websocket_client/examples/linux/README.md
+++ b/components/esp_websocket_client/examples/linux/README.md
@@ -6,10 +6,15 @@ This example demonstrates the ESP websocket client using the `linux` target. It 
 
 To compile and execute this example on Linux need to set target `linux`
 
+* Debian/Ubuntu: `sudo apt-get install -y libbsd-dev`
+* Fedora/RHEL: `sudo dnf install libbsd-devel`
+* Arch: `sudo pacman -S libbsd`
+* Alpine: `sudo apk add libbsd-dev`
+
 ```
 idf.py --preview set-target linux
 idf.py build
-./websocket.elf
+./build/websocket.elf
 ```
 
 ## Example Output


### PR DESCRIPTION
ESP-IDF linux target expects libbsd headers
Updated instructions for compiling the example on Linux to include the correct path for the executable.

Merging https://github.com/espressif/esp-protocols/pull/911