### PR TITLE
bump(lws): 4.3.3~1 -> 4.3.3~2

### DIFF
--- a/components/libwebsockets/.cz.yaml
+++ b/components/libwebsockets/.cz.yaml
@@ -3,6 +3,6 @@ commitizen:
   bump_message: 'bump(lws): $current_version -> $new_version'
   pre_bump_hooks: python ../../ci/changelog.py libwebsockets
   tag_format: lws-v$version
-  version: 4.3.3~1
+  version: 4.3.3~2
   version_files:
   - idf_component.yml

--- a/components/libwebsockets/CHANGELOG.md
+++ b/components/libwebsockets/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [4.3.3~2](https://github.com/espressif/esp-protocols/commits/lws-v4.3.3_2)
+
+### Features
+
+- add Kconfig toggles + bump submodule ([23448d54](https://github.com/espressif/esp-protocols/commit/23448d54))
+
 ## [4.3.3~1](https://github.com/espressif/esp-protocols/commits/lws-v4.3.3_1)
 
 ### Bug Fixes

--- a/components/libwebsockets/idf_component.yml
+++ b/components/libwebsockets/idf_component.yml
@@ -1,4 +1,4 @@
-version: "4.3.3~1"
+version: "4.3.3~2"
 url: https://github.com/espressif/esp-protocols/tree/master/components/libwebsockets
 description: The component provides a simple ESP-IDF port of libwebsockets client.
 dependencies:


### PR DESCRIPTION
## [4.3.3~2](https://github.com/espressif/esp-protocols/commits/lws-v4.3.3_2)

### Features

- add Kconfig toggles + bump submodule ([23448d54](https://github.com/espressif/esp-protocols/commit/23448d54))
