### PR TITLE
feat(websocket): expose close status code in event data

### DIFF
--- a/components/esp_websocket_client/esp_websocket_client.c
+++ b/components/esp_websocket_client/esp_websocket_client.c
@@ -156,6 +156,7 @@ struct esp_websocket_client {
     ws_transport_opcodes_t      last_opcode;
     int                         payload_len;
     int                         payload_offset;
+    int                         close_status_code;  /*!< Status code from the last received CLOSE frame (0 = none / client-initiated) */
     esp_transport_keep_alive_t  keep_alive_cfg;
     struct ifreq                *if_name;
 };
@@ -220,6 +221,7 @@ static esp_err_t esp_websocket_client_dispatch_event(esp_websocket_client_handle
     event_data.op_code = client->last_opcode;
     event_data.payload_len = client->payload_len;
     event_data.payload_offset = client->payload_offset;
+    event_data.close_status_code = client->close_status_code;
 
     if (client->error_handle.error_type == WEBSOCKET_ERROR_TYPE_TCP_TRANSPORT) {
         event_data.error_handle.esp_tls_last_esp_err = esp_tls_get_and_clear_last_error(esp_transport_get_error_handle(client->transport),
@@ -1138,7 +1140,14 @@ static esp_err_t esp_websocket_client_recv(esp_websocket_client_handle_t client)
     } else if (client->last_opcode == WS_TRANSPORT_OPCODES_PONG) {
         client->wait_for_pong_resp = false;
     } else if (client->last_opcode == WS_TRANSPORT_OPCODES_CLOSE) {
-        ESP_LOGD(TAG, "Received close frame");
+        /* RFC 6455 §5.5.1: first two bytes of the CLOSE body are the status code in network byte order */
+        client->close_status_code = 0;
+        if (client->payload_len >= 2) {
+            uint16_t code_net;
+            memcpy(&code_net, client->rx_buffer, sizeof(code_net));
+            client->close_status_code = (int)ntohs(code_net);
+        }
+        ESP_LOGD(TAG, "Received close frame, status code: %d", client->close_status_code);
         client->state = WEBSOCKET_STATE_CLOSING;
     }
     esp_websocket_free_buf(client, false);
@@ -1236,6 +1245,7 @@ static void esp_websocket_client_task(void *pv)
             client->payload_offset = 0;
             client->last_fin = false;
             client->last_opcode = WS_TRANSPORT_OPCODES_NONE;
+            client->close_status_code = 0;
 
             esp_websocket_client_dispatch_event(client, WEBSOCKET_EVENT_CONNECTED, NULL, 0);
 

--- a/components/esp_websocket_client/include/esp_websocket_client.h
+++ b/components/esp_websocket_client/include/esp_websocket_client.h
@@ -91,6 +91,7 @@ typedef struct {
     int payload_len;                        /*!< Total payload length, payloads exceeding buffer will be posted through multiple events */
     int payload_offset;                     /*!< Actual offset for the data associated with this event */
     esp_websocket_error_codes_t error_handle; /*!< esp-websocket error handle including esp-tls errors as well as internal websocket errors */
+    int close_status_code;                  /*!< RFC 6455 close status code received from the server (0 if none or client-initiated) */
 } esp_websocket_event_data_t;
 
 /**


### PR DESCRIPTION
Fix of https://github.com/espressif/esp-protocols/issues/892


Add _close_status_code_ field to esp_websocket_event_data_t so
applications can distinguish server-initiated close reasons
(e.g. 1001 Going Away) from client-initiated closes (code == 0).

The status code is parsed from the first two bytes of the received
CLOSE frame payload per RFC 6455 §5.5.1 and propagated through all
subsequent events (WEBSOCKET_EVENT_DATA, WEBSOCKET_EVENT_CLOSED).
The field is reset to 0 on each new connection to prevent stale
values from leaking across reconnects.
## Checklist

Before submitting a Pull Request, please ensure the following:

- [ *] 🚨 This PR does not introduce breaking changes.
- [ *] All CI checks (GH Actions) pass.
- [ *] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ *] Code is well-commented, especially in complex areas.
- [ *] Git history is clean — commits are squashed to the minimum necessary.
