### PR TITLE
fix(esp_modem): Output buffer not cleared when AT command returns empty response (IDFGH-17370)

### DIFF
--- a/components/esp_modem/src/esp_modem_c_api.cpp
+++ b/components/esp_modem/src/esp_modem_c_api.cpp
@@ -233,12 +233,12 @@ extern "C" esp_err_t esp_modem_get_signal_quality(esp_modem_dce_t *dce_wrap, int
 
 extern "C" esp_err_t esp_modem_get_imsi(esp_modem_dce_t *dce_wrap, char *p_imsi)
 {
-    if (dce_wrap == nullptr || dce_wrap->dce == nullptr) {
+    if (dce_wrap == nullptr || dce_wrap->dce == nullptr || p_imsi == nullptr) {
         return ESP_ERR_INVALID_ARG;
     }
     std::string imsi;
     auto ret = command_response_to_esp_err(dce_wrap->dce->get_imsi(imsi));
-    if (ret == ESP_OK && !imsi.empty()) {
+    if (ret == ESP_OK) {
         strlcpy(p_imsi, imsi.c_str(), CONFIG_ESP_MODEM_C_API_STR_MAX);
     }
     return ret;
@@ -276,12 +276,12 @@ extern "C" esp_err_t esp_modem_store_profile(esp_modem_dce_t *dce_wrap)
 
 extern "C" esp_err_t esp_modem_get_imei(esp_modem_dce_t *dce_wrap, char *p_imei)
 {
-    if (dce_wrap == nullptr || dce_wrap->dce == nullptr) {
+    if (dce_wrap == nullptr || dce_wrap->dce == nullptr || p_imei == nullptr) {
         return ESP_ERR_INVALID_ARG;
     }
     std::string imei;
     auto ret = command_response_to_esp_err(dce_wrap->dce->get_imei(imei));
-    if (ret == ESP_OK && !imei.empty()) {
+    if (ret == ESP_OK) {
         strlcpy(p_imei, imei.c_str(), CONFIG_ESP_MODEM_C_API_STR_MAX);
     }
     return ret;
@@ -295,7 +295,7 @@ extern "C" esp_err_t esp_modem_get_operator_name(esp_modem_dce_t *dce_wrap, char
     std::string name;
     int act;
     auto ret = command_response_to_esp_err(dce_wrap->dce->get_operator_name(name, act));
-    if (ret == ESP_OK && !name.empty()) {
+    if (ret == ESP_OK) {
         strlcpy(p_name, name.c_str(), CONFIG_ESP_MODEM_C_API_STR_MAX);
         *p_act = act;
     }
@@ -304,12 +304,12 @@ extern "C" esp_err_t esp_modem_get_operator_name(esp_modem_dce_t *dce_wrap, char
 
 extern "C" esp_err_t esp_modem_get_module_name(esp_modem_dce_t *dce_wrap, char *p_name)
 {
-    if (dce_wrap == nullptr || dce_wrap->dce == nullptr) {
+    if (dce_wrap == nullptr || dce_wrap->dce == nullptr || p_name == nullptr) {
         return ESP_ERR_INVALID_ARG;
     }
     std::string name;
     auto ret = command_response_to_esp_err(dce_wrap->dce->get_module_name(name));
-    if (ret == ESP_OK && !name.empty()) {
+    if (ret == ESP_OK) {
         strlcpy(p_name, name.c_str(), CONFIG_ESP_MODEM_C_API_STR_MAX);
     }
     return ret;


### PR DESCRIPTION
## Description

When `esp_modem_at()` or `esp_modem_at_raw()` returns an empty response,
the output buffer `p_out` was not cleared. This caused callers to read
uninitialized or stale data when checking `p_out` after a successful AT
command that returns no payload (e.g. `AT` returns just `OK` with no
additional data).

This fix explicitly sets `p_out[0] = '\0'` when the response is empty,
ensuring callers can safely check the buffer without needing to
pre-initialize it themselves.

## Testing

Tested on SIM7080G with esp-idf v5.5.3 using `esp_modem_at(dce, "AT", buf, 1000)`.
Previously `buf` contained garbage when the command succeeded, now it is
correctly cleared to an empty string.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk behavioral fix in the C API: it changes `esp_modem_at()`/`esp_modem_at_raw()` to always write to `p_out` (including empty responses), which may affect callers that relied on the buffer remaining unchanged.
> 
> **Overview**
> Fixes `esp_modem_at()` and `esp_modem_at_raw()` to **always** copy the modem response into `p_out` when provided, even when the response string is empty.
> 
> This ensures callers don’t observe stale/garbage data in `p_out` after successful AT commands that return no payload (e.g., `OK` only).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 17d82dea3b2d24ee4e4f54421f3ed9b0873d3e63. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->