### PR TITLE
fix(websocket): Fix the bug related to multi-threaded access to trans… (IDFGH-17155)

### DIFF
--- a/components/esp_websocket_client/Kconfig
+++ b/components/esp_websocket_client/Kconfig
@@ -7,17 +7,4 @@ menu "ESP WebSocket client"
             Enable this option will reallocated buffer when send or receive data and free them when end of use.
             This can save about 2 KB memory when no websocket data send and receive.
 
-    config ESP_WS_CLIENT_SEPARATE_TX_LOCK
-        bool "Enable separate tx lock for send and receive data"
-        default n
-        help
-            Enable this option will use separate lock for send and receive data.
-            This can avoid the lock contention when send and receive data at the same time.
-
-    config ESP_WS_CLIENT_TX_LOCK_TIMEOUT_MS
-        int "TX lock timeout in milliseconds"
-        depends on ESP_WS_CLIENT_SEPARATE_TX_LOCK
-        default 2000
-        help
-            Timeout for acquiring the TX lock when using separate TX lock.
 endmenu


### PR DESCRIPTION
The `close` operation on the `client->transport` resource is performed under the protection of `client->lock`. `esp_websocket_client_send_with_exact_opcode` checks the state without holding the lock when determining whether the transport can be accessed. This can lead to some unexpected behaviors:

1. If `tx_lock` is not enabled, calling `esp_transport_ws_send_raw` will be abnormally blocked if the transport is already closed.

2. If `tx_lock` is enabled, `esp_transport_close` and `esp_transport_ws_send_raw` may be called concurrently. Since `close` involves releasing some resources, this may lead to unpredictable behavior.

<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description
To fix this issue, I adjusted the implementation of resource mutual exclusion protection.
1、tx_lock has been removed
The original purpose of introducing `tx_lock` was to allow for parallel processing of receiving and sending, improving transmission efficiency. However, this doesn't necessarily require introducing a new `tx_lock`. This is because the receiving direction is accessed only by the `esp_websocket_client_task`. The sending direction may be accessed concurrently by several user tasks and the `esp_websocket_client_task`. Therefore, the `esp_websocket_client_task` does not need lock protection when receiving. Lock protection is only applied when the `esp_websocket_client_task` needs to send or when a user task sends, to check if the transport is available.

2、Change `esp_websocket_client_abort_connection` to asynchronous close transport.
Modify `esp_websocket_client_abort_connection` to only modify the state, preventing user tasks from directly executing close transport and conflicting with `esp_websocket_client_task`'s receive transport.

The APIs involved in resource access contention mainly include esp_websocket_client_send_bin, esp_websocket_client_send_bin_partial, esp_websocket_client_send_text, esp_websocket_client_send_text_partial, esp_websocket_client_send_cont_msg, esp_websocket_client_send_fin, esp_websocket_client_send_with_opcode, esp_websocket_client_close, and esp_websocket_client_close_with_code. Ultimately, all of these are involved in esp_websocket_client_send_with_exact_opcode. The main issue is contention involving transport sending, errormsg_buffer, and state when the state is WEBSOCKET_STATE_CONNECTED. After the modification, esp_websocket_client_send_with_exact_opcode accesses and modifies these resources under lock protection. In esp_websocket_client_task, when the state is WEBSOCKET_STATE_CONNECTED, any transport sending, changes to a connectionless state, or access to errormsg_buffer are all performed under lock protection. The close of the transport is uniformly performed by esp_websocket_client_task in a non-WEBSOCKET_STATE_CONNECTED state, ensuring that user task sending will not occur concurrently with the close of the transport, and esp_websocket_client_task does not require lock protection when receiving.
<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors websocket client concurrency and connection lifecycle handling.
> 
> - Removes `tx_lock` Kconfig/options and all associated separate TX locking; uses a single `client->lock` to guard all transport sends/state/error buffer access
> - Introduces `WEBSOCKET_STATE_WAIT_ABORT_CONNECT` and changes `esp_websocket_client_abort_connection()` to be asynchronous (sets state, dispatches disconnect); actual `esp_transport_close()` now performed by the client task
> - Ensures PING/PONG/CLOSE and send paths acquire `client->lock` and re-check `state` before accessing transport; adds locked aborts on read/write failures
> - Adjusts main task state machine: splits abort handling, reconnect/wait logic, and server-initiated close flow; removes previous WAIT_TIMEOUT handling tied to immediate close
> - Cleans up Kconfig (drops tx lock options) and updates SPDX year
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3bbe73ab983263237b8966542f65bc9fdde4801d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->