### PR TITLE
fix(mdns): fix deadlock caused by re-acquiring the service lock

### DIFF
--- a/components/mdns/mdns_browser.c
+++ b/components/mdns/mdns_browser.c
@@ -76,7 +76,7 @@ static void browse_sync(mdns_browse_sync_t *browse_sync)
             queueDetach(mdns_result_t, browse->result, result);
             // Just free current result
             result->next = NULL;
-            mdns_query_results_free(result);
+            mdns_priv_query_results_free(result);
         }
         sync_result = sync_result->next;
     }

--- a/components/mdns/mdns_netif.c
+++ b/components/mdns/mdns_netif.c
@@ -453,6 +453,6 @@ esp_err_t mdns_unregister_netif(esp_netif_t *esp_netif)
             break;
         }
     }
-    mdns_priv_service_lock();
+    mdns_priv_service_unlock();
     return err;
 }


### PR DESCRIPTION
## Description
This PR fixes a self-deadlock caused by nested acquisition of the mDNS service lock.

`service_task()` holds the service lock while processing `ACTION_BROWSE_SYNC`. In this path, `browse_sync()` may call `mdns_query_results_free()`, which attempts to acquire the same lock again.

This PR switches the internal call site from `mdns_query_results_free()` to mdns_priv_query_results_free(), avoiding nested acquisition of the service lock.

We also fixed an existing lock bug in `mdns_unregister_netif()` where the function took the service lock twice and never released it on the exit path.




---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] ~Documentation is updated as needed`.~
- [ ] ~Tests are updated or added as necessary.~
- [ ] ~Code is well-commented, especially in complex areas.~
- [x] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core mDNS locking and browse teardown on the service task; incorrect lock pairing could still deadlock or corrupt shared state, but the changes are small and directly fix known lock bugs.
> 
> **Overview**
> **Browse sync** now frees expired browse results with `mdns_priv_query_results_free()` instead of the public `mdns_query_results_free()` when `result->ttl == 0`. The public helper takes the mDNS service lock; `browse_sync()` runs on the service task while that lock is already held, so the old call could self-deadlock on a non-recursive mutex.
> 
> **`mdns_unregister_netif()`** fixes a lock bug: the exit path called `mdns_priv_service_lock()` a second time instead of `mdns_priv_service_unlock()`, which could leave the service mutex held after unregister.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88c68330000f0e3ea23014a2259a8579625ba332. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->