### PR TITLE
fix(examples): update websocket test paths

### DIFF
--- a/.github/workflows/websocket__build-target-test.yml
+++ b/.github/workflows/websocket__build-target-test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         idf_ver: ["release-v5.0", "release-v5.1", "release-v5.2", "release-v5.3", "latest"]
-        test: [ { app: example, path: "examples/target" }, { app: unit_test, path: "test" } ]
+        test: [ { app: example, path: "examples/target" }, { app: unit_test, path: "tests/unit" } ]
     runs-on: ubuntu-22.04
     container: espressif/idf:${{ matrix.idf_ver }}
     env:
@@ -53,7 +53,7 @@ jobs:
       matrix:
         idf_ver: ["release-v5.0", "release-v5.1", "release-v5.2", "release-v5.3", "latest"]
         idf_target: ["esp32"]
-        test: [ { app: example, path: "examples/target" }, { app: unit_test, path: "test" } ]
+        test: [ { app: example, path: "examples/target" }, { app: unit_test, path: "tests/unit" } ]
     runs-on:
       - self-hosted
       - ESP32-ETHERNET-KIT


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only path change; main risk is workflows failing if the directory name or artifact paths don’t match the repository layout.
> 
> **Overview**
> Updates the `websocket: build/target-tests` GitHub Actions workflow to run the websocket unit-test job from `components/esp_websocket_client/tests/unit` instead of the old `.../test` directory.
> 
> This change applies to both the containerized build matrix and the self-hosted ESP32 target-test matrix, ensuring artifacts/results are produced from the correct unit-test path across all IDF versions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7641e031b2267067584e7e39fe4a6823549eb0b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->