### PR TITLE
[modem]: Release `v1.4.2`

### DIFF
--- a/components/esp_modem/.cz.yaml
+++ b/components/esp_modem/.cz.yaml
@@ -3,6 +3,6 @@ commitizen:
   bump_message: 'bump(modem): $current_version -> $new_version'
   pre_bump_hooks: python ../../ci/changelog.py esp_modem
   tag_format: modem-v$version
-  version: 1.4.1
+  version: 1.4.2
   version_files:
   - idf_component.yml

--- a/components/esp_modem/CHANGELOG.md
+++ b/components/esp_modem/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.4.2](https://github.com/espressif/esp-protocols/commits/modem-v1.4.2)
+
+### Bug Fixes
+
+- CEREG parsing fails due to incorrect state index ([a80a3cbb](https://github.com/espressif/esp-protocols/commit/a80a3cbb))
+
 ## [1.4.1](https://github.com/espressif/esp-protocols/commits/modem-v1.4.1)
 
 ### Bug Fixes

--- a/components/esp_modem/idf_component.yml
+++ b/components/esp_modem/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.4.1"
+version: "1.4.2"
 description: Library for communicating with cellular modems in command and data modes
 url: https://github.com/espressif/esp-protocols/tree/master/components/esp_modem
 issues: https://github.com/espressif/esp-protocols/issues


### PR DESCRIPTION

## [1.4.2](https://github.com/espressif/esp-protocols/commits/modem-v1.4.2)

### Bug Fixes

- CEREG parsing fails due to incorrect state index ([a80a3cbb](https://github.com/espressif/esp-protocols/commit/a80a3cbb))
