### PR TITLE
fix(mdns): Fix null pointer exception in mdns_parse_packet (IDFGH-17353)

### DIFF
--- a/components/mdns/mdns_receive.c
+++ b/components/mdns/mdns_receive.c
@@ -554,6 +554,10 @@ static void remove_parsed_question(mdns_parsed_packet_t *parsed_packet, uint16_t
 {
     mdns_parsed_question_t *q = parsed_packet->questions;
 
+    if (!q) {
+        return;
+    }
+
     if (question_matches(q, type, service)) {
         parsed_packet->questions = q->next;
         mdns_mem_free(q->host);


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

This PR fixes a null pointer exception in mdns component.
In `mdns_parse_packet` function there is a call to `remove_parsed_question` which might get `parsed_packet` with the NULL `questions` field.
https://github.com/espressif/esp-protocols/blob/mdns-v1.10.1/components/mdns/mdns_receive.c#L860

There is the log of the crash. Backtrace points to the neighboring call, probably, due to compiler optimizations.
```
Guru Meditation Error: Core  0 panic'ed (Load access fault). Exception was unhandled.

--- Backtrace:


add symbol table from file "/home/scaiper/config/.esphome/build/test/build/bootloader/bootloader.elf"
question_matches (question=question@entry=0x0, type=type@entry=50, service=service@entry=0x3fcaf6e0) at /home/scaiper/config/.esphome/build/test/managed_components/espressif__mdns/mdns_receive.c:520
520         if (question->type != type) {
#0  question_matches (question=question@entry=0x0, type=type@entry=50, service=service@entry=0x3fcaf6e0) at /home/scaiper/config/.esphome/build/test/managed_components/espressif__mdns/mdns_receive.c:520
#1  0x4202d76e in remove_parsed_question (parsed_packet=0x3fcae294, type=50, service=0x3fcaf6e0) at /home/scaiper/config/.esphome/build/test/managed_components/espressif__mdns/mdns_receive.c:557
#2  0x4202e426 in mdns_parse_packet (packet=0x3fcb086c) at /home/scaiper/config/.esphome/build/test/managed_components/espressif__mdns/mdns_receive.c:862
#3  mdns_priv_receive_action (action=action@entry=0x3fcafa40, type=type@entry=ACTION_RUN) at /home/scaiper/config/.esphome/build/test/managed_components/espressif__mdns/mdns_receive.c:1276
#4  0x4202c8da in execute_action (action=0x3fcafa40) at /home/scaiper/config/.esphome/build/test/managed_components/espressif__mdns/mdns_service.c:182
#5  service_task (pvParameters=<optimized out>) at /home/scaiper/config/.esphome/build/test/managed_components/espressif__mdns/mdns_service.c:211
#6  0x00000000 in ?? ()
Backtrace stopped: frame did not save the PC
```
<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

All of my esphome devices running esp32 started crashing with this error after I updated my routers to OpenWrt 25.12.
I don't know, are mdns packets causing this issue valid or not. Regardless, mdns componets should not just crash.

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass. (approval needed)
- [x] Documentation is updated as needed. (not needed)
- [x] Tests are updated or added as necessary. (not needed)
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a simple NULL check to avoid dereferencing an empty questions list during mDNS packet parsing, with no behavioral change when questions are present.
> 
> **Overview**
> Prevents a crash in `mdns_parse_packet` by making `remove_parsed_question` return early when `parsed_packet->questions` is `NULL`, avoiding a null dereference in `question_matches` for packets that produce no saved questions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 568120928af3d7bc957b843ac2fcfaa04267855d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->