### PR TITLE
fix(mdns): Fix unused variable `dcst` warning for wifi-remote chips (IDFGH-16787)

### DIFF
--- a/components/mdns/mdns.c
+++ b/components/mdns/mdns.c
@@ -33,7 +33,7 @@ static void _mdns_browse_send(mdns_browse_t *browse, mdns_if_t interface);
 #if ESP_IDF_VERSION <= ESP_IDF_VERSION_VAL(5, 1, 0)
 #define MDNS_ESP_WIFI_ENABLED CONFIG_SOC_WIFI_SUPPORTED
 #else
-#define MDNS_ESP_WIFI_ENABLED CONFIG_ESP_WIFI_ENABLED
+#define MDNS_ESP_WIFI_ENABLED (CONFIG_ESP_WIFI_ENABLED || CONFIG_ESP_WIFI_REMOTE_ENABLED)
 #endif
 
 #if MDNS_ESP_WIFI_ENABLED && (CONFIG_MDNS_PREDEF_NETIF_STA || CONFIG_MDNS_PREDEF_NETIF_AP)
@@ -4493,9 +4493,9 @@ void mdns_preset_if_handle_system_event(void *arg, esp_event_base_t event_base,
         return;
     }
 
-    esp_netif_dhcp_status_t dcst;
-#if MDNS_ESP_WIFI_ENABLED && (CONFIG_MDNS_PREDEF_NETIF_STA || CONFIG_MDNS_PREDEF_NETIF_AP)
+    #if MDNS_ESP_WIFI_ENABLED && (CONFIG_MDNS_PREDEF_NETIF_STA || CONFIG_MDNS_PREDEF_NETIF_AP)
     if (event_base == WIFI_EVENT) {
+        esp_netif_dhcp_status_t dcst;
         switch (event_id) {
         case WIFI_EVENT_STA_CONNECTED:
             if (!esp_netif_dhcpc_get_status(esp_netif_from_preset_if(MDNS_IF_STA), &dcst)) {
@@ -4522,6 +4522,7 @@ void mdns_preset_if_handle_system_event(void *arg, esp_event_base_t event_base,
 #endif
 #if CONFIG_ETH_ENABLED && CONFIG_MDNS_PREDEF_NETIF_ETH
         if (event_base == ETH_EVENT) {
+            esp_netif_dhcp_status_t dcst;
             switch (event_id) {
             case ETHERNET_EVENT_CONNECTED:
                 if (!esp_netif_dhcpc_get_status(esp_netif_from_preset_if(MDNS_IF_ETH), &dcst)) {


### PR DESCRIPTION
## Description

Fix mdns.c dcst variable not used warning for ESP32-P4 and other non-native Wi-Fi devices

 - Cover WIFI_REMOTE as well for MDNS_ESP_WIFI_ENABLED macro
 - localize `esp_netif_dhcp_status_t dcst;` declaration where used
 - Bumped patch version for mdns component

## Testing

Tried with ESP RainMaker example on ESP32-P4
 - Build warning is not seen anymore and the device is discoverable

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expand `MDNS_ESP_WIFI_ENABLED` to cover `CONFIG_ESP_WIFI_REMOTE_ENABLED` and move `dcst` declarations into specific Wi‑Fi/Ethernet event branches to fix unused-variable warnings.
> 
> - **mDNS core (`components/mdns/mdns.c`)**:
>   - Update macro: `MDNS_ESP_WIFI_ENABLED` now checks `(CONFIG_ESP_WIFI_ENABLED || CONFIG_ESP_WIFI_REMOTE_ENABLED)`.
>   - Event handling:
>     - WIFI events: declare `esp_netif_dhcp_status_t dcst` inside `WIFI_EVENT` branch.
>     - ETH events: declare `esp_netif_dhcp_status_t dcst` inside `ETH_EVENT` branch.
>   - Minor preprocessor/indentation adjustments around event handlers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 081eef88cf0a704df2586c89607ee5e62f42440e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->