### PR TITLE
[eppp]: Bump 1.1.4 -> 1.1.5

### DIFF
--- a/components/eppp_link/.cz.yaml
+++ b/components/eppp_link/.cz.yaml
@@ -3,6 +3,6 @@ commitizen:
   bump_message: 'bump(eppp): $current_version -> $new_version'
   pre_bump_hooks: python ../../ci/changelog.py eppp_link
   tag_format: eppp-v$version
-  version: 1.1.4
+  version: 1.1.5
   version_files:
   - idf_component.yml

--- a/components/eppp_link/CHANGELOG.md
+++ b/components/eppp_link/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.1.5](https://github.com/espressif/esp-protocols/commits/eppp-v1.1.5)
+
+### Bug Fixes
+
+- Use C++ traits to control netif predicate type changes ([5eca0c55](https://github.com/espressif/esp-protocols/commit/5eca0c55))
+
 ## [1.1.4](https://github.com/espressif/esp-protocols/commits/eppp-v1.1.4)
 
 ### Bug Fixes

--- a/components/eppp_link/idf_component.yml
+++ b/components/eppp_link/idf_component.yml
@@ -1,4 +1,4 @@
-version: 1.1.4
+version: 1.1.5
 url: https://github.com/espressif/esp-protocols/tree/master/components/eppp_link
 description: The component provides a general purpose PPP connectivity, typically used as WiFi-PPP router
 dependencies:


### PR DESCRIPTION
## 1.1.5

### Bug Fixes

- Use C++ generic lambda to control netif predicate type changes (5eca0c55)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> This is a metadata/changelog-only version bump with no functional code changes in the component itself.
> 
> **Overview**
> Updates the `eppp_link` component release from `1.1.4` to `1.1.5` by bumping version metadata in `.cz.yaml` and `idf_component.yml`.
> 
> Adds a `1.1.5` entry to `CHANGELOG.md` documenting the bug fix for using C++ traits to handle netif predicate type changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f1a3cc9fe070bb8db5c745d0e87aa0631caf831. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->