### PR TITLE
fix(mbedtls_cxx): Add support for mbedtls psa api

### DIFF
--- a/components/mbedtls_cxx/CMakeLists.txt
+++ b/components/mbedtls_cxx/CMakeLists.txt
@@ -1,3 +1,3 @@
 idf_component_register(SRCS mbedtls_wrap.cpp
                        INCLUDE_DIRS include
-                       REQUIRES tcp_transport)
+                       REQUIRES tcp_transport esp_timer)

--- a/components/mbedtls_cxx/README.md
+++ b/components/mbedtls_cxx/README.md
@@ -1,3 +1,19 @@
 # mbedtls_cxx
 
-This is a simplified C++ wrapper of mbedTLS for performing TLS and DTLS handshake a communication. This component allows for overriding low level IO functions (`send()` and `recv()`) and thus supporting TLS over various physical channels.
+This is a simplified C++ wrapper of mbedTLS for performing TLS and DTLS handshake and communication. This component allows for overriding low level IO functions (`send()` and `recv()`) and thus supporting TLS over various physical channels.
+
+## mbedTLS Version Support
+
+This wrapper supports both mbedTLS v3 (legacy API) and mbedTLS v4 (PSA Crypto API). The appropriate API is selected automatically at compile time based on the mbedTLS version.
+
+### PSA Crypto Lifecycle (mbedTLS v4)
+
+When using mbedTLS v4, this wrapper calls `psa_crypto_init()` during `Tls::init()`. This function is idempotent - it's safe to call multiple times, whether by this wrapper or by other code using mbedTLS directly.
+
+**Important:** This wrapper does **not** call `mbedtls_psa_crypto_free()` on destruction. This is intentional to avoid breaking other code that may also be using PSA Crypto. If your application requires explicit cleanup of PSA resources (e.g., for memory leak detection), you should call `mbedtls_psa_crypto_free()` at application shutdown after all TLS operations and other mbedTLS usage is complete.
+
+```cpp
+// At application shutdown (if needed):
+#include "psa/crypto_extra.h"
+mbedtls_psa_crypto_free();
+```


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds mbedTLS v4 (PSA) support with conditional compilation while preserving v3 behavior, plus DTLS timer and cookie updates.
> 
> - Add version detection in `mbedtls_wrap.hpp` and split code paths for v4 (PSA) vs v3 (entropy/CTR_DRBG + timing)
> - Initialize PSA via `psa_crypto_init()` in `Tls::init()` for v4; retain RNG seeding/config for v3 and free on deinit/destructor
> - Implement DTLS timer callbacks using `esp_timer` for v4; keep `mbedtls_timing_*` for v3
> - Update DTLS cookie setup to PSA-compatible form on v4; unchanged RNG-backed setup on v3
> - Require `esp_timer` in `CMakeLists.txt`
> - README: document v3/v4 support and PSA crypto lifecycle notes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 884d8fe6f54ba54808e62e4c368e2659aa9b9965. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->