### PR TITLE
fix(websocket): correct IDF version guard for HTTP redirect support

### DIFF
--- a/components/esp_websocket_client/esp_websocket_client.c
+++ b/components/esp_websocket_client/esp_websocket_client.c
@@ -67,8 +67,8 @@ static const char *TAG = "websocket_client";
 #define WS_HTTP_BASIC_AUTH  "Basic "
 #define WS_HTTP_REDIRECT(code) ((code >= 300) && (code < 400))
 
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 0)
-// Features supported in 5.5.0
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 1)
+// esp_transport_ws_get_redir_uri was added after the v5.5.0 tag; first appears in v5.5.1
 #define WS_TRANSPORT_REDIRECT_HEADER_SUPPORT    1
 #endif
 


### PR DESCRIPTION
Related https://github.com/espressif/esp-protocols/issues/1059 and https://github.com/espressif/esp-protocols/issues/947

Problem
`esp_websocket_client v1.6.x` introduced HTTP redirect support gated behind:
https://github.com/espressif/esp-protocols/commit/ce1560ac

```
#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 0)
#define WS_TRANSPORT_REDIRECT_HEADER_SUPPORT    1
#endif
```
However, _esp_transport_ws_get_redir_uri_ — the only function used inside this block — was introduced via commit [_97e6f4ab_](https://github.com/espressif/esp-idf/commit/97e6f4ab0fd2d4c7bef3998fbb08e0d6de987028) which missed the v5.5.0 tag. It first appears in v5.5.1 of ESP-IDF.

Any user building against the v5.5.0 git tag gets a hard compile error:

`error: implicit declaration of function 'esp_transport_ws_get_redir_uri'`

Root Cause
The v5.5.0 tag was cut on Jul 18, 2025. Commit 97e6f4ab was cherry-picked to release/v5.5 after that date and first landed in v5.5.1. Verified directly from git:


What this does
The macro WS_TRANSPORT_REDIRECT_HEADER_SUPPORT gates an entire block of code that calls esp_transport_ws_get_redir_uri. By raising the threshold from 5.5.0 to 5.5.1:

**On IDF v5.5.0**  the condition evaluates false, the macro is never defined, the redirect block is entirely skipped by the preprocessor, and the missing function is never referenced → no compile error

On **IDF v5.5.1+**  the condition evaluates true, the macro is defined, the redirect block compiles as before → full redirect feature works
