### PR TITLE
[modem]: Additional hardening (uart/netif)

### DIFF
--- a/components/esp_modem/src/esp_modem_netif.cpp
+++ b/components/esp_modem/src/esp_modem_netif.cpp
@@ -120,6 +120,7 @@ void Netif::pause()
 
 Netif::~Netif()
 {
+    ppp_dte->set_read_cb(nullptr);
     if (signal.is_any(PPP_STARTED)) {
         esp_netif_action_stop(driver.base.netif, nullptr, 0, nullptr);
         signal.clear(PPP_STARTED);

--- a/components/esp_modem/src/esp_modem_uart.cpp
+++ b/components/esp_modem/src/esp_modem_uart.cpp
@@ -177,6 +177,10 @@ int UartTerminal::read(uint8_t *data, size_t len)
     length = std::min(len, length);
     if (length > 0) {
         int read_len = uart_read_bytes(uart.port, data, length, portMAX_DELAY);
+        if (read_len < 0) {
+            ESP_LOGE(TAG, "Error occurred during read: %d", read_len);
+            return 0;
+        }
 #if CONFIG_ESP_MODEM_ADD_DEBUG_LOGS
         ESP_LOG_BUFFER_HEXDUMP("uart-rx", data, read_len, ESP_LOG_DEBUG);
 #endif


### PR DESCRIPTION
Related to https://github.com/espressif/esp-protocols/pull/1014

    9176fa6e fix(modem): Prevent UART read -1/int leak to size_t
    5be5f6a2 fix(modem): Fix netif destructor UAF