### PR TITLE
[modem]: Build job with cmake v2

### DIFF
--- a/.github/workflows/modem__build-host-tests.yml
+++ b/.github/workflows/modem__build-host-tests.yml
@@ -93,6 +93,36 @@ jobs:
         run_coverage: false
         pre_run_script: "esp-protocols/components/esp_modem/test/host_test/env.sh"
 
+  build_esp_modem_v2:
+    if: contains(github.event.pull_request.labels.*.name, 'modem') || github.event_name == 'push'
+    # Component manager + v2 mismatches the esp_modem override name; use EXTRA_COMPONENT_DIRS instead.
+    name: Build ap_to_pppos with IDF build system v2
+    runs-on: ubuntu-22.04
+    container: espressif/idf:release-v6.0
+    steps:
+      - name: Checkout esp-protocols
+        uses: actions/checkout@v4
+        with:
+          path: protocols
+      - name: Build ap_to_pppos with v2
+        shell: bash
+        run: |
+          . ${IDF_PATH}/export.sh
+          cd $GITHUB_WORKSPACE/protocols/components/esp_modem/examples/ap_to_pppos
+          rm -f main/idf_component.yml dependencies.lock
+          cat > CMakeLists.txt << 'EOF'
+          cmake_minimum_required(VERSION 3.22)
+
+          set(EXTRA_COMPONENT_DIRS ../..)
+          include($ENV{IDF_PATH}/tools/cmakev2/idf.cmake)
+
+          project(ap-to-pppos C CXX ASM)
+
+          idf_project_default()
+          EOF
+          idf.py set-target esp32
+          idf.py build
+
   esp_modem_generated_commands:
     if: contains(github.event.pull_request.labels.*.name, 'modem') || github.event_name == 'push'
     name: Generated commands compatibility

--- a/components/esp_modem/CMakeLists.txt
+++ b/components/esp_modem/CMakeLists.txt
@@ -40,6 +40,11 @@ set(srcs ${platform_srcs}
         "src/esp_modem_vfs_socket_creator.cpp"
         "${command_dir}/src/esp_modem_modules.cpp")
 
+if(IDF_BUILD_V2)
+    include(CMakeLists_v2.txt)
+    return()
+endif()
+
 idf_component_register(SRCS "${srcs}"
                     INCLUDE_DIRS include ${command_dir}/include
                     PRIV_INCLUDE_DIRS private_include

--- a/components/esp_modem/CMakeLists_v2.txt
+++ b/components/esp_modem/CMakeLists_v2.txt
@@ -1,0 +1,37 @@
+# --- IDF Build System V2 Integration ---
+# Initialize lists before use to avoid inheriting variables from
+# a parent component scope (recursive evaluation in v2).
+set(public_deps)
+set(optional_deps)
+
+foreach(dep IN LISTS dependencies)
+    idf_component_include(${dep})
+    list(APPEND public_deps idf::${dep})
+endforeach()
+
+add_library(${COMPONENT_TARGET} STATIC ${srcs})
+
+target_include_directories(${COMPONENT_TARGET}
+    PUBLIC
+        include
+        ${command_dir}/include
+    PRIVATE
+        private_include
+)
+
+target_link_libraries(${COMPONENT_TARGET} PUBLIC ${public_deps})
+
+target_compile_features(${COMPONENT_TARGET} PUBLIC cxx_std_17)
+set_target_properties(${COMPONENT_TARGET} PROPERTIES
+    CXX_EXTENSIONS ON
+)
+
+# Optional dependency on "main" when custom module is enabled.
+# Use TARGET_EXISTS generator expression so the link is a no-op when
+# "main" is not part of the build (v2 makes all Kconfig visible, so
+# CONFIG_ESP_MODEM_ADD_CUSTOM_MODULE can be set even if "main" is absent).
+if(CONFIG_ESP_MODEM_ADD_CUSTOM_MODULE)
+    idf_component_include(main)
+    target_link_libraries(${COMPONENT_TARGET} PUBLIC
+        "$<$<TARGET_EXISTS:idf::main>:idf::main>")
+endif()

--- a/components/esp_modem/examples/ap_to_pppos/main/CMakeLists.txt
+++ b/components/esp_modem/examples/ap_to_pppos/main/CMakeLists.txt
@@ -6,7 +6,8 @@ endif()
 
 idf_component_register(SRCS "ap_to_pppos.c"
                             ${NETWORK_DCE}
-                    INCLUDE_DIRS ".")
+                    INCLUDE_DIRS "."
+                    REQUIRES esp_netif esp_wifi esp_modem nvs_flash)
 
 # Ignore strict prototypes, as the network_dce.h can used in both C and C++ compilation
 target_compile_options(${COMPONENT_LIB} PRIVATE "-Wno-strict-prototypes")


### PR DESCRIPTION
followup on https://github.com/espressif/esp-protocols/pull/1039

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes build-system integration for `esp_modem` and adds a new CI build path; failures could block builds across IDF v6/v2 configurations.
> 
> **Overview**
> Adds a new CI job to build `esp_modem`’s `ap_to_pppos` example using ESP-IDF’s **CMake build system v2** (IDF `release-v6.0`), generating a minimal top-level `CMakeLists.txt` and using `EXTRA_COMPONENT_DIRS` to avoid component manager override issues.
> 
> Updates `components/esp_modem` to detect `IDF_BUILD_V2` and switch to a new `CMakeLists_v2.txt` that builds the component via `add_library`, wires include dirs/link deps, enforces C++17, and safely links `idf::main` only when present (for `CONFIG_ESP_MODEM_ADD_CUSTOM_MODULE`). Also tightens the `ap_to_pppos` example’s `main` component to explicitly `REQUIRES` its runtime dependencies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5d7f849f2268812e23f748d9cc7bfa511dcc13d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->