### PR TITLE
fix(websocket): Fix stale CLOSE_FRAME_SENT_BIT blocking PINGs after reconnect

### DIFF
--- a/components/esp_websocket_client/esp_websocket_client.c
+++ b/components/esp_websocket_client/esp_websocket_client.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2015-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -1509,6 +1509,11 @@ static esp_err_t esp_websocket_client_close_with_optional_body(esp_websocket_cli
 
     // Set closing bit to prevent from sending PING frames while connected
     xEventGroupSetBits(client->status_bits, CLOSE_FRAME_SENT_BIT);
+
+    if (client->config->auto_reconnect && client->config->close_reconnect) {
+        // Client does not stop(STOPPED_BIT) with auto-reconnect-on-close
+        return ESP_OK;
+    }
 
     if (STOPPED_BIT & xEventGroupWaitBits(client->status_bits, STOPPED_BIT, false, true, timeout)) {
         return ESP_OK;

--- a/components/esp_websocket_client/esp_websocket_client.c
+++ b/components/esp_websocket_client/esp_websocket_client.c
@@ -1247,6 +1247,8 @@ static void esp_websocket_client_task(void *pv)
             client->last_opcode = WS_TRANSPORT_OPCODES_NONE;
             client->close_status_code = 0;
 
+            // Clear CLOSE_FRAME_SENT_BIT to allow PINGs to be sent after reconnect
+            xEventGroupClearBits(client->status_bits, CLOSE_FRAME_SENT_BIT);
             esp_websocket_client_dispatch_event(client, WEBSOCKET_EVENT_CONNECTED, NULL, 0);
 
             // Check if there is data pending to be read (e.g. piggybacked with handshake)
@@ -1501,15 +1503,23 @@ static esp_err_t esp_websocket_client_close_with_optional_body(esp_websocket_cli
         return ESP_FAIL;
     }
 
+    int close_ret;
     if (send_body) {
-        esp_websocket_client_send_close(client, code, data, len + 2, portMAX_DELAY); // len + 2 -> always sending the code
+        close_ret = esp_websocket_client_send_close(client, code, data, len + 2, portMAX_DELAY); // len + 2 -> always sending the code
     } else {
-        esp_websocket_client_send_close(client, 0, NULL, 0, portMAX_DELAY); // only opcode frame
+        close_ret = esp_websocket_client_send_close(client, 0, NULL, 0, portMAX_DELAY); // only opcode frame
+    }
+
+    if (close_ret < 0) {
+        return ESP_FAIL;
     }
 
     // Set closing bit to prevent from sending PING frames while connected
     xEventGroupSetBits(client->status_bits, CLOSE_FRAME_SENT_BIT);
 
+    // When auto_reconnect and close_reconnect are both enabled, the task thread owns the
+    // close handshake and will reconnect autonomously. Return immediately; do not wait for
+    // STOPPED_BIT which will never be set in this configuration.
     if (client->config->auto_reconnect && client->config->close_reconnect) {
         // Client does not stop(STOPPED_BIT) with auto-reconnect-on-close
         return ESP_OK;

--- a/components/esp_websocket_client/include/esp_websocket_client.h
+++ b/components/esp_websocket_client/include/esp_websocket_client.h
@@ -113,8 +113,18 @@ typedef struct {
     const char                  *username;                  /*!< Using for Http authentication, only support basic auth now */
     const char                  *password;                  /*!< Using for Http authentication */
     const char                  *path;                      /*!< HTTP Path, if not set, default is `/` */
-    bool                        disable_auto_reconnect;     /*!< Disable the automatic reconnect function when disconnected */
-    bool                        enable_close_reconnect;     /*!< Enable reconnect after server close */
+    bool                        disable_auto_reconnect;     /*!< Disable automatic reconnect on unexpected disconnection (transport errors, poll failures).
+                                                                 Default: false (auto-reconnect is enabled). Reconnect delay is controlled by `reconnect_timeout_ms`.
+                                                                 Note: this flag does not affect behaviour after a clean WebSocket CLOSE handshake;
+                                                                 use `enable_close_reconnect` for that. */
+    bool                        enable_close_reconnect;     /*!< Reconnect after a clean WebSocket CLOSE handshake (RFC 6455 close frame exchange),
+                                                                 whether the close was initiated by the server or by calling esp_websocket_client_close().
+                                                                 Default: false (client stops after a clean close).
+                                                                 When true, esp_websocket_client_close() returns immediately (non-blocking) after sending
+                                                                 the CLOSE frame; the task handles the handshake and reconnects autonomously.
+                                                                 Requires `disable_auto_reconnect` to be false; setting this flag while
+                                                                 `disable_auto_reconnect` is true has no effect on error-triggered disconnections and
+                                                                 may result in a single reconnect attempt that stops on any subsequent error. */
     void                        *user_context;              /*!< HTTP user data context */
     bool                        task_core_id_set;           /*!< Set to true to use task_core_id. If false, the websocket task uses tskNO_AFFINITY(default) */
     int                         task_core_id;               /*!< Core ID for the websocket task when task_core_id_set is true. Must be explicitly set by the user, otherwise a zero-initialized config, will pin the task to core 0. Use tskNO_AFFINITY for no pinning. */


### PR DESCRIPTION
Related https://github.com/espressif/esp-protocols/pull/999

Only set CLOSE_FRAME_SENT_BIT when send_close() succeeds; clear it on every
INIT->CONNECTED transition so a reconnected connection always sends PINGs normally.
Also document the auto_reconnect/close_reconnect dependency in config struct.