### PR TITLE
[asio]: Fix picolib missing pthread_sigmask() declaration

### DIFF
--- a/components/asio/port/include/asio/detail/config.hpp
+++ b/components/asio/port/include/asio/detail/config.hpp
@@ -7,5 +7,6 @@
 
 #include "sys/socket.h"
 #include "socketpair.h"
+#include "asio_stub.hpp"
 
 #include_next "asio/detail/config.hpp"

--- a/components/asio/port/include/asio_stub.hpp
+++ b/components/asio/port/include/asio_stub.hpp
@@ -1,0 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+#include <signal.h>
+
+extern "C" int pthread_sigmask(int, const sigset_t *, sigset_t *);


### PR DESCRIPTION
Another picolib related
* potentially missing `pthread_sigmask()` declarations
* fixes https://github.com/espressif/esp-protocols/actions/runs/20132443182/job/57777032103#step:4:1484