### PR TITLE
Bump/mdns 1.11.1

### DIFF
--- a/components/mdns/.cz.yaml
+++ b/components/mdns/.cz.yaml
@@ -3,6 +3,6 @@ commitizen:
   bump_message: 'bump(mdns): $current_version -> $new_version'
   pre_bump_hooks: python ../../ci/changelog.py mdns
   tag_format: mdns-v$version
-  version: 1.11.0
+  version: 1.11.1
   version_files:
   - idf_component.yml

--- a/components/mdns/CHANGELOG.md
+++ b/components/mdns/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [1.11.1](https://github.com/espressif/esp-protocols/commits/mdns-v1.11.1)
+
+### Bug Fixes
+
+- Remove IDF tracker from sources/comments ([4870186b](https://github.com/espressif/esp-protocols/commit/4870186b))
+- Bounds check RR header and NSEC length in debug parser ([c10eb9ac](https://github.com/espressif/esp-protocols/commit/c10eb9ac))
+- Validate RDATA length for A/AAAA records ([df9644aa](https://github.com/espressif/esp-protocols/commit/df9644aa))
+- Validate second byte of DNS compression pointer ([6dd051a1](https://github.com/espressif/esp-protocols/commit/6dd051a1))
+- Minor cleanup in mdns socket layer ([37b8a7ca](https://github.com/espressif/esp-protocols/commit/37b8a7ca))
+- Fix parsing of mdns.txt records containing booleans ([a6e09518](https://github.com/espressif/esp-protocols/commit/a6e09518))
+- race conditions in async query lifecycle (IDFGH-17246) ([ab5aeaf8](https://github.com/espressif/esp-protocols/commit/ab5aeaf8), [#1010](https://github.com/espressif/esp-protocols/issues/1010))
+
 ## [1.11.0](https://github.com/espressif/esp-protocols/commits/mdns-v1.11.0)
 
 ### Features

--- a/components/mdns/idf_component.yml
+++ b/components/mdns/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.11.0"
+version: "1.11.1"
 description: "Multicast UDP service used to provide local network service and host discovery."
 url: "https://github.com/espressif/esp-protocols/tree/master/components/mdns"
 issues: "https://github.com/espressif/esp-protocols/issues"

--- a/components/mdns/mdns_networking_socket.c
+++ b/components/mdns/mdns_networking_socket.c
@@ -366,7 +366,7 @@ void sock_recv_task(void *arg)
                 packet->pb = packet_pbuf;
                 packet->src_port = ntohs(port);
                 memcpy(&packet->src, &addr, sizeof(esp_ip_addr_t));
-                // TODO(IDF-3651): Add the correct dest addr -- for mdns to decide multicast/unicast
+                // TODO: Add the correct dest addr -- for mdns to decide multicast/unicast
                 // Currently it's enough to assume the packet is multicast and mdns to check the source port of the packet
                 memset(&packet->dest, 0, sizeof(esp_ip_addr_t));
                 packet->multicast = 1;


### PR DESCRIPTION
## [1.11.1](https://github.com/espressif/esp-protocols/commits/mdns-v1.11.1)

### Bug Fixes

- Remove IDF tracker from sources/comments ([4870186b](https://github.com/espressif/esp-protocols/commit/4870186b))
- Bounds check RR header and NSEC length in debug parser ([c10eb9ac](https://github.com/espressif/esp-protocols/commit/c10eb9ac))
- Validate RDATA length for A/AAAA records ([df9644aa](https://github.com/espressif/esp-protocols/commit/df9644aa))
- Validate second byte of DNS compression pointer ([6dd051a1](https://github.com/espressif/esp-protocols/commit/6dd051a1))
- Minor cleanup in mdns socket layer ([37b8a7ca](https://github.com/espressif/esp-protocols/commit/37b8a7ca))
- Fix parsing of mdns.txt records containing booleans ([a6e09518](https://github.com/espressif/esp-protocols/commit/a6e09518))
- race conditions in async query lifecycle (IDFGH-17246) ([ab5aeaf8](https://github.com/espressif/esp-protocols/commit/ab5aeaf8), [#1010](https://github.com/espressif/esp-protocols/issues/1010))

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly a version/changelog bump; only a comment text tweak in the socket networking code, so functional risk is low.
> 
> **Overview**
> Bumps the `mdns` component version to `1.11.1` (updates `.cz.yaml` and `idf_component.yml`) and adds the `1.11.1` release notes to `CHANGELOG.md`.
> 
> Includes a small cleanup in `mdns_networking_socket.c` by removing the IDF issue reference from a TODO comment (no behavior change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a69466ad301628fa99389c29d46871109cdab15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->