### PR TITLE
Reset last URC processed on consume all

### DIFF
--- a/components/esp_modem/src/esp_modem_dte.cpp
+++ b/components/esp_modem/src/esp_modem_dte.cpp
@@ -413,7 +413,7 @@ bool DTE::command_cb::process_line(uint8_t *data, size_t consumed, size_t len, D
 
         case UrcConsumeResult::CONSUME_ALL:
             // Consume entire buffer
-            dte->buffer_state.last_urc_processed = consumed + len;
+            dte->buffer_state.last_urc_processed = 0;
             return true;  // Signal buffer consumption
         }
     }


### PR DESCRIPTION
Fixes #706 - https://github.com/espressif/esp-protocols/issues/706

CONSUME_ALL discards the current buffer, so the URC processed offset must be reset before processing the next buffer. Otherwise, new_data_size can underflow when the next buffer is smaller.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line fix in enhanced URC buffer accounting with no API or behavior change beyond fixing incorrect offset after full buffer consumption.
> 
> **Overview**
> When the enhanced URC handler returns **`CONSUME_ALL`**, the DTE now sets **`buffer_state.last_urc_processed`** to **0** instead of the end of the current slice.
> 
> **`CONSUME_ALL`** drops the whole receive buffer; keeping a non-zero offset made **`new_data_size`** in **`create_urc_info`** wrong on the next chunk (including underflow when the next buffer was smaller). The reset matches what already happens after a command finishes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 311611fe428af9c5e6fddb6bca440e234c302155. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->