### PR TITLE
feat(modem): add idf build system v2 support

### DIFF
--- a/components/esp_modem/CMakeLists.txt
+++ b/components/esp_modem/CMakeLists.txt
@@ -40,6 +40,11 @@ set(srcs ${platform_srcs}
         "src/esp_modem_vfs_socket_creator.cpp"
         "${command_dir}/src/esp_modem_modules.cpp")
 
+if(IDF_BUILD_V2)
+    include(CMakeLists_v2.txt)
+    return()
+endif()
+
 idf_component_register(SRCS "${srcs}"
                     INCLUDE_DIRS include ${command_dir}/include
                     PRIV_INCLUDE_DIRS private_include

--- a/components/esp_modem/CMakeLists_v2.txt
+++ b/components/esp_modem/CMakeLists_v2.txt
@@ -2,7 +2,6 @@
 # Initialize lists before use to avoid inheriting variables from
 # a parent component scope (recursive evaluation in v2).
 set(public_deps)
-set(optional_deps)
 
 foreach(dep IN LISTS dependencies)
     idf_component_include(${dep})

--- a/components/esp_modem/CMakeLists_v2.txt
+++ b/components/esp_modem/CMakeLists_v2.txt
@@ -1,0 +1,37 @@
+# --- IDF Build System V2 Integration ---
+# Initialize lists before use to avoid inheriting variables from
+# a parent component scope (recursive evaluation in v2).
+set(public_deps)
+set(optional_deps)
+
+foreach(dep IN LISTS dependencies)
+    idf_component_include(${dep})
+    list(APPEND public_deps idf::${dep})
+endforeach()
+
+add_library(${COMPONENT_TARGET} STATIC ${srcs})
+
+target_include_directories(${COMPONENT_TARGET}
+    PUBLIC
+        include
+        ${command_dir}/include
+    PRIVATE
+        private_include
+)
+
+target_link_libraries(${COMPONENT_TARGET} PUBLIC ${public_deps})
+
+target_compile_features(${COMPONENT_TARGET} PUBLIC cxx_std_17)
+set_target_properties(${COMPONENT_TARGET} PROPERTIES
+    CXX_EXTENSIONS ON
+)
+
+# Optional dependency on "main" when custom module is enabled.
+# Use TARGET_EXISTS generator expression so the link is a no-op when
+# "main" is not part of the build (v2 makes all Kconfig visible, so
+# CONFIG_ESP_MODEM_ADD_CUSTOM_MODULE can be set even if "main" is absent).
+if(CONFIG_ESP_MODEM_ADD_CUSTOM_MODULE)
+    idf_component_include(main)
+    target_link_libraries(${COMPONENT_TARGET} PUBLIC
+        "$<$<TARGET_EXISTS:idf::main>:idf::main>")
+endif()


### PR DESCRIPTION
## Description

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

Adds Build System v2 support to `esp_modem`. Linking to `esp_modem` in a new project for testing v2 failed, so I looked up the [documentation for updating a component for v2 compatibility](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-guides/build-system-v2.html#updating-component-for-v2-compatibility).

## Related

Build System v2 documentation:  
https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-guides/build-system-v2.html

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->
Tested and verified locally in a ESP-IDF 6.0 project using Build System v2.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Build-system changes can impact how `esp_modem` is compiled/linked across projects and IDF versions, potentially causing integration/link errors. Scope is limited to CMake logic with no runtime/behavior changes to modem code.
> 
> **Overview**
> Adds conditional support for ESP-IDF **Build System v2** in `esp_modem` by detecting `IDF_BUILD_V2` and delegating to a new `CMakeLists_v2.txt`.
> 
> The v2 CMake file builds `esp_modem` as a static library target (`${COMPONENT_TARGET}`), wires include paths and public deps via `idf::` targets, enforces C++17, and handles the optional `main` link for `CONFIG_ESP_MODEM_ADD_CUSTOM_MODULE` using a `TARGET_EXISTS` guarded link to avoid failures when `main` isn’t present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 783d23a5a1a68e8a9a1f2d8d68f456906ea8c9c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->