### PR TITLE
fix(websocket): Fix close function with auto-reconnect-on-close

### DIFF
--- a/components/esp_websocket_client/esp_websocket_client.c
+++ b/components/esp_websocket_client/esp_websocket_client.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2015-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -1467,6 +1467,11 @@ static esp_err_t esp_websocket_client_close_with_optional_body(esp_websocket_cli
 
     // Set closing bit to prevent from sending PING frames while connected
     xEventGroupSetBits(client->status_bits, CLOSE_FRAME_SENT_BIT);
+
+    if (client->config->auto_reconnect && client->config->close_reconnect) {
+        // Client does not stop(STOPPED_BIT) with auto-reconnect-on-close
+        return ESP_OK;
+    }
 
     if (STOPPED_BIT & xEventGroupWaitBits(client->status_bits, STOPPED_BIT, false, true, timeout)) {
         return ESP_OK;


### PR DESCRIPTION
## Description

If auto-reconnect-on-close is configured, close should not try to stop the client, but just close the current connection.

This is needed to support fault injection for reliability testing of protocols like SocketIO, who will perform a higher-level [connection-state-recovery](https://socket.io/docs/v4/connection-state-recovery).

This is also needed to support load balanced services, where a SocketIO event might indicate the client should temporarily disconnect to reconnect to a healthier or longer-living backend server.

## Related

I introduced this bug in 19891d8c3c1df27068049bc52b1d5684288d3de1, though it only broke for anyone trying to cleanly close a connection without stopping the client with this particular configuration.

## Testing

Tested by adding a button to my UI that calls `esp_websocket_client_close_with_code()`, and verifying I could manually close the websocket client and device automatically reconnects on demand.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [X] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [X] Documentation is updated as needed.
- [] Tests are updated or added as necessary.
- [X] Code is well-commented, especially in complex areas.
- [X] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures `esp_websocket_client_close_with_optional_body()` does not stop the client when `auto_reconnect` and `close_reconnect` are enabled, allowing a clean close of the current connection and seamless auto-reconnect.
> 
> - After sending CLOSE and setting `CLOSE_FRAME_SENT_BIT`, return early if `config->auto_reconnect && config->close_reconnect`, skipping STOP/WAIT logic
> - Minor: update SPDX copyright year to 2026
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2083a0b2ab06f75eb9e0e389c0498d7b12c9c381. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->