### PR TITLE
mdns: guard against null esp_netif during deinit / reboot

### DIFF
--- a/components/mdns/mdns_networking_lwip.c
+++ b/components/mdns/mdns_networking_lwip.c
@@ -109,13 +109,20 @@ static esp_err_t join_group(mdns_if_t if_inx, mdns_ip_protocol_t ip_protocol, bo
     struct netif *netif = NULL;
     esp_netif_t *tcpip_if = mdns_priv_get_esp_netif(if_inx);
 
+    if (!tcpip_if) {
+        // The interface can disappear before mDNS deinit finishes during reboot.
+        return ESP_ERR_INVALID_STATE;
+    }
+
     if (!esp_netif_is_netif_up(tcpip_if)) {
         // Network interface went down before event propagated, skipping IGMP config
         return ESP_ERR_INVALID_STATE;
     }
 
     netif = esp_netif_get_netif_impl(tcpip_if);
-    assert(netif);
+    if (!netif) {
+        return ESP_ERR_INVALID_STATE;
+    }
 
 #if LWIP_IPV4
     if (ip_protocol == MDNS_IP_PROTOCOL_V4) {


### PR DESCRIPTION
Summary

During reboot, application code may call mdns_free() while the predefined Wi-Fi or Ethernet esp_netif is already being torn down. In that window, mdns_priv_get_esp_netif() can return NULL in the LwIP-thread deinit path and join_group() dereferences it through esp_netif_is_netif_up(), causing a panic.

Observed call path

- app stop path calls discovery_deinit()
- discovery_deinit() calls mdns_free()
- mdns_free() deinitializes PCB state
- pcb_if_deinit() / join_group(..., false) runs in the LwIP thread
- mdns_priv_get_esp_netif() returns NULL
- esp_netif_is_netif_up(NULL) crashes

Decoded backtrace from affected firmware

- esp_netif_is_netif_up
- _udp_join_group / join_group in mdns_networking_lwip.c
- _udp_pcb_deinit / pcb_if_deinit
- tcpip_thread_handle_msg

Why this change is safe

The function already treats an interface that is no longer up as a non-fatal condition and returns ESP_ERR_INVALID_STATE to skip IGMP/MLD operations. A NULL esp_netif or NULL lwIP netif is the same class of condition during teardown: there is no live interface left to update.

Minimal fix

- return ESP_ERR_INVALID_STATE when mdns_priv_get_esp_netif() returns NULL
- return ESP_ERR_INVALID_STATE when esp_netif_get_netif_impl() returns NULL
- do not assert on a missing lwIP netif during teardown

This crash was observed during mdns_free() in the reboot/shutdown path, and the backtrace leads to esp_netif_is_netif_up(NULL).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small defensive checks in `join_group` that only alter behavior during interface teardown by returning `ESP_ERR_INVALID_STATE` instead of asserting/crashing.
> 
> **Overview**
> Avoids a reboot/deinit panic in `mdns_networking_lwip.c` by adding NULL guards in `join_group()`.
> 
> If `mdns_priv_get_esp_netif()` or `esp_netif_get_netif_impl()` returns NULL, the code now returns `ESP_ERR_INVALID_STATE` (and removes the `assert(netif)`), skipping IGMP/MLD membership updates when the interface is already being torn down.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d5a393f61c48c7466993b69483aa62752572ccad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->