### PR TITLE
fix(mdns): mdns_browse_delete works as intended (IDFGH-16796)

### DIFF
--- a/components/mdns/include/mdns.h
+++ b/components/mdns/include/mdns.h
@@ -921,14 +921,13 @@ mdns_browse_t *mdns_browse_new(const char *service, const char *proto, mdns_brow
 
 /**
  * @brief   Stop the `_service._proto` browse.
- * @param service  Pointer to the `_service` which will be browsed.
- * @param proto    Pointer to the `_proto` which will be browsed.
+ * @param browse  Pointer to the browse object created by mdns_browse_new().
  * @return
  *     - ESP_OK                 success.
  *     - ESP_ERR_FAIL           mDNS is not running or the browsing of `_service._proto` is never started.
  *     - ESP_ERR_NO_MEM         memory error.
  */
-esp_err_t mdns_browse_delete(const char *service, const char *proto);
+esp_err_t mdns_browse_delete(mdns_browse_t *browse);
 
 #ifdef __cplusplus
 }

--- a/components/mdns/mdns.c
+++ b/components/mdns/mdns.c
@@ -7363,24 +7363,13 @@ mdns_browse_t *mdns_browse_new(const char *service, const char *proto, mdns_brow
     return browse;
 }
 
-esp_err_t mdns_browse_delete(const char *service, const char *proto)
+esp_err_t mdns_browse_delete(mdns_browse_t *browse)
 {
-    mdns_browse_t *browse = NULL;
-
-    if (!_mdns_server || _str_null_or_empty(service) || _str_null_or_empty(proto)) {
+    if (!_mdns_server || !browse) {
         return ESP_FAIL;
     }
 
-    browse = _mdns_browse_init(service, proto, NULL);
-    if (!browse) {
-        return ESP_ERR_NO_MEM;
-    }
-
-    if (_mdns_send_browse_action(ACTION_BROWSE_END, browse)) {
-        _mdns_browse_item_free(browse);
-        return ESP_ERR_NO_MEM;
-    }
-    return ESP_OK;
+    return _mdns_send_browse_action(ACTION_BROWSE_END, browse);
 }
 
 /**


### PR DESCRIPTION

## Description

Not much to say, the `mdns_browse_delete()` didn't have a proper API nor a correct implementation, it was creating an object for itself that it deleted later on, the whole method was mostly copy-paste from `mdns_browse_new()`.

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
