### PR TITLE
fix(websocket): fix use-after-free race condition in task stop sequence (IDFGH-17044)

### DIFF
--- a/components/esp_websocket_client/esp_websocket_client.c
+++ b/components/esp_websocket_client/esp_websocket_client.c
@@ -478,9 +478,11 @@ static void destroy_and_free_resources(esp_websocket_client_handle_t client)
 {
     if (client->event_handle) {
         esp_event_loop_delete(client->event_handle);
+        client->event_handle = NULL;
     }
     if (client->if_name) {
         free(client->if_name);
+        client->if_name = NULL;
     }
     esp_websocket_client_destroy_config(client);
     if (client->transport_list) {
@@ -488,15 +490,31 @@ static void destroy_and_free_resources(esp_websocket_client_handle_t client)
         client->transport_list = NULL;
         client->transport = NULL;
     }
-    vSemaphoreDelete(client->lock);
+    if (client->lock) {
+        vSemaphoreDelete(client->lock);
+        client->lock = NULL;
+    }
 #ifdef CONFIG_ESP_WS_CLIENT_SEPARATE_TX_LOCK
-    vSemaphoreDelete(client->tx_lock);
+    if (client->tx_lock) {
+        vSemaphoreDelete(client->tx_lock);
+        client->tx_lock = NULL;
+    }
 #endif
-    free(client->tx_buffer);
-    free(client->rx_buffer);
-    free(client->errormsg_buffer);
+    if (client->tx_buffer) {
+        free(client->tx_buffer);
+        client->tx_buffer = NULL;
+    }
+    if (client->rx_buffer) {
+        free(client->rx_buffer);
+        client->rx_buffer = NULL;
+    }
+    if (client->errormsg_buffer) {
+        free(client->errormsg_buffer);
+        client->errormsg_buffer = NULL;
+    }
     if (client->status_bits) {
         vEventGroupDelete(client->status_bits);
+        client->status_bits = NULL;
     }
     free(client);
     client = NULL;

--- a/components/esp_websocket_client/include/esp_websocket_client.h
+++ b/components/esp_websocket_client/include/esp_websocket_client.h
@@ -236,6 +236,7 @@ esp_err_t esp_websocket_client_stop(esp_websocket_client_handle_t client);
  *
  *  Notes:
  *  - Cannot be called from the websocket event handler
+ *  - This function cannot be called if `esp_websocket_client_destroy_on_exit` was used for the same handle.
  *
  * @param[in]  client  The client
  *
@@ -248,6 +249,7 @@ esp_err_t esp_websocket_client_destroy(esp_websocket_client_handle_t client);
  *
  *  Notes:
  *  - After event loop finished, client handle would be dangling and should never be used
+ *  - This function is mutually exclusive with `esp_websocket_client_destroy`. Do not call `esp_websocket_client_destroy` manually if this API is used.
  *
  * @param[in]  client      The client
  *


### PR DESCRIPTION
**Root Cause:**
The race condition occurred because `STOPPED_BIT` was set before the websocket task finished accessing the `client` structure. This allowed `esp_websocket_client_destroy()` to free the memory while the task was still reading from it.

## Related

https://github.com/espressif/esp-protocols/issues/984

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ *] 🚨 This PR does not introduce breaking changes.
- [ *] All CI checks (GH Actions) pass.
- [ *] Documentation is updated as needed.
- [ *] Tests are updated or added as necessary.
- [ *] Code is well-commented, especially in complex areas.
- [ *] Git history is clean — commits are squashed to the minimum necessary.
