### PR TITLE
bump(websocket): 1.6.0 -> 1.6.1

### DIFF
--- a/components/esp_websocket_client/.cz.yaml
+++ b/components/esp_websocket_client/.cz.yaml
@@ -3,6 +3,6 @@ commitizen:
   bump_message: 'bump(websocket): $current_version -> $new_version'
   pre_bump_hooks: python ../../ci/changelog.py esp_websocket_client
   tag_format: websocket-v$version
-  version: 1.6.0
+  version: 1.6.1
   version_files:
   - idf_component.yml

--- a/components/esp_websocket_client/CHANGELOG.md
+++ b/components/esp_websocket_client/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [1.6.1](https://github.com/espressif/esp-protocols/commits/websocket-v1.6.1)
+
+### Bug Fixes
+
+- Fix race conditions, memory leak, and data loss ([23ca97d5](https://github.com/espressif/esp-protocols/commit/23ca97d5))
+    - Add state check in abort_connection to prevent double-close
+    - Fix memory leak: free errormsg_buffer on disconnect
+    - Reset connection state on reconnect to prevent stale data
+    - Implement lock ordering for separate TX lock mode
+    - Read buffered data immediately after connection to prevent data loss
+    - Added sdkconfig.ci.tx_lock config
+
 ## [1.6.0](https://github.com/espressif/esp-protocols/commits/websocket-v1.6.0)
 
 ### Features

--- a/components/esp_websocket_client/idf_component.yml
+++ b/components/esp_websocket_client/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.6.0"
+version: "1.6.1"
 description: WebSocket protocol client for ESP-IDF
 url: https://github.com/espressif/esp-protocols/tree/master/components/esp_websocket_client
 dependencies:


### PR DESCRIPTION
1.6.1
Bug Fixes
- Fix race conditions, memory leak, and data loss (23ca97d5)
    - Add state check in abort_connection to prevent double-close
    - Fix memory leak: free errormsg_buffer on disconnect
    - Reset connection state on reconnect to prevent stale data
    - Implement lock ordering for separate TX lock mode
    - Read buffered data immediately after connection to prevent data loss
    - Added sdkconfig.ci.tx_lock config


## Checklist

Before submitting a Pull Request, please ensure the following:

- [ *] 🚨 This PR does not introduce breaking changes.
- [ *] All CI checks (GH Actions) pass.
- [ *] Documentation is updated as needed.
- [ *] Tests are updated or added as necessary.
- [ *] Code is well-commented, especially in complex areas.
- [ *] Git history is clean — commits are squashed to the minimum necessary.
