### PR TITLE
fix(mdns): free dropped TXT query results when max results reached

### DIFF
--- a/components/mdns/mdns_querier.c
+++ b/components/mdns/mdns_querier.c
@@ -573,8 +573,8 @@ void mdns_priv_query_result_add_txt(mdns_search_once_t *search, mdns_txt_item_t 
         r->next = search->result;
         search->result = r;
         search->num_results++;
+        return;
     }
-    return;
 
 free_txt:
     for (size_t i = 0; i < txt_count; i++) {


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description
Fix a memory leak in `mdns_priv_query_result_add_txt()` when `search->num_results >= search->max_results`.

### Root Cause
When a TXT response was parsed, memory for `txt`, `txt_value_len`, and TXT key/value strings was already allocated.
If the query result list was full (`num_results == max_results`), the function returned without attaching the new result and without freeing the allocated TXT buffers.

### Fix
Return immediately only after successful insertion into result list. For full-list cases, fall through to `free_txt` and release all allocated TXT buffers.

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] ~Documentation is updated as needed.~
- [ ] ~Tests are updated or added as necessary.~
- [ ] ~Code is well-commented, especially in complex areas.~
- [x] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single control-flow change in mDNS querier cleanup path; no API or behavior change beyond fixing a leak when result limits are hit.
> 
> **Overview**
> Fixes a memory leak in **`mdns_priv_query_result_add_txt()`** when an mDNS search already has **`num_results >= max_results`**.
> 
> Parsed TXT buffers (`txt`, `txt_value_len`, and key/value strings) were allocated before the function decided whether to attach them. A **`return`** after the “room for another result” branch ran on the full-list path too, so those buffers were never released.
> 
> The change **returns only after a successful attach** (existing result updated or new `mdns_result_t` linked). When the cap blocks a new entry, execution **falls through to `free_txt`** and frees the orphaned TXT memory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f81720b78c6bbfa12553db58be232bb8c37d57a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->