### PR TITLE
fix(eppp_link): Fix const qualifier violation in eppp_link (IDFGH-17135)

### DIFF
--- a/components/eppp_link/eppp_link.c
+++ b/components/eppp_link/eppp_link.c
@@ -211,7 +211,7 @@ static void ppp_task(void *args)
 }
 #endif
 
-static bool have_some_eppp_netif(esp_netif_t *netif, void *ctx)
+static bool have_some_eppp_netif(esp_netif_t *netif, const void *ctx)
 {
     return get_netif_num(netif) > 0;
 }


### PR DESCRIPTION
## Description

ESP-IDF MR 45069, 45375 enables -Wwrite-strings and -Werror=discarded-qualifiers in ESP-IDF CI builds. This PR fixes const qualifier violations in examples that use espressif/eppp_link managed component causing build failures.

## Related

- https://github.com/espressif/esp-idf/issues/18120

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates callback signature for const-correctness.
> 
> - Change `have_some_eppp_netif` second parameter from `void *ctx` to `const void *ctx` to align with `esp_netif_find_if` usage and eliminate discarded-qualifiers warnings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 712e0a5340cb41928bc62be431b959995cb40993. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->