### PR TITLE
feat(modem): Add Delay after netif stop prior sending disconnect to CMUX

### DIFF
--- a/components/esp_modem/Kconfig
+++ b/components/esp_modem/Kconfig
@@ -36,6 +36,12 @@ menu "esp-modem"
             The typical reason for failing SABM request without a delay is that
             some devices (SIM800) send MSC requests just after opening a new DLCI.
 
+    config ESP_MODEM_CMUX_DELAY_AFTER_NETIF_DISCONNECT
+        int "Delay in ms to wait before closing virtual terminal abd rigt after PPP disconnect(NETIF)"
+        default 0
+        help
+            Some devices might need a pause before sending disconnect command that closes
+            virtual terminal. This delay applies only in CMUX mode.
     config ESP_MODEM_CMUX_USE_SHORT_PAYLOADS_ONLY
         bool "CMUX to support only short payloads (<128 bytes)"
         default n

--- a/components/esp_modem/src/esp_modem_dce.cpp
+++ b/components/esp_modem/src/esp_modem_dce.cpp
@@ -160,6 +160,7 @@ bool DCE_Mode::set_unsafe(DTE *dte, ModuleIf *device, Netif &netif, modem_mode m
         if (mode == modem_mode::CMUX_MODE) {
             netif.stop();
             netif.wait_until_ppp_exits();
+            usleep(CONFIG_ESP_MODEM_CMUX_DELAY_AFTER_NETIF_DISCONNECT * 1'000);
             if (!dte->set_mode(modem_mode::COMMAND_MODE)) {
                 return false;
             }


### PR DESCRIPTION
Add delay after netif stop prior sending disconnect to CMUX virtual terminal, some devices require this delay

<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description
Add delay after netif stop prior sending disconnect to CMUX virtual terminal, some devices require this delay using Kconfig
<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
