### PR TITLE
fix: pre-commit warning

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,7 +53,7 @@ repos:
     hooks:
       - id: commitizen
       - id: commitizen-branch
-        stages: [push, manual]
+        stages: [pre-push, manual]
   - repo: local
     hooks:
       - id: commit message scopes


### PR DESCRIPTION
## Description

Resolve this warning:

[WARNING] hook id `commitizen-branch` uses deprecated stage names (push) which will be removed in a future version.
run: `pre-commit migrate-config` to automatically fix this.

> Also include the motivation (why this change) and context.

1. Not to have warnings on each commit.
2. Follow the Commitizen preferences to rename `push` to `pre-push`.

## Testing

Made another commit, verified tests still pass.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [X] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [X] Documentation is updated as needed.
- [X] Tests are updated or added as necessary.
- [X] Code is well-commented, especially in complex areas.
- [X] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces deprecated `push` stage with `pre-push` for the `commitizen-branch` hook in `.pre-commit-config.yaml` to silence deprecation warnings. No code or runtime behavior changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 106466b73a37379ecce339f56d05b3d5dd0e7008. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->