### PR TITLE
fix(mdns): Fix parsing of mdns.txt records containing booleans

### DIFF
--- a/components/mdns/mdns_receive.c
+++ b/components/mdns/mdns_receive.c
@@ -280,7 +280,7 @@ static void result_txt_create(const uint8_t *data, size_t len, mdns_txt_item_t *
 
         memcpy(key, data + i, name_len);
         key[name_len] = 0;
-        i += name_len + 1;
+        i += name_len + (name_len < part_len); // skip '=' only if present
         t->key = key;
 
         int new_value_len = part_len - name_len - 1;


### PR DESCRIPTION
RFC 6763 / page 16 explicitly allows booleans without '='. Failing to parse these caused mdns_query_txt() to return a null pointer. This is a simple and straight-forward fix for the scan index stepping correctly when no '=' is present.

## Testing

I did positive and negative testing by changing a boolean in the mdns.txt record of the target host.
I did test it with a "register=true" and then again with just a "register" txt record.
Without this single-line patch the latter would fail to parse when calling mdns_query_txt().

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches mDNS TXT record parsing on incoming network packets; a small index-calculation change could affect how subsequent TXT entries/values are read for edge-case inputs.
> 
> **Overview**
> Fixes parsing of mDNS TXT records that omit `'='` (RFC 6763 boolean-style keys) by advancing the scan index only when an equals sign is actually present. This prevents boolean TXT entries like `"register"` from breaking TXT parsing and returning missing/NULL results.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a6e09518959898517a60c9a58e935999e08b21fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->