### PR TITLE
feat(websocket): affinity configuration (IDFGH-17319)

### DIFF
--- a/components/esp_websocket_client/esp_websocket_client.c
+++ b/components/esp_websocket_client/esp_websocket_client.c
@@ -29,6 +29,7 @@ static const char *TAG = "websocket_client";
 #define WEBSOCKET_SSL_DEFAULT_PORT      (443)
 #define WEBSOCKET_BUFFER_SIZE_BYTE      (1024)
 #define WEBSOCKET_RECONNECT_TIMEOUT_MS  (10*1000)
+#define WEBSOCKET_TASK_CORE_ID          (tskNO_AFFINITY)
 #define WEBSOCKET_TASK_PRIORITY         (5)
 #define WEBSOCKET_TASK_STACK            (4*1024)
 #define WEBSOCKET_NETWORK_TIMEOUT_MS    (10*1000)
@@ -79,6 +80,7 @@ const static int REQUESTED_STOP_BIT = BIT2;     // Indicates that a client stop 
 ESP_EVENT_DEFINE_BASE(WEBSOCKET_EVENTS);
 
 typedef struct {
+    BaseType_t                  task_core_id;
     const char                 *task_name;
     int                         task_stack;
     int                         task_prio;
@@ -352,6 +354,13 @@ static char *http_auth_basic(const char *username, const char *password)
 static esp_err_t esp_websocket_client_set_config(esp_websocket_client_handle_t client, const esp_websocket_client_config_t *config)
 {
     websocket_config_storage_t *cfg = client->config;
+
+    if (config->task_core_id_set) {
+        cfg->task_core_id = config->task_core_id;
+    } else {
+        cfg->task_core_id = WEBSOCKET_TASK_CORE_ID;
+    }
+
     cfg->task_prio = config->task_prio;
     if (cfg->task_prio <= 0) {
         cfg->task_prio = WEBSOCKET_TASK_PRIORITY;
@@ -1423,8 +1432,8 @@ esp_err_t esp_websocket_client_start(esp_websocket_client_handle_t client)
         }
     }
 
-    if (xTaskCreate(esp_websocket_client_task, client->config->task_name ? client->config->task_name : "websocket_task",
-                    client->config->task_stack, client, client->config->task_prio, &client->task_handle) != pdTRUE) {
+    if (xTaskCreatePinnedToCore(esp_websocket_client_task, client->config->task_name ? client->config->task_name : "websocket_task",
+                                client->config->task_stack, client, client->config->task_prio, &client->task_handle, client->config->task_core_id) != pdTRUE) {
         ESP_LOGE(TAG, "Error create websocket task");
         return ESP_FAIL;
     }

--- a/components/esp_websocket_client/include/esp_websocket_client.h
+++ b/components/esp_websocket_client/include/esp_websocket_client.h
@@ -115,6 +115,8 @@ typedef struct {
     bool                        disable_auto_reconnect;     /*!< Disable the automatic reconnect function when disconnected */
     bool                        enable_close_reconnect;     /*!< Enable reconnect after server close */
     void                        *user_context;              /*!< HTTP user data context */
+    bool                        task_core_id_set;           /*!< Set to true to use task_core_id. If false, the websocket task uses tskNO_AFFINITY(default) */
+    int                         task_core_id;               /*!< Core ID for the websocket task when task_core_id_set is true. Must be explicitly set by the user, otherwise a zero-initialized config, will pin the task to core 0. Use tskNO_AFFINITY for no pinning. */
     int                         task_prio;                  /*!< Websocket task priority */
     const char                 *task_name;                  /*!< Websocket task name */
     int                         task_stack;                 /*!< Websocket task stack */


### PR DESCRIPTION
## Description

Add CPU core affinity to websocket thread configuration. Otherwise simple parsing code like cJSON may pin it unexpectedly.

## Testing

This was tested by printing the affinity on event receipt. We could add a test to run a WS client on each core if desired, as well as unpinned.

## Checklist

Before submitting a Pull Request, please ensure the following:

- [X] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [X] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [X] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds configurable CPU core affinity for the websocket client task and pins it using xTaskCreatePinnedToCore.
> 
> - **WebSocket client**:
>   - **API**: Extend `esp_websocket_client_config_t` with `task_core_id_set` and `task_core_id` to allow specifying CPU affinity.
>   - **Defaults**: Add `WEBSOCKET_TASK_CORE_ID` default (`tskNO_AFFINITY`).
>   - **Config handling**: Store `task_core_id` in internal `websocket_config_storage_t`; set from config or default.
>   - **Task startup**: Replace `xTaskCreate` with `xTaskCreatePinnedToCore(..., client->config->task_core_id)` to pin client task to the chosen core.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 21f4c5376aaaf722ac65d9265612152784486afe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->