### PR TITLE
fix(mdns): correct server initialization condition in mdns_browse_new (IDFGH-17318)

### DIFF
--- a/components/mdns/mdns_browser.c
+++ b/components/mdns/mdns_browser.c
@@ -618,7 +618,7 @@ mdns_browse_t *mdns_browse_new(const char *service, const char *proto, mdns_brow
 {
     mdns_browse_t *browse = NULL;
 
-    if (mdns_priv_is_server_init() || mdns_utils_str_null_or_empty(service) || mdns_utils_str_null_or_empty(proto)) {
+    if (!mdns_priv_is_server_init() || mdns_utils_str_null_or_empty(service) || mdns_utils_str_null_or_empty(proto)) {
         return NULL;
     }
 


### PR DESCRIPTION
## Description

The server initialization check in mdns_browse_new() was reversed, causing browse creation to fail when the server was initialized.
This PR corrects the logic.


---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, single-condition bug fix in `mdns_browse_new` that only affects whether browsing can be created when mDNS is running.
> 
> **Overview**
> Fixes a logic error in `mdns_browse_new` (`mdns_browser.c`) by inverting the server-init guard so browse handles are created **only when** the mDNS server is initialized (and `service`/`proto` are valid), instead of incorrectly failing in the initialized state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dcc33d692f82d61ac118987129f2aae24d7ef9ab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->