### PR TITLE
[lws]: Bump 4.3.3 -> 4.3.3~1

### DIFF
--- a/components/libwebsockets/.cz.yaml
+++ b/components/libwebsockets/.cz.yaml
@@ -3,6 +3,6 @@ commitizen:
   bump_message: 'bump(lws): $current_version -> $new_version'
   pre_bump_hooks: python ../../ci/changelog.py libwebsockets
   tag_format: lws-v$version
-  version: 4.3.3
+  version: 4.3.3~1
   version_files:
   - idf_component.yml

--- a/components/libwebsockets/CHANGELOG.md
+++ b/components/libwebsockets/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [4.3.3~1](https://github.com/espressif/esp-protocols/commits/lws-v4.3.3_1)
+
+### Bug Fixes
+
+- Remove lws support for IDF>=v6.0 ([b70cc3fc](https://github.com/espressif/esp-protocols/commit/b70cc3fc))
+- Update websocket Echo server (#894) ([318e41b3](https://github.com/espressif/esp-protocols/commit/318e41b3))
+- Adds missing license info ([7ea6879a](https://github.com/espressif/esp-protocols/commit/7ea6879a))
+
+### Updated
+
+- chore(lws): fixed formatting ([91e7e9fa](https://github.com/espressif/esp-protocols/commit/91e7e9fa))
+
 ## [4.3.3](https://github.com/espressif/esp-protocols/commits/lws-v4.3.3)
 
 ### Features

--- a/components/libwebsockets/idf_component.yml
+++ b/components/libwebsockets/idf_component.yml
@@ -1,4 +1,4 @@
-version: "4.3.3"
+version: "4.3.3~1"
 url: https://github.com/espressif/esp-protocols/tree/master/components/libwebsockets
 description: The component provides a simple ESP-IDF port of libwebsockets client.
 dependencies:


### PR DESCRIPTION
## [4.3.3~1](https://github.com/espressif/esp-protocols/commits/lws-v4.3.3_1)

### Bug Fixes

- Remove lws support for IDF>=v6.0 ([b70cc3fc](https://github.com/espressif/esp-protocols/commit/b70cc3fc))
- Update websocket Echo server (#894) ([318e41b3](https://github.com/espressif/esp-protocols/commit/318e41b3))
- Adds missing license info ([7ea6879a](https://github.com/espressif/esp-protocols/commit/7ea6879a))

### Updated

- chore(lws): fixed formatting ([91e7e9fa](https://github.com/espressif/esp-protocols/commit/91e7e9fa))

---
Partially addresses: https://github.com/espressif/esp-protocols/issues/949