### PR TITLE
bump(modem): 2.0.0 -> 2.0.1

### DIFF
--- a/components/esp_modem/.cz.yaml
+++ b/components/esp_modem/.cz.yaml
@@ -3,6 +3,6 @@ commitizen:
   bump_message: 'bump(modem): $current_version -> $new_version'
   pre_bump_hooks: python ../../ci/changelog.py esp_modem
   tag_format: modem-v$version
-  version: 2.0.0
+  version: 2.0.1
   version_files:
   - idf_component.yml

--- a/components/esp_modem/CHANGELOG.md
+++ b/components/esp_modem/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [2.0.1](https://github.com/espressif/esp-protocols/commits/modem-v2.0.1)
+
+### Bug Fixes
+
+- Fix inconsistent error checks in C-API wrappers ([de02d8a3](https://github.com/espressif/esp-protocols/commit/de02d8a3))
+- null terminate output buffers when modem sends empty response & check output buffers are not null ([6124b7ee](https://github.com/espressif/esp-protocols/commit/6124b7ee))
+- null terminate output buffer if no response in esp_modem_at functions ([17d82dea](https://github.com/espressif/esp-protocols/commit/17d82dea))
+- Fix catch based target tests with v6.0 ([7f4e3690](https://github.com/espressif/esp-protocols/commit/7f4e3690))
+- Fix deinit function in ap2ppp example ([853e8e28](https://github.com/espressif/esp-protocols/commit/853e8e28))
+
 ## [2.0.0](https://github.com/espressif/esp-protocols/commits/modem-v2.0.0)
 
 ### Breaking changes

--- a/components/esp_modem/idf_component.yml
+++ b/components/esp_modem/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.0.0"
+version: "2.0.1"
 description: Library for communicating with cellular modems in command and data modes
 url: https://github.com/espressif/esp-protocols/tree/master/components/esp_modem
 issues: https://github.com/espressif/esp-protocols/issues


### PR DESCRIPTION
2.0.1

Bug Fixes

- Fix inconsistent error checks in C-API wrappers (de02d8a3)
- null terminate output buffers when modem sends empty response & check output buffers are not null (6124b7ee)
- null terminate output buffer if no response in esp_modem_at functions (17d82dea)
- Fix catch based target tests with v6.0 (7f4e3690)
- Fix deinit function in ap2ppp example (853e8e28)

