### PR TITLE
[mdns]: Hardening mdns lib

### DIFF
--- a/components/mdns/mdns_debug.c
+++ b/components/mdns/mdns_debug.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2015-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -191,6 +191,11 @@ void static dbg_packet(const uint8_t *data, size_t len)
                 break;
             }
 
+            if (content + MDNS_LEN_OFFSET + 1 >= data + len) {
+                // malformed packet, RR header (TYPE/CLASS/TTL/LEN) would read past the buffer
+                dbg_printf("ERROR: truncated RR header\n");
+                break;
+            }
             uint16_t type = mdns_utils_read_u16(content, MDNS_TYPE_OFFSET);
             uint16_t mdns_class = mdns_utils_read_u16(content, MDNS_CLASS_OFFSET);
             uint32_t ttl = mdns_utils_read_u32(content, MDNS_TTL_OFFSET);
@@ -309,6 +314,11 @@ void static dbg_packet(const uint8_t *data, size_t len)
                 if (new_ptr) {
                     dbg_printf("%s.%s.%s.%s. ", name->host, name->service, name->proto, name->domain);
                     size_t diff = new_ptr - old_ptr;
+                    if (diff > data_len) {
+                        // FQDN parsed past the record boundary; avoid underflowing data_len
+                        dbg_printf("ERROR: parse NSEC\n");
+                        continue;
+                    }
                     data_len -= diff;
                     data_ptr = new_ptr;
                 }

--- a/components/mdns/mdns_debug.c
+++ b/components/mdns/mdns_debug.c
@@ -288,10 +288,18 @@ void static dbg_packet(const uint8_t *data, size_t len)
                 }
                 dbg_printf("\n");
             } else if (type == MDNS_TYPE_AAAA) {
+                if (data_len < sizeof(esp_ip6_addr_t)) {
+                    dbg_printf("ERROR: truncated AAAA\n");
+                    continue;
+                }
                 esp_ip6_addr_t ip6;
                 memcpy(&ip6, data_ptr, sizeof(esp_ip6_addr_t));
                 dbg_printf(IPV6STR "\n", IPV62STR(ip6));
             } else if (type == MDNS_TYPE_A) {
+                if (data_len < sizeof(esp_ip4_addr_t)) {
+                    dbg_printf("ERROR: truncated A\n");
+                    continue;
+                }
                 esp_ip4_addr_t ip;
                 memcpy(&ip, data_ptr, sizeof(esp_ip4_addr_t));
                 dbg_printf(IPSTR "\n", IP2STR(&ip));

--- a/components/mdns/mdns_receive.c
+++ b/components/mdns/mdns_receive.c
@@ -1,6 +1,6 @@
 
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -1090,6 +1090,9 @@ static void mdns_parse_packet(mdns_rx_packet_t *packet)
             }
 #ifdef CONFIG_LWIP_IPV6
             else if (type == MDNS_TYPE_AAAA) { // ipv6
+                if (data_len < MDNS_ANSWER_AAAA_SIZE) {
+                    continue; // malformed AAAA record, RDATA smaller than an IPv6 address
+                }
                 esp_ip_addr_t ip6;
                 ip6.type = ESP_IPADDR_TYPE_V6;
                 memcpy(ip6.u_addr.ip6.addr, data_ptr, MDNS_ANSWER_AAAA_SIZE);
@@ -1150,6 +1153,9 @@ static void mdns_parse_packet(mdns_rx_packet_t *packet)
 #endif /* CONFIG_LWIP_IPV6 */
 #ifdef CONFIG_LWIP_IPV4
             else if (type == MDNS_TYPE_A) {
+                if (data_len < 4) {
+                    continue; // malformed A record, RDATA smaller than an IPv4 address
+                }
                 esp_ip_addr_t ip;
                 ip.type = ESP_IPADDR_TYPE_V4;
                 memcpy(&(ip.u_addr.ip4.addr), data_ptr, 4);

--- a/components/mdns/mdns_utils.c
+++ b/components/mdns/mdns_utils.c
@@ -54,6 +54,10 @@ const uint8_t *mdns_utils_read_fqdn(const uint8_t *packet, const uint8_t *start,
                 memcpy(mdns_name_ptrs[name->parts++], buf, len + 1);
             }
         } else {
+            if (start + index >= packet_end) {
+                // truncated compression pointer (second byte would be out of bounds)
+                return NULL;
+            }
             size_t address = (((uint16_t)len & 0x3F) << 8) | start[index++];
             if ((packet + address) >= start) {
                 //reference address can not be after where we are


### PR DESCRIPTION
##  fix(mdns): Bounds check RR header and NSEC length in debug parser
    
    dbg_packet() is invoked for every received datagram when mDNS debug
    output is enabled. Two bugs could cause out-of-bounds reads against a
    malformed packet:
    
    - The RR header (TYPE/CLASS/TTL/LEN, 10 bytes) was read without first
      verifying that content + 9 is within the packet buffer. The outer
      loop only guarantees that 'content' itself is in range.
    - In the NSEC branch, 'diff' (the number of bytes consumed by the
      embedded FQDN) could exceed the record's rd_length, underflowing
      data_len into a huge size_t and causing the subsequent hex-dump loop
      to read far past the RDATA.
    
    Add the same RR-header guard used by the production parser and skip
    NSEC records whose embedded FQDN overruns rd_length.

##    fix(mdns): Validate RDATA length for A/AAAA records
    
    The parser copied a fixed number of bytes (4 for A, 16 for AAAA) from
    the RDATA region without checking that the record's rd_length was at
    least that large. Although the outer loop bounds the cursor by
    rd_length, it does not guarantee that rd_length >= sizeof(address), so
    a maliciously short AAAA/A answer would read up to 15 bytes past the
    RDATA (and potentially past the end of the received packet if the
    record was the last one in the datagram).
    
    Skip A/AAAA records whose rd_length is smaller than the corresponding
    address size before the memcpy.

##    fix(mdns): Validate second byte of DNS compression pointer
    
    mdns_utils_read_fqdn() consumed the low byte of a compression pointer
    without verifying that it is still within the packet. The outer loop
    only guarantees that the first (high) byte can be read, so a one-byte
    truncated pointer (a trailing 0xC? with no low byte) would cause a
    one-byte out-of-bounds read on the received packet buffer.
    
    Add an explicit bounds check before reading the low byte, mirroring the
    check already present in the literal-label branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core mDNS receive/debug parsing paths; while changes are defensive, they may cause previously-tolerated malformed packets/records to be ignored.
> 
> **Overview**
> Improves mDNS robustness by adding **strict bounds checks** in the debug record dumper (`mdns_debug.c`) to prevent reading past the packet when RR headers are truncated, when `A`/`AAAA` RDATA is shorter than expected, and when `NSEC` FQDN parsing would overrun `rd_length`.
> 
> Adds additional validation in the receive/parser logic (`mdns_receive.c`) to **skip malformed `A`/`AAAA` records** whose `rd_length` is too small, and hardens FQDN parsing (`mdns_utils.c`) by rejecting truncated DNS compression pointers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c10eb9ac8528f02180bb4c420ac2fc00a250b74d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->