### PR TITLE
[eppp]: Use C++ traits to control netif predicate type changes

### DIFF
--- a/components/eppp_link/CMakeLists.txt
+++ b/components/eppp_link/CMakeLists.txt
@@ -24,7 +24,7 @@ if(NOT CONFIG_EPPP_LINK_USES_PPP)
     set(netif_src eppp_netif_tun.c)
 endif()
 
-idf_component_register(SRCS eppp_link.c ${transport_src} ${netif_src}
+idf_component_register(SRCS eppp_link.c eppp_link_netif.cpp ${transport_src} ${netif_src}
                     INCLUDE_DIRS "include"
                     PRIV_REQUIRES esp_netif esp_timer esp_eth ${driver_deps})
 

--- a/components/eppp_link/eppp_link_netif.cpp
+++ b/components/eppp_link/eppp_link_netif.cpp
@@ -1,0 +1,47 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <string.h>
+#include <stdint.h>
+#include "sdkconfig.h"
+#include "esp_log.h"
+#include "esp_netif.h"
+#include "esp_check.h"
+#include "eppp_link.h"
+
+static const char *TAG = "eppp_link_netif";
+
+extern "C" int eppp_netif_get_num(esp_netif_t *netif)
+{
+    if (netif == NULL) {
+        return -1;
+    }
+    const char *ifkey = esp_netif_get_ifkey(netif);
+    if (strstr(ifkey, "EPPP") == NULL) {
+        return -1; // not our netif
+    }
+    int netif_cnt = ifkey[4] - '0';
+    if (netif_cnt < 0 || netif_cnt > 9) {
+        ESP_LOGE(TAG, "Unexpected netif key %s", ifkey);
+        return -1;
+    }
+    return  netif_cnt;
+}
+
+static bool have_some_eppp_netif_impl(esp_netif_t *netif)
+{
+    return eppp_netif_get_num(netif) >= 0;
+}
+
+// Generic lambda adapts to ctx constness changes across IDF versions.
+extern "C" bool eppp_have_some_netif(void)
+{
+    return esp_netif_find_if(
+    [](esp_netif_t *netif, auto ctx) {
+        return have_some_eppp_netif_impl(netif);
+    },
+    NULL
+           ) != NULL;
+}


### PR DESCRIPTION
Preparation for IDF change:
```patch
-typedef bool (*esp_netif_find_predicate_t)(esp_netif_t *netif, void *ctx);
+typedef bool (*esp_netif_find_predicate_t)(esp_netif_t *netif, const void *ctx);
```

~~Using C++ type traits for fine grained control of specific arguments (which are allowed and which are not)~~

Using generic lambda to adapt to ctx constness changes in future IDF versions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: mainly refactors helper logic for netif lookup into a new C++ shim to stay compatible with upcoming ESP-IDF API signature changes; core connection flow is unchanged.
> 
> **Overview**
> **Improves ESP-IDF compatibility for EPPP netif discovery.**
> 
> Moves EPPP netif key parsing and the `esp_netif_find_if` predicate into a new `eppp_link_netif.cpp`, using a generic C++ lambda to tolerate `ctx` constness differences across IDF versions.
> 
> Updates `eppp_link.c` to call the new `eppp_netif_get_num()`/`eppp_have_some_netif()` helpers and registers the new source file in `components/eppp_link/CMakeLists.txt`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5eca0c5545d34d7efc4cf8baec79928bd048f042. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->