### PR TITLE
Fix wrong "truncated AAAA" error

### DIFF
--- a/components/mdns/mdns_debug.c
+++ b/components/mdns/mdns_debug.c
@@ -293,12 +293,12 @@ void static dbg_packet(const uint8_t *data, size_t len)
                 }
                 dbg_printf("\n");
             } else if (type == MDNS_TYPE_AAAA) {
-                if (data_len < sizeof(esp_ip6_addr_t)) {
+                if (data_len < MDNS_ANSWER_AAAA_SIZE) {
                     dbg_printf("ERROR: truncated AAAA\n");
                     continue;
                 }
-                esp_ip6_addr_t ip6;
-                memcpy(&ip6, data_ptr, sizeof(esp_ip6_addr_t));
+                esp_ip6_addr_t ip6 = {0};
+                memcpy(&ip6.addr, data_ptr, MDNS_ANSWER_AAAA_SIZE);
                 dbg_printf(IPV6STR "\n", IPV62STR(ip6));
             } else if (type == MDNS_TYPE_A) {
                 if (data_len < sizeof(esp_ip4_addr_t)) {


### PR DESCRIPTION
## Description

AAAA messages are always `MDNS_ANSWER_AAAA_SIZE` ([16 bytes](https://datatracker.ietf.org/doc/html/rfc3596#section-2.2)) long.
The [`esp_ip6_addr_t`](https://github.com/espressif/esp-idf/blob/bc6616854ea6303c538b97de66b7aaf290f8f1b0/components/esp_netif/include/esp_netif_ip_addr.h#L102) contains an additional `zone`-value, which makes the struct bigger than 16 bytes. This causes the condition to always fail, when it shouldn't.

## Testing

I experience the error, when I enable `MDNS_ENABLE_DEBUG_PRINTS` in my [basic_thread_border_router](https://github.com/espressif/esp-thread-br/tree/main/examples/basic_thread_border_router) project. With my fix the error disappears and displays the AAAA responses.