### PR TITLE
feat(websocket): interruptable wait timeout

### DIFF
--- a/components/esp_websocket_client/esp_websocket_client.c
+++ b/components/esp_websocket_client/esp_websocket_client.c
@@ -76,6 +76,7 @@ const static int STOPPED_BIT = BIT0;
 const static int CLOSE_FRAME_SENT_BIT = BIT1;   // Indicates that a close frame was sent by the client
 // and we are waiting for the server to continue with clean close
 const static int REQUESTED_STOP_BIT = BIT2;     // Indicates that a client stop has been requested
+const static int WAKEUP_BIT = BIT3;             // Wakes the reconnect wait early (e.g. on timeout change)
 
 ESP_EVENT_DEFINE_BASE(WEBSOCKET_EVENTS);
 
@@ -1315,8 +1316,9 @@ static void esp_websocket_client_task(void *pv)
             }
             break;
         case WEBSOCKET_STATE_WAIT_TIMEOUT:
-
-            if (_tick_get_ms() - client->reconnect_tick_ms > client->wait_timeout_ms) {
+            int wait_timeout_ms = client->wait_timeout_ms;
+            if (wait_timeout_ms <= 0 ||
+                    _tick_get_ms() - client->reconnect_tick_ms >= (uint64_t)wait_timeout_ms) {
                 client->state = WEBSOCKET_STATE_INIT;
                 client->reconnect_tick_ms = _tick_get_ms();
                 ESP_LOGD(TAG, "Reconnecting...");
@@ -1385,8 +1387,26 @@ static void esp_websocket_client_task(void *pv)
                 ESP_LOGV(TAG, "Read poll timeout: skipping esp_transport_poll_read().");
             }
         } else if (WEBSOCKET_STATE_WAIT_TIMEOUT == client->state) {
-            // waiting for reconnection or a request to stop the client...
-            xEventGroupWaitBits(client->status_bits, REQUESTED_STOP_BIT, false, true, client->wait_timeout_ms / 2 / portTICK_PERIOD_MS);
+            xEventGroupClearBits(client->status_bits, WAKEUP_BIT);
+
+            int wait_timeout_ms = client->wait_timeout_ms;
+            if (client->run && wait_timeout_ms > 0) {
+                uint64_t elapsed_ms = _tick_get_ms() - client->reconnect_tick_ms;
+                uint64_t timeout_ms = (uint64_t)wait_timeout_ms;
+
+                if (elapsed_ms < timeout_ms) {
+                    uint32_t remaining_ms = (uint32_t)(timeout_ms - elapsed_ms);
+                    TickType_t wait_ticks = pdMS_TO_TICKS(remaining_ms);
+                    /* Avoid a non-blocking wait when the remaining delay is shorter than one tick. */
+                    if (wait_ticks == 0) {
+                        wait_ticks = 1;
+                    }
+                    xEventGroupWaitBits(client->status_bits,
+                                        REQUESTED_STOP_BIT | WAKEUP_BIT,
+                                        false, false,
+                                        wait_ticks);
+                }
+            }
         } else if (WEBSOCKET_STATE_CLOSING == client->state &&
                    (CLOSE_FRAME_SENT_BIT & xEventGroupGetBits(client->status_bits))) {
             ESP_LOGD(TAG, " Waiting for TCP connection to be closed by the server");
@@ -1449,7 +1469,7 @@ esp_err_t esp_websocket_client_start(esp_websocket_client_handle_t client)
         ESP_LOGE(TAG, "Error create websocket task");
         return ESP_FAIL;
     }
-    xEventGroupClearBits(client->status_bits, STOPPED_BIT | CLOSE_FRAME_SENT_BIT | REQUESTED_STOP_BIT);
+    xEventGroupClearBits(client->status_bits, STOPPED_BIT | CLOSE_FRAME_SENT_BIT | REQUESTED_STOP_BIT | WAKEUP_BIT);
     ESP_LOGI(TAG, "Started");
     return ESP_OK;
 }
@@ -1655,6 +1675,9 @@ esp_err_t esp_websocket_client_set_reconnect_timeout(esp_websocket_client_handle
     }
 
     client->wait_timeout_ms = reconnect_timeout_ms;
+    if (client->status_bits) {
+        xEventGroupSetBits(client->status_bits, WAKEUP_BIT);
+    }
 
     return ESP_OK;
 }

--- a/components/esp_websocket_client/include/esp_websocket_client.h
+++ b/components/esp_websocket_client/include/esp_websocket_client.h
@@ -452,7 +452,7 @@ size_t esp_websocket_client_get_ping_interval_sec(esp_websocket_client_handle_t 
 esp_err_t esp_websocket_client_set_ping_interval_sec(esp_websocket_client_handle_t client, size_t ping_interval_sec);
 
 /**
- * @brief      Get the next reconnect timeout for client. Returns -1 when client is not initialized or automatic reconnect is disabled.
+ * @brief      Get the reconnect timeout for client. Returns -1 when client is not initialized or automatic reconnect is disabled.
  *
  * @param[in]  client             The client
  *
@@ -461,11 +461,11 @@ esp_err_t esp_websocket_client_set_ping_interval_sec(esp_websocket_client_handle
 int esp_websocket_client_get_reconnect_timeout(esp_websocket_client_handle_t client);
 
 /**
- * @brief      Set next reconnect timeout for client.
+ * @brief      Set new reconnect timeout for client.
  *
  *  Notes:
- *  - Changing this value when reconnection delay is already active does not immediately affect the active delay and may have unexpected result.
  *  - Good place to change this value is when handling WEBSOCKET_EVENT_DISCONNECTED or WEBSOCKET_EVENT_ERROR events.
+ *  - This also updates already active reconnection delay, if any.
  *
  * @param[in]  client             The client
  * @param[in]  reconnect_timeout_ms  The new timeout


### PR DESCRIPTION
Based on https://github.com/espressif/esp-protocols/pull/607

Previously, calling `esp_websocket_client_set_reconnect_timeout()` while a reconnection delay was already in progress had no immediate effect this made dynamic backoff strategies unreliable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches FreeRTOS event-group timing and the reconnect state machine; behavior change for apps using dynamic backoff, but scope is limited to auto-reconnect wait logic.
> 
> **Overview**
> **Reconnect backoff can now take effect while a delay is already running.** `esp_websocket_client_set_reconnect_timeout()` sets `WAKEUP_BIT` on the client event group so the websocket task leaves its wait early and re-evaluates the remaining delay against the updated `wait_timeout_ms`.
> 
> In **`WEBSOCKET_STATE_WAIT_TIMEOUT`**, the task no longer blocks for half the timeout on a coarse timer. It computes **remaining** time from `reconnect_tick_ms`, waits on `REQUESTED_STOP_BIT | WAKEUP_BIT` for that interval (minimum one tick), and the state-machine branch uses `>=` with an explicit `wait_timeout_ms <= 0` guard so reconnect timing stays consistent.
> 
> **`WAKEUP_BIT`** is cleared on client start and at the beginning of each wait loop iteration. Public API notes in `esp_websocket_client.h` now state that changing the reconnect timeout **updates an active** reconnection delay.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 848c6a1931d5e6a7708eebc5b9a991c1359978f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->