### PR TITLE
fix(mdns): queue browse send and trigger per-family browse on GOT_IP events

### DIFF
--- a/components/mdns/mdns_browser.c
+++ b/components/mdns/mdns_browser.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2015-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -77,7 +77,7 @@ static void browse_sync(mdns_browse_sync_t *browse_sync)
 /**
  * @brief  Send PTR query packet to all available interfaces for browsing.
  */
-static void browse_send(mdns_browse_t *browse, mdns_if_t interface)
+static void browse_send(mdns_browse_t *browse, mdns_if_t interface, mdns_ip_protocol_t ip_protocol)
 {
     // Using search once for sending the PTR query
     mdns_search_once_t search = {0};
@@ -89,18 +89,22 @@ static void browse_send(mdns_browse_t *browse, mdns_if_t interface)
     search.unicast = false;
     search.result = NULL;
     search.next = NULL;
+    mdns_priv_query_send(&search, interface, ip_protocol);
+}
 
-    for (uint8_t protocol_idx = 0; protocol_idx < MDNS_IP_PROTOCOL_MAX; protocol_idx++) {
-        mdns_priv_query_send(&search, interface, (mdns_ip_protocol_t) protocol_idx);
+void mdns_priv_browse_send_by_ip_protocol(mdns_if_t mdns_if, mdns_ip_protocol_t ip_protocol)
+{
+    mdns_browse_t *browse = s_browse;
+    while (browse) {
+        browse_send(browse, mdns_if, ip_protocol);
+        browse = browse->next;
     }
 }
 
 void mdns_priv_browse_send_all(mdns_if_t mdns_if)
 {
-    mdns_browse_t *browse = s_browse;
-    while (browse) {
-        browse_send(browse, mdns_if);
-        browse = browse->next;
+    for (uint8_t protocol_idx = 0; protocol_idx < MDNS_IP_PROTOCOL_MAX; protocol_idx++) {
+        mdns_priv_browse_send_by_ip_protocol(mdns_if, (mdns_ip_protocol_t) protocol_idx);
     }
 }
 
@@ -192,7 +196,9 @@ static void browse_add(mdns_browse_t *browse)
         s_browse = browse;
     }
     for (uint8_t interface_idx = 0; interface_idx < MDNS_MAX_INTERFACES; interface_idx++) {
-        browse_send(browse, (mdns_if_t) interface_idx);
+        for (uint8_t protocol_idx = 0; protocol_idx < MDNS_IP_PROTOCOL_MAX; protocol_idx++) {
+            browse_send(browse, (mdns_if_t) interface_idx, (mdns_ip_protocol_t) protocol_idx);
+        }
     }
     if (found) {
         browse_item_free(browse);

--- a/components/mdns/mdns_netif.c
+++ b/components/mdns/mdns_netif.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -177,6 +177,29 @@ static esp_err_t post_custom_action(mdns_if_t mdns_if, mdns_event_actions_t even
     return ESP_OK;
 }
 
+#if CONFIG_MDNS_PREDEF_NETIF_STA || CONFIG_MDNS_PREDEF_NETIF_AP || CONFIG_MDNS_PREDEF_NETIF_ETH
+static esp_err_t post_browse_send_by_ip_protocol_action(mdns_if_t mdns_if, mdns_ip_protocol_t ip_protocol)
+{
+    if (!mdns_priv_is_server_init() || mdns_if >= MDNS_MAX_INTERFACES) {
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    mdns_action_t *action = (mdns_action_t *)mdns_mem_calloc(1, sizeof(mdns_action_t));
+    if (!action) {
+        HOOK_MALLOC_FAILED;
+        return ESP_ERR_NO_MEM;
+    }
+    action->type = ACTION_BROWSE_SEND_BY_IP_PROTOCOL;
+    action->data.browse_send.interface = mdns_if;
+    action->data.browse_send.ip_protocol = ip_protocol;
+
+    if (!mdns_priv_queue_action(action)) {
+        mdns_mem_free(action);
+    }
+    return ESP_OK;
+}
+#endif
+
 /**
  * @brief  Dispatch interface changes based on system events
  */
@@ -258,10 +281,12 @@ static void handle_system_event_for_preset(void *arg, esp_event_base_t event_bas
                 case IP_EVENT_STA_GOT_IP:
                     post_enable_pcb(MDNS_IF_STA, MDNS_IP_PROTOCOL_V4);
                     post_announce_pcb(MDNS_IF_STA, MDNS_IP_PROTOCOL_V6);
+                    post_browse_send_by_ip_protocol_action(mdns_if_from_preset(MDNS_IF_STA), MDNS_IP_PROTOCOL_V4);
                     break;
 #if CONFIG_ETH_ENABLED && CONFIG_MDNS_PREDEF_NETIF_ETH
                 case IP_EVENT_ETH_GOT_IP:
                     post_enable_pcb(MDNS_IF_ETH, MDNS_IP_PROTOCOL_V4);
+                    post_browse_send_by_ip_protocol_action(mdns_if_from_preset(MDNS_IF_ETH), MDNS_IP_PROTOCOL_V4);
                     break;
 #endif
                 case IP_EVENT_GOT_IP6: {
@@ -272,7 +297,7 @@ static void handle_system_event_for_preset(void *arg, esp_event_base_t event_bas
                     }
                     post_enable_pcb(mdns_if, MDNS_IP_PROTOCOL_V6);
                     post_announce_pcb(mdns_if, MDNS_IP_PROTOCOL_V4);
-                    mdns_priv_browse_send_all(mdns_if);
+                    post_browse_send_by_ip_protocol_action(mdns_if, MDNS_IP_PROTOCOL_V6);
 
                 }
                 break;

--- a/components/mdns/mdns_service.c
+++ b/components/mdns/mdns_service.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -187,6 +187,9 @@ static void execute_action(mdns_action_t *action)
     case ACTION_DELEGATE_HOSTNAME_SET_ADDR:
     case ACTION_DELEGATE_HOSTNAME_REMOVE:
         mdns_priv_responder_action(action, ACTION_RUN);
+        break;
+    case ACTION_BROWSE_SEND_BY_IP_PROTOCOL:
+        mdns_priv_browse_send_by_ip_protocol(action->data.browse_send.interface, action->data.browse_send.ip_protocol);
         break;
     default:
         break;

--- a/components/mdns/private_include/mdns_browser.h
+++ b/components/mdns/private_include/mdns_browser.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -35,6 +35,14 @@ mdns_browse_t *mdns_priv_browse_find(mdns_name_t *name, uint16_t type, mdns_if_t
  * @note Calls (indirectly) search-send from mdns_querier.c, which sends out the query
  */
 void mdns_priv_browse_send_all(mdns_if_t mdns_if);
+
+/**
+ * @brief Send out browse queries by IP protocol
+ *
+ * @note Called from the network events (mdns_netif.c)
+ * @note Calls (indirectly) search-send from mdns_querier.c, which sends out the query
+ */
+void mdns_priv_browse_send_by_ip_protocol(mdns_if_t mdns_if, mdns_ip_protocol_t ip_protocol);
 
 /**
  * @brief Sync browse results

--- a/components/mdns/private_include/mdns_private.h
+++ b/components/mdns/private_include/mdns_private.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2015-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -165,6 +165,7 @@ typedef enum {
     ACTION_DELEGATE_HOSTNAME_ADD,
     ACTION_DELEGATE_HOSTNAME_REMOVE,
     ACTION_DELEGATE_HOSTNAME_SET_ADDR,
+    ACTION_BROWSE_SEND_BY_IP_PROTOCOL,
     ACTION_MAX
 } mdns_action_type_t;
 
@@ -402,5 +403,9 @@ typedef struct {
         struct {
             mdns_browse_sync_t *browse_sync;
         } browse_sync;
+        struct {
+            mdns_if_t interface;
+            mdns_ip_protocol_t ip_protocol;
+        } browse_send;
     } data;
 } mdns_action_t;


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description
### Problem

Two issues were observed in browse trigger timing:

1. Browse send could run before the queued PCB enable action completed.
2. Browse resend was coupled to `IP_EVENT_GOT_IP6`, so IPv4 updates did not trigger an immediate IPv4 browse resend.

### Fix

- Add a queued internal action: `ACTION_BROWSE_SEND_BY_IP_PROTOCOL`.
- Post this action from IP events instead of calling browse send directly in the event handler.
- Trigger browse resend by matching address family:
  - `IP_EVENT_STA_GOT_IP` / `IP_EVENT_ETH_GOT_IP` -> send browse on IPv4
  - `IP_EVENT_GOT_IP6` -> send browse on IPv6

### Result

Browse send now executes in-order with other mDNS service actions, avoiding the enable/send race.
It also resends queries on the corresponding protocol as soon as that protocol's IP event arrives.

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] ~Documentation is updated as needed.~
- [ ] ~Tests are updated or added as necessary.~
- [ ] ~Code is well-commented, especially in complex areas.~
- [ ] Git history is clean — commits are squashed to the minimum necessary.
