### PR TITLE
bump(websocket): 1.6.1 -> 1.6.2

### DIFF
--- a/components/esp_websocket_client/.cz.yaml
+++ b/components/esp_websocket_client/.cz.yaml
@@ -3,6 +3,6 @@ commitizen:
   bump_message: 'bump(websocket): $current_version -> $new_version'
   pre_bump_hooks: python ../../ci/changelog.py esp_websocket_client
   tag_format: websocket-v$version
-  version: 1.6.1
+  version: 1.6.2
   version_files:
   - idf_component.yml

--- a/components/esp_websocket_client/CHANGELOG.md
+++ b/components/esp_websocket_client/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [1.6.2](https://github.com/espressif/esp-protocols/commits/websocket-v1.6.2)
+
+### Features
+
+- affinity configuration ([aa55d069](https://github.com/espressif/esp-protocols/commit/aa55d069))
+- websocket autobahn test suit integration ([0f102151](https://github.com/espressif/esp-protocols/commit/0f102151))
+
+### Bug Fixes
+
+- use local test server instead of public echo.websocket.org ([37413999](https://github.com/espressif/esp-protocols/commit/37413999))
+- prevent NULL pointer crash in error handling ([cdf064dc](https://github.com/espressif/esp-protocols/commit/cdf064dc))
+- improve resource cleanup robustness and update destroy API documentation ([3d37eaa7](https://github.com/espressif/esp-protocols/commit/3d37eaa7))
+- fix use-after-free race condition in task stop sequence ([22c77c76](https://github.com/espressif/esp-protocols/commit/22c77c76))
+
 ## [1.6.1](https://github.com/espressif/esp-protocols/commits/websocket-v1.6.1)
 
 ### Bug Fixes

--- a/components/esp_websocket_client/idf_component.yml
+++ b/components/esp_websocket_client/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.6.1"
+version: "1.6.2"
 description: WebSocket protocol client for ESP-IDF
 url: https://github.com/espressif/esp-protocols/tree/master/components/esp_websocket_client
 dependencies:


### PR DESCRIPTION
1.6.2
Features
- affinity configuration (aa55d069)
- websocket autobahn test suit integration (0f102151) 

Bug Fixes
- use local test server instead of public echo.websocket.org (37413999)
- prevent NULL pointer crash in error handling (cdf064dc)
- improve resource cleanup robustness and update destroy API documentation (3d37eaa7)
- fix use-after-free race condition in task stop sequence (22c77c76)

<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->