### PR TITLE
[mosq]: Bump 2.0.20~4 -> 2.0.20~5

### DIFF
--- a/components/mosquitto/.cz.yaml
+++ b/components/mosquitto/.cz.yaml
@@ -3,6 +3,6 @@ commitizen:
   bump_message: 'bump(mosq): $current_version -> $new_version'
   pre_bump_hooks: python ../../ci/changelog.py mosquitto
   tag_format: mosq-v$version
-  version: 2.0.20~4
+  version: 2.0.20~5
   version_files:
   - idf_component.yml

--- a/components/mosquitto/CHANGELOG.md
+++ b/components/mosquitto/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [2.0.20~5](https://github.com/espressif/esp-protocols/commits/mosq-v2.0.20_5)
+
+### Features
+
+- Add support for basic MQTT authentication ([65b58aa0](https://github.com/espressif/esp-protocols/commit/65b58aa0))
+
+### Bug Fixes
+
+- Add optional mqtt deps to examples ([6f6110e3](https://github.com/espressif/esp-protocols/commit/6f6110e3))
+- Update example to optionally use basic mqtt auth ([38384852](https://github.com/espressif/esp-protocols/commit/38384852))
+- Fix unpwd-check wrap function ([ba3377b2](https://github.com/espressif/esp-protocols/commit/ba3377b2))
+- Fix the version check ([9fbb6e6d](https://github.com/espressif/esp-protocols/commit/9fbb6e6d))
+
 ## [2.0.20~4](https://github.com/espressif/esp-protocols/commits/mosq-v2.0.20_4)
 
 ### Features

--- a/components/mosquitto/idf_component.yml
+++ b/components/mosquitto/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.0.20~4"
+version: "2.0.20~5"
 url: https://github.com/espressif/esp-protocols/tree/master/components/mosquitto
 description: The component provides a simple ESP32 port of mosquitto broker
 dependencies:

--- a/components/mosquitto/port/priv_include/config.h
+++ b/components/mosquitto/port/priv_include/config.h
@@ -20,4 +20,4 @@
 #undef  isspace
 #define isspace(__c) (__ctype_lookup((int)__c)&_S)
 
-#define VERSION "v2.0.20~4"
+#define VERSION "v2.0.20~5"


### PR DESCRIPTION
## [2.0.20~5](https://github.com/espressif/esp-protocols/commits/mosq-v2.0.20_5)

### Features

- Add support for basic MQTT authentication ([65b58aa0](https://github.com/espressif/esp-protocols/commit/65b58aa0))

### Bug Fixes

- Add optional mqtt deps to examples ([6f6110e3](https://github.com/espressif/esp-protocols/commit/6f6110e3))
- Update example to optionally use basic mqtt auth ([38384852](https://github.com/espressif/esp-protocols/commit/38384852))
- Fix unpwd-check wrap function ([ba3377b2](https://github.com/espressif/esp-protocols/commit/ba3377b2))
- Fix the version check ([9fbb6e6d](https://github.com/espressif/esp-protocols/commit/9fbb6e6d))

