### PR TITLE
fix(modem): spinlock_acquire assert (use-after-free) when tearing down / switching modes while RX data is in flight

### DIFF
--- a/components/esp_modem/Kconfig
+++ b/components/esp_modem/Kconfig
@@ -36,6 +36,12 @@ menu "esp-modem"
             The typical reason for failing SABM request without a delay is that
             some devices (SIM800) send MSC requests just after opening a new DLCI.
 
+    config ESP_MODEM_CMUX_DELAY_AFTER_NETIF_DISCONNECT
+        int "Delay in ms to wait before closing virtual terminal abd rigt after PPP disconnect(NETIF)"
+        default 0
+        help
+            Some devices might need a pause before sending disconnect command that closes
+            virtual terminal. This delay applies only in CMUX mode.
     config ESP_MODEM_CMUX_USE_SHORT_PAYLOADS_ONLY
         bool "CMUX to support only short payloads (<128 bytes)"
         default n

--- a/components/esp_modem/include/cxx_include/esp_modem_cmux.hpp
+++ b/components/esp_modem/include/cxx_include/esp_modem_cmux.hpp
@@ -49,7 +49,7 @@ class CMux {
 public:
     explicit CMux(std::shared_ptr<Terminal> t, unique_buffer &&b):
         term(std::move(t)), payload_start(nullptr), total_payload_size(0), buffer(std::move(b))  {}
-    ~CMux() = default;
+    ~CMux();
 
     /**
      * @brief Initializes CMux protocol
@@ -95,6 +95,14 @@ public:
      * @return true on success
      */
     bool recover();
+
+    /**
+     * @brief Stops the underlying (physical) terminal's RX task.
+     *
+     * Used on teardown to quiesce the data pump that drives the virtual terminals before the
+     * CMux/DTE state it touches is destroyed.
+     */
+    void stop();
 
 private:
 
@@ -150,6 +158,13 @@ private:
     unique_buffer buffer;
 
     Lock lock;
+    /**
+     * @brief Serializes (re)assignment of read_cb[] (set_read_cb()) against their invocation from
+     * the underlying terminal's RX task. Deliberately separate from `lock`: the read callback
+     * upcall may take a long time (or block in the network stack) and must not block write(),
+     * which uses `lock`. Recursive, so the upcall may re-enter write().
+     */
+    Lock cb_lock;
 };
 
 /**
@@ -173,7 +188,12 @@ public:
         return  0;
     }
     void start() override { }
-    void stop() override { }
+    // A virtual terminal has no task of its own; the physical terminal pumps all of them. Forward
+    // stop() so that tearing down a DTE in CMUX mode quiesces that physical terminal's RX task.
+    void stop() override
+    {
+        cmux->stop();
+    }
 private:
     std::shared_ptr<CMux> cmux;
     size_t instance;

--- a/components/esp_modem/include/cxx_include/esp_modem_dte.hpp
+++ b/components/esp_modem/include/cxx_include/esp_modem_dte.hpp
@@ -53,7 +53,7 @@ public:
     explicit DTE(const esp_modem_dte_config *config, std::unique_ptr<Terminal> t, std::unique_ptr<Terminal> s);
     explicit DTE(std::unique_ptr<Terminal> t, std::unique_ptr<Terminal> s);
 
-    ~DTE() = default;
+    ~DTE();
 
     /**
      * @brief Writing to the underlying terminal

--- a/components/esp_modem/include/cxx_include/esp_modem_terminal.hpp
+++ b/components/esp_modem/include/cxx_include/esp_modem_terminal.hpp
@@ -45,11 +45,13 @@ public:
 
     void set_error_cb(std::function<void(terminal_error)> f)
     {
+        Scoped<Lock> l(cb_lock);
         on_error = std::move(f);
     }
 
     virtual void set_read_cb(std::function<bool(uint8_t *data, size_t len)> f)
     {
+        Scoped<Lock> l(cb_lock);
         on_read = std::move(f);
     }
 
@@ -74,6 +76,14 @@ public:
     virtual void stop() = 0;
 
 protected:
+    /**
+     * @brief Serializes (re)assignment of on_read/on_error (set_read_cb/set_error_cb) against their
+     * invocation by the terminal's RX task. Recursive, so a callback may re-enter set_read_cb()
+     * (e.g. DTE clears its own read callback from within the callback). Holding this lock while
+     * clearing a callback guarantees no callback is in flight afterwards, which is what makes it
+     * safe to tear down the state the callback captures.
+     */
+    Lock cb_lock{};
     std::function<bool(uint8_t *data, size_t len)> on_read;
     std::function<void(terminal_error)> on_error;
 };

--- a/components/esp_modem/src/esp_modem_cmux.cpp
+++ b/components/esp_modem/src/esp_modem_cmux.cpp
@@ -124,6 +124,10 @@ bool CMux::data_available(uint8_t *data, size_t len)
     if (data && (type & FT_UIH) == FT_UIH && len > 0 && dlci > 0) { // valid payload on a virtual term
         int virtual_term = dlci - 1;
         if (virtual_term < MAX_TERMINALS_NUM) {
+            // Hold cb_lock (not the state lock) across the read_cb check and invocation, so the
+            // callback cannot be reassigned/cleared (set_read_cb()/teardown) while we're using it,
+            // without blocking write() during the (potentially long) upcall.
+            Scoped<Lock> l(cb_lock);
             if (read_cb[virtual_term] == nullptr) {
                 // ignore all virtual terminal's data before we completely establish CMUX
                 ESP_LOG_BUFFER_HEXDUMP("CMUX Rx before init", data, len, ESP_LOG_DEBUG);
@@ -148,6 +152,7 @@ bool CMux::data_available(uint8_t *data, size_t len)
     } else if (data == nullptr && dlci > 0) {
         int virtual_term = dlci - 1;
         if (virtual_term < MAX_TERMINALS_NUM) {
+            Scoped<Lock> l(cb_lock);
             if (read_cb[virtual_term] == nullptr) {
                 // silently ignore this CMUX frame (not finished entering CMUX, yet)
                 return true;
@@ -430,6 +435,18 @@ bool CMux::deinit()
     return true;
 }
 
+CMux::~CMux()
+{
+    // The underlying terminal's RX task drives on_cmux_data(), which touches CMux state (lock,
+    // buffer, read_cb[]). Detach it before that state is destroyed, otherwise a late RX event
+    // would use this CMux after free. set_read_cb()/set_error_cb() are synchronized against the
+    // RX task, so once they return no callback is in flight.
+    if (term) {
+        term->set_read_cb(nullptr);
+        term->set_error_cb(nullptr);
+    }
+}
+
 bool CMux::init()
 {
     frame_header_offset = 0;
@@ -494,6 +511,7 @@ int CMux::write(int virtual_term, uint8_t *data, size_t len)
 
 void CMux::set_read_cb(int inst, std::function<bool(uint8_t *, size_t)> f)
 {
+    Scoped<Lock> l(cb_lock);
     if (inst < MAX_TERMINALS_NUM) {
         read_cb[inst] = std::move(f);
     }
@@ -518,4 +536,11 @@ bool CMux::recover()
     Scoped<Lock> l(lock);
     recover_protocol(protocol_mismatch_reason::UNKNOWN);
     return true;
+}
+
+void CMux::stop()
+{
+    if (term) {
+        term->stop();
+    }
 }

--- a/components/esp_modem/src/esp_modem_dce.cpp
+++ b/components/esp_modem/src/esp_modem_dce.cpp
@@ -160,6 +160,7 @@ bool DCE_Mode::set_unsafe(DTE *dte, ModuleIf *device, Netif &netif, modem_mode m
         if (mode == modem_mode::CMUX_MODE) {
             netif.stop();
             netif.wait_until_ppp_exits();
+            usleep(CONFIG_ESP_MODEM_CMUX_DELAY_AFTER_NETIF_DISCONNECT * 1'000);
             if (!dte->set_mode(modem_mode::COMMAND_MODE)) {
                 return false;
             }

--- a/components/esp_modem/src/esp_modem_dte.cpp
+++ b/components/esp_modem/src/esp_modem_dte.cpp
@@ -61,6 +61,28 @@ DTE::DTE(std::unique_ptr<Terminal> t, std::unique_ptr<Terminal> s)
 }
 
 
+DTE::~DTE()
+{
+    // The terminals' RX tasks invoke read/error callbacks that capture this DTE (and reference
+    // command_cb.line_lock). Members are destroyed after this body runs, and command_cb is
+    // destroyed first of all (declared last), so we must guarantee no callback can fire into a
+    // half-destroyed DTE.
+    //
+    // stop() quiesces the RX task (for CMUX, CMuxInstance::stop() forwards to the physical
+    // terminal); clearing the callbacks afterwards is synchronized against the RX task, so once
+    // these return no callback is in flight and none will start.
+    if (primary_term) {
+        primary_term->stop();
+        primary_term->set_read_cb(nullptr);
+        primary_term->set_error_cb(nullptr);
+    }
+    if (secondary_term && secondary_term != primary_term) {
+        secondary_term->stop();
+        secondary_term->set_read_cb(nullptr);
+        secondary_term->set_error_cb(nullptr);
+    }
+}
+
 void DTE::set_command_callbacks()
 {
     primary_term->set_read_cb([this](uint8_t *data, size_t len) {

--- a/components/esp_modem/src/esp_modem_term_fs.cpp
+++ b/components/esp_modem/src/esp_modem_term_fs.cpp
@@ -45,7 +45,16 @@ public:
 
     void stop() override
     {
-        signal.clear(TASK_START);
+        if (signal.is_any(TASK_STOPPED)) {
+            return;     // already stopped (stop() is also called from the destructor)
+        }
+        signal.clear(TASK_START);   // make the processing loop exit
+        signal.set(TASK_STOP);      // release the task if it never started
+        // Block until the task confirms it has left the processing loop, so no read callback is
+        // in flight when the task is deleted .
+        if (!signal.wait_any(TASK_STOPPED, stop_timeout_ms)) {
+            ESP_LOGW(TAG, "Timed out waiting for fs task to stop");
+        }
     }
 
     int write(uint8_t *data, size_t len) override;
@@ -54,17 +63,28 @@ public:
 
     void set_read_cb(std::function<bool(uint8_t *data, size_t len)> f) override
     {
+        Scoped<Lock> l(cb_lock);
         on_read = std::move(f);
-        signal.set(TASK_PARAMS);
     }
 
 private:
     void task();
 
+    // Invoke on_read under cb_lock so it cannot be reassigned/cleared (set_mode()/teardown on
+    // another task) while we're executing it; re-check under the lock.
+    void notify_read()
+    {
+        Scoped<Lock> l(cb_lock);
+        if (on_read) {
+            on_read(nullptr, 0);
+        }
+    }
+
     static const size_t TASK_INIT = SignalGroup::bit0;
     static const size_t TASK_START = SignalGroup::bit1;
     static const size_t TASK_STOP = SignalGroup::bit2;
-    static const size_t TASK_PARAMS = SignalGroup::bit3;
+    static const size_t TASK_STOPPED = SignalGroup::bit3;   /*!< Set by the task once it has left the processing loop */
+    static const uint32_t stop_timeout_ms = 2000;           /*!< Max wait for a graceful stop (must exceed the select() timeout) */
 
     File f;
     SignalGroup signal;
@@ -86,13 +106,22 @@ FdTerminal::FdTerminal(const esp_modem_dte_config *config) :
 {
     auto t = static_cast<FdTerminal *>(p);
     t->task();
-    Task::Delete();
+    // task() returns only after stop() requested it. Acknowledge that the processing loop has
+    // been left -- this is the last access to any member.
+    t->signal.set(TASK_STOPPED);
+#if !defined(CONFIG_IDF_TARGET_LINUX)
+    // FreeRTOS: a task function must not return. Idle until the owner (Task destructor) deletes
+    // us; we deliberately do not self-delete, to avoid racing that delete.
+    while (true) {
+        Task::Delay(3600 * 1000);
+    }
+#endif
+    // Linux: returning ends the std::thread, which the Task destructor join()s.
 })
 {}
 
 void FdTerminal::task()
 {
-    std::function<bool(uint8_t *data, size_t len)> on_read_priv = nullptr;
     signal.set(TASK_INIT);
     signal.wait_any(TASK_START | TASK_STOP, portMAX_DELAY);
     if (signal.is_any(TASK_STOP)) {
@@ -110,10 +139,6 @@ void FdTerminal::task()
         FD_SET(f.fd, &rfds);
 
         s = select(f.fd + 1, &rfds, nullptr, nullptr, &tv);
-        if (signal.is_any(TASK_PARAMS)) {
-            on_read_priv = on_read;
-            signal.clear(TASK_PARAMS);
-        }
 
         if (s < 0) {
             break;
@@ -121,9 +146,7 @@ void FdTerminal::task()
 //            ESP_LOGV(TAG, "Select exited with timeout");
         } else {
             if (FD_ISSET(f.fd, &rfds)) {
-                if (on_read_priv) {
-                    on_read_priv(nullptr, 0);
-                }
+                notify_read();
             }
         }
         Task::Relinquish();

--- a/components/esp_modem/src/esp_modem_uart.cpp
+++ b/components/esp_modem/src/esp_modem_uart.cpp
@@ -46,7 +46,12 @@ public:
         event_queue(), uart(&config->uart_config, &event_queue, -1), signal(),
         task_handle(config->task_stack_size, config->task_priority, this, s_task) {}
 
-    ~UartTerminal() override = default;
+    ~UartTerminal() override
+    {
+        // Stop the RX task gracefully (and synchronously) before our members are torn down,
+        // so it is never force-deleted while inside a callback or blocked in the UART driver.
+        UartTerminal::stop();
+    }
 
     void start() override
     {
@@ -55,7 +60,16 @@ public:
 
     void stop() override
     {
-        signal.set(TASK_STOP);
+        if (signal.is_any(TASK_STOPPED)) {
+            return;     // already stopped (stop() is also called from the destructor)
+        }
+        signal.clear(TASK_START);   // make the processing loop exit
+        signal.set(TASK_STOP);      // release the task if it never started
+        // Block until the task confirms it has left the processing loop: no read/error callback
+        // is in flight, and it is not blocked in the UART driver, so it is safe to delete.
+        if (!signal.wait_any(TASK_STOPPED, stop_timeout_ms)) {
+            ESP_LOGW(TAG, "Timed out waiting for uart_task to stop");
+        }
     }
 
     int write(uint8_t *data, size_t len) override;
@@ -64,6 +78,7 @@ public:
 
     void set_read_cb(std::function<bool(uint8_t *data, size_t len)> f) override
     {
+        Scoped<Lock> l(cb_lock);
         on_read = std::move(f);
     }
 
@@ -72,14 +87,37 @@ private:
     {
         auto t = static_cast<UartTerminal *>(task_param);
         t->task();
-        t->task_handle.task_handle = nullptr;
-        vTaskDelete(nullptr);
+        // task() returns only after stop() requested it. Acknowledge that the processing loop has
+        // been left -- this is the last access to any member -- then idle until the owner deletes
+        // us from ~uart_task(). We deliberately do not self-delete, to avoid racing that delete.
+        t->signal.set(TASK_STOPPED);
+        while (true) {
+            vTaskDelay(portMAX_DELAY);
+        }
     }
 
     void task();
     bool get_event(uart_event_t &event, uint32_t time_ms)
     {
         return xQueueReceive(event_queue, &event, pdMS_TO_TICKS(time_ms));
+    }
+
+    // Invoke the read/error callbacks under cb_lock so they cannot be reassigned or cleared
+    // (by set_mode()/teardown on another task) while we're executing them. Re-check under the
+    // lock, since the callback may have been cleared between the outer check and acquiring it.
+    void notify_read(size_t len)
+    {
+        Scoped<Lock> l(cb_lock);
+        if (on_read) {
+            on_read(nullptr, len);
+        }
+    }
+    void notify_error(terminal_error err)
+    {
+        Scoped<Lock> l(cb_lock);
+        if (on_error) {
+            on_error(err);
+        }
     }
 
     void reset_events()
@@ -91,6 +129,8 @@ private:
     static const size_t TASK_INIT = BIT0;
     static const size_t TASK_START = BIT1;
     static const size_t TASK_STOP = BIT2;
+    static const size_t TASK_STOPPED = BIT3;        /*!< Set by the task once it has left the processing loop */
+    static const uint32_t stop_timeout_ms = 1000;   /*!< Max wait for a graceful stop before forcing deletion */
 
     QueueHandle_t event_queue;
     uart_resource uart;
@@ -121,41 +161,31 @@ void UartTerminal::task()
             switch (event.type) {
             case UART_DATA:
                 uart_get_buffered_data_len(uart.port, &len);
-                if (len && on_read) {
-                    on_read(nullptr, len);
+                if (len) {
+                    notify_read(len);
                 }
                 break;
             case UART_FIFO_OVF:
                 ESP_LOGW(TAG, "HW FIFO Overflow");
-                if (on_error) {
-                    on_error(terminal_error::BUFFER_OVERFLOW);
-                }
+                notify_error(terminal_error::BUFFER_OVERFLOW);
                 reset_events();
                 break;
             case UART_BUFFER_FULL:
                 ESP_LOGW(TAG, "Ring Buffer Full");
-                if (on_error) {
-                    on_error(terminal_error::BUFFER_OVERFLOW);
-                }
+                notify_error(terminal_error::BUFFER_OVERFLOW);
                 reset_events();
                 break;
             case UART_BREAK:
                 ESP_LOGW(TAG, "Rx Break");
-                if (on_error) {
-                    on_error(terminal_error::UNEXPECTED_CONTROL_FLOW);
-                }
+                notify_error(terminal_error::UNEXPECTED_CONTROL_FLOW);
                 break;
             case UART_PARITY_ERR:
                 ESP_LOGE(TAG, "Parity Error");
-                if (on_error) {
-                    on_error(terminal_error::CHECKSUM_ERROR);
-                }
+                notify_error(terminal_error::CHECKSUM_ERROR);
                 break;
             case UART_FRAME_ERR:
                 ESP_LOGE(TAG, "Frame Error");
-                if (on_error) {
-                    on_error(terminal_error::UNEXPECTED_CONTROL_FLOW);
-                }
+                notify_error(terminal_error::UNEXPECTED_CONTROL_FLOW);
                 break;
             default:
                 ESP_LOGW(TAG, "unknown uart event type: %d", event.type);
@@ -163,8 +193,8 @@ void UartTerminal::task()
             }
         } else {
             uart_get_buffered_data_len(uart.port, &len);
-            if (len && on_read) {
-                on_read(nullptr, len);
+            if (len) {
+                notify_read(len);
             }
         }
     }


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description
Destroying the DTE/DCE (or calling set_mode() / exit_data() / exit_cmux())
while the modem link is still receiving data can crash with a FreeRTOS spinlock
corruption assert. The crash is a use-after-free of a terminal callback (or the
mutex it takes) by the terminal RX task.

Backtrace
assert failed: spinlock_acquire spinlock.h:123 ((result == SPINLOCK_FREE) == (lock->count == 0))
0x400818ef: panic_abort at panic.c:407
0x4008b815: esp_system_abort at system_api.c:112
0x40092645: __assert_func at assert.c:85
0x4008ea8d: spinlock_acquire at spinlock.h:123
(inlined by) vPortEnterCritical at port.c:448
0x4008c6d9: xQueueSemaphoreTake at queue.c:1466
0x4008c848: xQueueTakeMutexRecursive at queue.c:687
0x400f756a: esp_modem::Lock::lock() at esp_modem_primitives_freertos.cpp:33
0x400fa9a1: esp_modem::Scoped<esp_modem::Lock>::Scoped() at esp_modem_primitives.hpp:53
(inlined by) operator() at esp_modem_dte.cpp:67 // the read callback taking command_cb.line_lock
0x400f7c41: esp_modem::UartTerminal::task() at esp_modem_uart.cpp:167
0x400f7c51: esp_modem::UartTerminal::s_task(void*) at esp_modem_uart.cpp:74
0x4008e8e6: vPortTaskWrapper at port.c:168

Root cause
Terminal callbacks are mutated without any synchronization against the RX task
that invokes them:

Terminal::set_read_cb()/set_error_cb() and CMux::set_read_cb() reassign a
std::function (or read_cb[]) with no lock.
set_mode()/set_command_callbacks() swap and rebind these during DATA/CMUX
transitions; ~DTE lets command_cb (which owns line_lock) be destroyed
while the RX task is still running.
internal_lock (held during set_mode) does not protect this, because the
RX task (UartTerminal::task()) never takes internal_lock.
So the RX task can be executing a callback whose std::function target is being
destroyed, or whose captured this/command_cb.line_lock has already been freed
— it then locks a freed/garbage mutex and the spinlock consistency assert fires.

Separately, stop() is effectively a no-op for loop exit (it sets TASK_STOP
but the loop checks TASK_START), so the RX task is always force-deleted via
vTaskDelete() — potentially mid-callback or inside the UART driver — and
FdTerminal additionally has a self-delete vs owner-delete double-delete window.

Reproduction
Bring up PPP/CMUX so the modem is actively pushing RX data.
Tear down the DCE/DTE (or call exit_data() / set_mode(COMMAND_MODE))
while data is still arriving.
Intermittent crash with the assert above (timing/SMP dependent).
Note: the below will have the modem crash in no time
In file : esp_modem_uart.cpp/get_event --> change the timeout to 1
*Initialize via
cell_netif= esp_netif_new(&config)
dce = esp_modem_new(...)
esp_event_handler_instance_register(...)
Call long AT command (AT+COPS? for example) with immediate return (timeout 1 ms) then
*Destroy
esp_event_handler_instance_unregister(....)
sct_esp_modem_destroy(dce);
esp_netif_destroy(cell_netif);
cell_netif= NULL;
dce = NULL;
<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ x] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches modem RX threading, callback lifetime, and FreeRTOS task teardown on all UART/VFS/CMUX paths; incorrect ordering could still race or hang stop, but the change directly addresses security-relevant use-after-free crashes during destroy and mode transitions.
> 
> **Overview**
> Fixes intermittent **FreeRTOS `spinlock_acquire` asserts** when destroying the modem stack or switching modes while UART/CMUX traffic is still arriving. The RX task could run read/error callbacks after their `std::function` targets or captured DTE state (e.g. `command_cb.line_lock`) were torn down.
> 
> **Synchronization:** `Terminal` and CMUX gain a dedicated **`cb_lock`** so `set_read_cb` / `set_error_cb` (and CMUX `read_cb[]`) are serialized against RX-task invocation; UART/VFS invoke callbacks via `notify_read` / `notify_error` under that lock. CMUX keeps **`cb_lock` separate from `lock`** so long PPP upcalls do not block CMUX writes.
> 
> **Graceful RX shutdown:** UART and VFS **`stop()`** now clears `TASK_START`, signals stop, and **blocks until `TASK_STOPPED`** instead of relying on a broken stop path and **`vTaskDelete` mid-callback**. Tasks idle after exiting the loop (no self-delete race). **`~DTE`** and **`~CMux`** call **`stop()`** then clear callbacks; **`CMuxInstance::stop()`** forwards to the physical terminal. **`~UartTerminal`** stops synchronously in the destructor.
> 
> **CMUX teardown:** New Kconfig **`ESP_MODEM_CMUX_DELAY_AFTER_NETIF_DISCONNECT`** adds an optional pause after PPP disconnect before exiting CMUX to command mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 323bc7977e0ea8af77eab52570a6be8cf9d1fb9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->