### PR TITLE
feat(lws): add Kconfig toggles + bump submodule

### DIFF
--- a/components/libwebsockets/CMakeLists.txt
+++ b/components/libwebsockets/CMakeLists.txt
@@ -4,6 +4,27 @@ set(LWS_WITH_EXPORT_LWSTARGETS OFF CACHE BOOL "Export libwebsockets CMake target
 set(LWS_WITH_MBEDTLS ON CACHE BOOL "Use mbedTLS (>=2.0) replacement for OpenSSL.")
 set(LWS_WITH_JPEG OFF CACHE BOOL "Enable stateful JPEG stream decoder")
 
+# Kconfig-driven libwebsockets options. Defaults preserve the previous
+# behaviour (extensions off, file_ops on, threadpool off) so existing
+# consumers see no change. See Kconfig for help text and per-knob rationale.
+if(CONFIG_LWS_WITH_EXTENSIONS)
+    set(LWS_WITHOUT_EXTENSIONS OFF CACHE INTERNAL "Compile with extensions")
+else()
+    set(LWS_WITHOUT_EXTENSIONS ON  CACHE INTERNAL "Don't compile with extensions")
+endif()
+
+if(CONFIG_LWS_WITH_FILE_OPS)
+    set(LWS_WITH_FILE_OPS ON  CACHE INTERNAL "Support file operations vfs")
+else()
+    set(LWS_WITH_FILE_OPS OFF CACHE INTERNAL "Drop file operations vfs")
+endif()
+
+if(CONFIG_LWS_WITH_THREADPOOL)
+    set(LWS_WITH_THREADPOOL ON  CACHE INTERNAL "Managed worker thread pool support")
+else()
+    set(LWS_WITH_THREADPOOL OFF CACHE INTERNAL "No worker thread pool")
+endif()
+
 
 set(WRAP_FUNCTIONS mbedtls_ssl_handshake_step
                    lws_adopt_descriptor_vhost)
@@ -18,3 +39,6 @@ target_sources(${COMPONENT_LIB} INTERFACE "port/lws_port.c")
 
 
 add_subdirectory(libwebsockets)
+
+# pollfd.c at this lws pin has an unused 'vpt' on FreeRTOS; drop after the next bump.
+target_compile_options(websockets PRIVATE -Wno-unused-variable)

--- a/components/libwebsockets/Kconfig
+++ b/components/libwebsockets/Kconfig
@@ -1,0 +1,35 @@
+menu "libwebsockets"
+
+    # All defaults below preserve the previously-baked behaviour
+    # (extensions off, file_ops on, threadpool off). Flip them to suit
+    # the workload — e.g. WebRTC signaling consumers enable extensions
+    # for permessage-deflate and threadpool for parallel TLS work.
+
+    config LWS_WITH_EXTENSIONS
+        bool "Build libwebsockets with extensions (permessage-deflate, mux)"
+        default n
+        help
+            Enables LWS extensions support. Required for clients/servers
+            that negotiate permessage-deflate or other RFC 7692 extensions
+            over the WebSocket handshake. Requires LWS_WITH_ZLIB at link
+            time, which the ESP-IDF mbedTLS build does not pull in by
+            default — you'll need to add zlib as a dependency.
+
+    config LWS_WITH_FILE_OPS
+        bool "Build libwebsockets with the file-operations VFS"
+        default y
+        help
+            Compiles the libwebsockets virtual filesystem layer used by
+            server-side static file serving. Disable on embedded targets
+            that don't expose a real filesystem to lws to save flash.
+
+    config LWS_WITH_THREADPOOL
+        bool "Build libwebsockets with the worker threadpool API"
+        default n
+        help
+            Enables lws's managed worker thread pool (pthread-backed).
+            Used by clients that want to off-load parallel TLS handshake
+            or other work from the lws service thread (e.g. AWS KVS
+            WebRTC signaling). Costs a few hundred bytes of static data.
+
+endmenu


### PR DESCRIPTION
## Summary

Two changes to `components/libwebsockets`:

1. **Three Kconfig toggles** so consumers can tune libwebsockets without forking the component — `LWS_WITH_EXTENSIONS`, `LWS_WITH_FILE_OPS`, `LWS_WITH_THREADPOOL`.
2. **Submodule bump** from `a74362ff` → `d659d4f2` (93 commits forward on the warmcat 4.3.x mainline).

## Motivation

The AWS KVS WebRTC SDK port we maintain in espressif-port carries a local `components/libwebsockets/` whose only delta vs the one here is a CMakeLists that force-sets three knobs (extensions on, file_ops off, threadpool on) for the WebRTC-signaling workload. With this PR those workloads can flip Kconfig instead of forking — and we can drop the local copy in espressif-port entirely and consume `espressif/libwebsockets` from the registry.

The submodule bump is independent: we already pin a newer SHA on the same warmcat 4.3.x mainline (no patches, no fork), and it picks up upstream fixes including the Linux-host build path that was landed via an earlier Espressif contribution.

## Backwards compatibility

All three Kconfig defaults preserve the previously-baked behaviour:

| Knob | Default | What changes when flipped |
|---|---|---|
| `LWS_WITH_EXTENSIONS` | **n** | extensions on — needed for permessage-deflate (RFC 7692). Caller also needs zlib at link time. |
| `LWS_WITH_FILE_OPS` | **y** | drop the libwebsockets server-side VFS layer; saves flash on clients that never serve static files. |
| `LWS_WITH_THREADPOOL` | **n** | enable lws's managed worker thread pool (pthread-backed); used by callers that off-load parallel TLS handshake work. |

Existing consumers — `examples/client/`, downstream registry users on `espressif/libwebsockets@4.3.3~1` — see zero behaviour change.

### Note on existing `port/lws_port.c` wraps

This PR doesn't touch the existing `__wrap_mbedtls_ssl_handshake_step` / `__wrap_lws_adopt_descriptor_vhost` linker hooks. Consumers that migrate from a fork inherit them as-is. The handshake-step wrap converts mbedTLS's async `WANT_READ/WANT_WRITE` returns into a synchronous busy-loop, which is fine when lws's mbedTLS BIO is blocking (the inner call blocks instead of returning WANT_*) — that's the case for ESP-IDF's TLS port. Flagging here so reviewers / future-migrators know.

## Verification

### Configure / build (component + Kconfig)

- **Default Kconfig** on esp32 target: configure + build clean.
- **KVS-flavour Kconfig** (`LWS_WITH_EXTENSIONS=y / LWS_WITH_FILE_OPS=n / LWS_WITH_THREADPOOL=y`) on esp32s3: configure clean, Kconfig→upstream-LWS_* translation confirmed in `CMakeCache.txt`:
  ```
  LWS_WITHOUT_EXTENSIONS:INTERNAL=OFF
  LWS_WITH_FILE_OPS:INTERNAL=OFF
  LWS_WITH_THREADPOOL:INTERNAL=ON
  ```
- The pre-existing `examples/client` partition-overflow on the esp32 target (`client_example.bin` > 1 MB factory partition) is **not** caused by this PR — same overflow reproduces on master with the old submodule pin. Out of scope; happy to file a follow-up.

### End-to-end consumer swap (real workload)

Re-pointed the AWS KVS WebRTC SDK espressif-port (`components/kvs_signaling/idf_component.yml` + `components/kvs_webrtc/idf_component.yml`) at this PR's branch via `path:` override, dropped the local `components/libwebsockets/` from the picture, and rebuilt `examples/streaming_only` on esp32p4 with the three Kconfig flags as described above:

```
NOTICE: [40/47] libwebsockets (4.3.3~2) (.../esp-protocols/components/libwebsockets)
streaming_only.bin binary size 0x265860 bytes. Smallest app partition is 0x2e0000 bytes. 0x7a7a0 bytes (17%) free.
Project build complete.
```

Zero errors, zero undefined references, zero link warnings. The downstream component-manager namespace match works, the new Kconfig is picked up, and the bundled binary fits the partition with comparable headroom to today.

## Changelog

`4.3.3~1` → `4.3.3~2` (`.cz.yaml` + `idf_component.yml` + `CHANGELOG.md` bumped).

## Next steps for consumers

Once this lands and a `4.3.3~2` is published, the AWS KVS WebRTC SDK port can drop its local libwebsockets fork and depend on `espressif/libwebsockets ^4.3.3~2` from the registry with:

```yaml
dependencies:
  espressif/libwebsockets: "^4.3.3~2"
```

plus `CONFIG_LWS_WITH_EXTENSIONS=y` + `CONFIG_LWS_WITH_THREADPOOL=y` + `# CONFIG_LWS_WITH_FILE_OPS is not set` in their sdkconfig.defaults.

cc @euripedesrocha @david-cermak