### PR TITLE
fix(websocket): remove redundant timeout check in client task loop

### DIFF
--- a/components/esp_websocket_client/esp_websocket_client.c
+++ b/components/esp_websocket_client/esp_websocket_client.c
@@ -1168,12 +1168,6 @@ static void esp_websocket_client_task(void *pv)
                     }
                 }
             }
-
-
-            if (read_select == 0) {
-                ESP_LOGV(TAG, "Read poll timeout: skipping esp_transport_read()...");
-                break;
-            }
             break;
         case WEBSOCKET_STATE_WAIT_TIMEOUT:
 
@@ -1226,6 +1220,8 @@ static void esp_websocket_client_task(void *pv)
                     esp_websocket_client_abort_connection(client, WEBSOCKET_ERROR_TYPE_TCP_TRANSPORT);
                     xSemaphoreGiveRecursive(client->lock);
                 }
+            } else {
+                ESP_LOGV(TAG, "Read poll timeout: skipping esp_transport_poll_read().");
             }
         } else if (WEBSOCKET_STATE_WAIT_TIMEOUT == client->state) {
             // waiting for reconnection or a request to stop the client...


### PR DESCRIPTION
Remove dead code from WEBSOCKET_STATE_CONNECTED case that checked
read_select == 0. This condition is already properly handled by the
poll/receive logic outside the switch statement.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes a redundant `read_select == 0` check in `WEBSOCKET_STATE_CONNECTED` and centralizes read poll timeout logging in the post-poll branch.
> 
> - **WebSocket client (`components/esp_websocket_client/esp_websocket_client.c`)**:
>   - Remove redundant `read_select == 0` handling inside `WEBSOCKET_STATE_CONNECTED`.
>   - Add unified else-branch after `esp_transport_poll_read()` to log read poll timeouts (`ESP_LOGV`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e83bee4feda90673607174d07bceb21d1b641ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->