### PR TITLE
fix(websocket): fix PING timing - enable periodic PING during active traffic (IDFGH-16701)

### DIFF
--- a/components/esp_websocket_client/esp_websocket_client.c
+++ b/components/esp_websocket_client/esp_websocket_client.c
@@ -1174,7 +1174,6 @@ static void esp_websocket_client_task(void *pv)
                 ESP_LOGV(TAG, "Read poll timeout: skipping esp_transport_read()...");
                 break;
             }
-            client->ping_tick_ms = _tick_get_ms();
             break;
         case WEBSOCKET_STATE_WAIT_TIMEOUT:
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Stops resetting `client->ping_tick_ms` on read poll timeout so periodic PINGs proceed on schedule during active traffic.
> 
> - **WebSocket client (`components/esp_websocket_client/esp_websocket_client.c`)**:
>   - Adjust PING scheduling in `WEBSOCKET_STATE_CONNECTED` by removing `client->ping_tick_ms = _tick_get_ms()` after read poll timeout, preventing unintended PING delays.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f424325d89d9d69a889bb1b2735ef70dd47ac84. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->