### PR TITLE
bump(websocket): 1.5.0 -> 1.6.0

### DIFF
--- a/components/esp_websocket_client/.cz.yaml
+++ b/components/esp_websocket_client/.cz.yaml
@@ -3,6 +3,6 @@ commitizen:
   bump_message: 'bump(websocket): $current_version -> $new_version'
   pre_bump_hooks: python ../../ci/changelog.py esp_websocket_client
   tag_format: websocket-v$version
-  version: 1.5.0
+  version: 1.6.0
   version_files:
   - idf_component.yml

--- a/components/esp_websocket_client/CHANGELOG.md
+++ b/components/esp_websocket_client/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [1.6.0](https://github.com/espressif/esp-protocols/commits/websocket-v1.6.0)
+
+### Features
+
+- add WEBSOCKET_EVENT_HEADER_RECEIVED (#827) ([18f0d028](https://github.com/espressif/esp-protocols/commit/18f0d028), [#715](https://github.com/espressif/esp-protocols/issues/715))
+- enhance example with docs, pytest setup, and standalone test server     - Add comprehensive README with TOC and quick start     - Add pytest setup and certificate generation scripts     - Add standalone WebSocket test server with TLS support     - Add troubleshooting and multiple testing approaches ([cad527d2](https://github.com/espressif/esp-protocols/commit/cad527d2))
+- Add websocket HTTP redirect ([ce1560ac](https://github.com/espressif/esp-protocols/commit/ce1560ac))
+
+### Bug Fixes
+
+- remove redundant timeout check in client task loop ([1e83bee4](https://github.com/espressif/esp-protocols/commit/1e83bee4))
+- fix PING timing - enable periodic PING during active traffic ([7f424325](https://github.com/espressif/esp-protocols/commit/7f424325))
+- Update linux build docs on required libs ([e52a5757](https://github.com/espressif/esp-protocols/commit/e52a5757))
+- clean up component dependencies - Remove unused 'json', 'nvs_flash', 'esp_stubs', dependency from Linux build configuration - Add cJSON dependency to target example's idf_component.yml ([d665e6f1](https://github.com/espressif/esp-protocols/commit/d665e6f1))
+- fix relying on asprintf() to NULL strp on failure ([54eb0027](https://github.com/espressif/esp-protocols/commit/54eb0027))
+- Update Remaining Websocket Echo Server (#893) ([18faeb3d](https://github.com/espressif/esp-protocols/commit/18faeb3d))
+- avoid long stopping time when waiting to auto-reconnect ([2432e41d](https://github.com/espressif/esp-protocols/commit/2432e41d))
+- Update Websocket Echo Server ([94bd5b07](https://github.com/espressif/esp-protocols/commit/94bd5b07))
+
+### Updated
+
+- ci(common): Update test component dir for IDFv6.0 ([18418c83](https://github.com/espressif/esp-protocols/commit/18418c83))
+
 ## [1.5.0](https://github.com/espressif/esp-protocols/commits/websocket-v1.5.0)
 
 ### Features

--- a/components/esp_websocket_client/idf_component.yml
+++ b/components/esp_websocket_client/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.5.0"
+version: "1.6.0"
 description: WebSocket protocol client for ESP-IDF
 url: https://github.com/espressif/esp-protocols/tree/master/components/esp_websocket_client
 dependencies:


### PR DESCRIPTION
1.6.0
Features
- add WEBSOCKET_EVENT_HEADER_RECEIVED (#827) (18f0d028, #715)
- enhance example with docs, pytest setup, and standalone test server     - Add comprehensive README with TOC and quick start     - Add pytest setup and certificate generation scripts     - Add standalone WebSocket test server with TLS support     - Add troubleshooting and multiple testing approaches (cad527d2)
- Add websocket HTTP redirect (ce1560ac)

Bug Fixes
- remove redundant timeout check in client task loop (1e83bee4)
- fix PING timing - enable periodic PING during active traffic (7f424325)
- Update linux build docs on required libs (e52a5757)
- clean up component dependencies - Remove unused 'json', 'nvs_flash', 'esp_stubs', dependency from Linux build configuration - Add cJSON dependency to target example's idf_component.yml (d665e6f1)
- fix relying on asprintf() to NULL strp on failure (54eb0027)
- Update Remaining Websocket Echo Server (#893) (18faeb3d)
- avoid long stopping time when waiting to auto-reconnect (2432e41d)
- Update Websocket Echo Server (94bd5b07)
Updated
- ci(common): Update test component dir for IDFv6.0 (18418c83)

<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps `esp_websocket_client` to 1.6.0 with new header-received event, HTTP redirect support, example/test enhancements, and multiple fixes.
> 
> - **Version**: bump `components/esp_websocket_client` to `1.6.0`
>   - Update `components/esp_websocket_client/.cz.yaml` and `components/esp_websocket_client/idf_component.yml`
> - **Changelog (1.6.0)**:
>   - **Features**:
>     - Add `WEBSOCKET_EVENT_HEADER_RECEIVED`
>     - Add WebSocket HTTP redirect handling
>     - Enhance example/docs with pytest setup and TLS test server
>   - **Bug Fixes/Updates**:
>     - Improve PING timing; remove redundant timeout check
>     - Reduce stop wait during auto-reconnect
>     - Dependency cleanup and Linux build/doc updates
>     - Update echo server examples
>     - CI: adjust test component dir for IDF v6.0
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 67188fd7b44baaff4302565659524b2756ad88b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->