### PR TITLE
fix(websocket): Fix leaking user_info if strdup for user or pass fails

### DIFF
--- a/components/esp_websocket_client/esp_websocket_client.c
+++ b/components/esp_websocket_client/esp_websocket_client.c
@@ -992,11 +992,11 @@ esp_err_t esp_websocket_client_set_uri(esp_websocket_client_handle_t client, con
                 pass ++;
                 free(client->config->password);
                 client->config->password = strdup(pass);
-                ESP_WS_CLIENT_MEM_CHECK(TAG, client->config->password, return ESP_ERR_NO_MEM);
+                ESP_WS_CLIENT_MEM_CHECK(TAG, client->config->password, free(user_info); return ESP_ERR_NO_MEM);
             }
             free(client->config->username);
             client->config->username = strdup(user_info);
-            ESP_WS_CLIENT_MEM_CHECK(TAG, client->config->username, return ESP_ERR_NO_MEM);
+            ESP_WS_CLIENT_MEM_CHECK(TAG, client->config->username, free(user_info); return ESP_ERR_NO_MEM);
             free(user_info);
         } else {
             return ESP_ERR_NO_MEM;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: small, localized change that only affects the error path when allocating username/password from a URI fails, preventing a memory leak.
> 
> **Overview**
> Fixes a memory leak in `esp_websocket_client_set_uri()` when parsing `userinfo` from the URI: if `strdup()` fails for the extracted username or password, the temporary `user_info` buffer is now freed before returning `ESP_ERR_NO_MEM`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a79f77c0a6408c7a7a975ea118fdad4420d0c1d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->