### PR TITLE
feat(mdns): Add a structure and APIs for allocating TXT items with given value length

### DIFF
--- a/components/mdns/include/mdns.h
+++ b/components/mdns/include/mdns.h
@@ -69,6 +69,17 @@ typedef struct {
 } mdns_txt_item_t;
 
 /**
+ * @brief   mDNS basic text item structure, with length of values
+ *          Suitable for both string and non-string items
+ *          Used in mdns_service_add_with_len()
+ */
+typedef struct {
+    const char *key;                        /*!< item key name */
+    const uint8_t *value;                   /*!< item value */
+    uint8_t value_len;                /*!< item value length */
+} mdns_txt_item_with_len_t;
+
+/**
  * @brief   mDNS basic subtype item structure
  *          Used in mdns_service_subtype_xxx() APIs
  */
@@ -312,6 +323,56 @@ esp_err_t mdns_service_add_for_host(const char *instance_name, const char *servi
                                     const char *hostname, uint16_t port, mdns_txt_item_t txt[], size_t num_items);
 
 /**
+ * @brief  Add service to mDNS server
+ *
+ * @note The value length of txt items should be configured in sturctures
+ *
+ * @param  instance_name    instance name to set. If NULL,
+ *                          global instance name or hostname will be used.
+ *                          Note that MDNS_MULTIPLE_INSTANCE config option
+ *                          needs to be enabled for adding multiple instances
+ *                          with the same instance type.
+ * @param  service_type     service type (_http, _ftp, etc)
+ * @param  proto            service protocol (_tcp, _udp)
+ * @param  port             service port
+ * @param  txt              array of TXT data with value length (eg. {{"var", "val", 3},{"other", "2", 1}})
+ * @param  num_items        number of items in TXT data
+ *
+ * @return
+ *     - ESP_OK success
+ *     - ESP_ERR_INVALID_ARG Parameter error
+ *     - ESP_ERR_NO_MEM memory error
+ *     - ESP_FAIL failed to add service
+ */
+esp_err_t mdns_service_add_with_len(const char *instance_name, const char *service_type, const char *proto, uint16_t port, mdns_txt_item_with_len_t txt[], size_t num_items);
+
+/**
+ * @brief  Add service to mDNS server with a delegated hostname
+ *
+ * @note The value length of txt items should be configured in sturctures
+ *
+ * @param  instance_name    instance name to set. If NULL,
+ *                          global instance name or hostname will be used
+ *                          Note that MDNS_MULTIPLE_INSTANCE config option
+ *                          needs to be enabled for adding multiple instances
+ *                          with the same instance type.
+ * @param  service_type     service type (_http, _ftp, etc)
+ * @param  proto            service protocol (_tcp, _udp)
+ * @param  hostname         service hostname. If NULL, local hostname will be used.
+ * @param  port             service port
+ * @param  txt              array of TXT data with value length (eg. {{"var", "val", 3},{"other", "2", 1}})
+ * @param  num_items        number of items in TXT data
+ *
+ * @return
+ *     - ESP_OK success
+ *     - ESP_ERR_INVALID_ARG Parameter error
+ *     - ESP_ERR_NO_MEM memory error
+ *     - ESP_FAIL failed to add service
+ */
+esp_err_t mdns_service_add_for_host_with_len(const char *instance_name, const char *service_type, const char *proto,
+                                    const char *hostname, uint16_t port, mdns_txt_item_with_len_t txt[], size_t num_items);
+
+/**
  * @brief  Check whether a service has been added.
  *
  * @param  service_type     service type (_http, _ftp, etc)
@@ -474,6 +535,45 @@ esp_err_t mdns_service_txt_set(const char *service_type, const char *proto, mdns
  */
 esp_err_t mdns_service_txt_set_for_host(const char *instance, const char *service_type, const char *proto, const char *hostname,
                                         mdns_txt_item_t txt[], uint8_t num_items);
+
+/**
+ * @brief  Replace all TXT items for service
+ *
+ * @note The value length of txt items should be configured in sturctures
+ *
+ * @param  service_type service type (_http, _ftp, etc)
+ * @param  proto        service protocol (_tcp, _udp)
+ * @param  txt          array of TXT data with value length (eg. {{"var", "val", 3},{"other", "2", 1}})
+ * @param  num_items    number of items in TXT data
+ *
+ * @return
+ *     - ESP_OK success
+ *     - ESP_ERR_INVALID_ARG Parameter error
+ *     - ESP_ERR_NOT_FOUND Service not found
+ *     - ESP_ERR_NO_MEM memory error
+ */
+esp_err_t mdns_service_txt_set_with_len(const char *service_type, const char *proto, mdns_txt_item_with_len_t txt[], uint8_t num_items);
+
+/**
+ * @brief  Replace all TXT items for service with hostname
+ *
+ * @note The value length of txt items should be configured in sturctures
+ *
+ * @param  instance     instance name
+ * @param  service_type service type (_http, _ftp, etc)
+ * @param  proto        service protocol (_tcp, _udp)
+ * @param  hostname     service hostname. If NULL, local hostname will be used.
+ * @param  txt          array of TXT data with value length (eg. {{"var", "val", 3},{"other", "2", 1}})
+ * @param  num_items    number of items in TXT data
+ *
+ * @return
+ *     - ESP_OK success
+ *     - ESP_ERR_INVALID_ARG Parameter error
+ *     - ESP_ERR_NOT_FOUND Service not found
+ *     - ESP_ERR_NO_MEM memory error
+ */
+esp_err_t mdns_service_txt_set_for_host_with_len(const char *instance, const char *service_type, const char *proto, const char *hostname,
+                                        mdns_txt_item_with_len_t txt[], uint8_t num_items);
 
 /**
  * @brief  Set/Add TXT item for service TXT record

--- a/components/mdns/mdns_responder.c
+++ b/components/mdns/mdns_responder.c
@@ -302,6 +302,53 @@ static mdns_txt_linked_item_t *allocate_txt(size_t num_items, mdns_txt_item_t tx
 }
 
 /**
+ * @brief  creates/allocates new text item list with value length
+ * @param  num_items     service number of txt items or 0
+ * @param  txt           service txt items with value length array or NULL
+ *
+ * @return pointer to the linked txt item list or NULL
+ */
+static mdns_txt_linked_item_t *allocate_txt_with_len(size_t num_items, mdns_txt_item_with_len_t txt[])
+{
+    mdns_txt_linked_item_t *new_txt = NULL;
+    size_t i = 0;
+    if (num_items) {
+        for (i = 0; i < num_items; i++) {
+            mdns_txt_linked_item_t *new_item = (mdns_txt_linked_item_t *)mdns_mem_malloc(sizeof(mdns_txt_linked_item_t));
+            if (!new_item) {
+                HOOK_MALLOC_FAILED;
+                break;
+            }
+            new_item->key = mdns_mem_strdup(txt[i].key);
+            if (!new_item->key) {
+                mdns_mem_free(new_item);
+                break;
+            }
+
+            // Value is copied according to given value length
+            // 要+1吗，后面需要测试一下（包括mechcop里的alloc_txt_list）
+            if (txt[i].value) {
+                new_item->value = (char *)malloc(txt[i].value_len + 1);
+                if (!new_item->value) {
+                    mdns_mem_free((char *)new_item->key);
+                    mdns_mem_free(new_item);
+                    break;
+                }
+                memcpy(new_item->value, txt[i].value, txt[i].value_len);
+                new_item->value[txt[i].value_len] = '\0';
+                new_item->value_len = txt[i].value_len;
+            } else {
+                new_item->value = NULL;
+                new_item->value_len = 0;
+            }
+            new_item->next = new_txt;
+            new_txt = new_item;
+        }
+    }
+    return new_txt;
+}
+
+/**
  * @brief Deallocate the txt linked list
  * @param txt pointer to the txt pointer to free, noop if txt==NULL
  */
@@ -340,6 +387,71 @@ static mdns_service_t *create_service(const char *service, const char *proto, co
     }
 
     mdns_txt_linked_item_t *new_txt = allocate_txt(num_items, txt);
+    if (num_items && new_txt == NULL) {
+        goto fail;
+    }
+
+    s->priority = 0;
+    s->weight = 0;
+    s->instance = instance ? mdns_mem_strndup(instance, MDNS_NAME_BUF_LEN - 1) : NULL;
+    s->txt = new_txt;
+    s->port = port;
+    s->subtype = NULL;
+
+    if (hostname) {
+        s->hostname = mdns_mem_strndup(hostname, MDNS_NAME_BUF_LEN - 1);
+        if (!s->hostname) {
+            goto fail;
+        }
+    } else {
+        s->hostname = NULL;
+    }
+
+    s->service = mdns_mem_strndup(service, MDNS_NAME_BUF_LEN - 1);
+    if (!s->service) {
+        goto fail;
+    }
+
+    s->proto = mdns_mem_strndup(proto, MDNS_NAME_BUF_LEN - 1);
+    if (!s->proto) {
+        goto fail;
+    }
+    return s;
+
+fail:
+    free_linked_txt(s->txt);
+    mdns_mem_free((char *)s->instance);
+    mdns_mem_free((char *)s->service);
+    mdns_mem_free((char *)s->proto);
+    mdns_mem_free((char *)s->hostname);
+    mdns_mem_free(s);
+
+    return NULL;
+}
+
+/**
+ * @brief  creates/allocates new service using txt items with value length
+ * @param  service       service type
+ * @param  proto         service proto
+ * @param  hostname      service hostname
+ * @param  port          service port
+ * @param  instance      service instance
+ * @param  num_items     service number of txt items with calue length or 0
+ * @param  txt           array of service txt items with value length or NULL
+ *
+ * @return pointer to the service or NULL on error
+ */
+static mdns_service_t *create_service_with_len(const char *service, const char *proto, const char *hostname,
+                                      uint16_t port, const char *instance, size_t num_items,
+                                      mdns_txt_item_with_len_t txt[])
+{
+    mdns_service_t *s = (mdns_service_t *)mdns_mem_calloc(1, sizeof(mdns_service_t));
+    if (!s) {
+        HOOK_MALLOC_FAILED;
+        return NULL;
+    }
+
+    mdns_txt_linked_item_t *new_txt = allocate_txt_with_len(num_items, txt);
     if (num_items && new_txt == NULL) {
         goto fail;
     }
@@ -815,6 +927,57 @@ esp_err_t mdns_service_add(const char *instance, const char *service, const char
     return mdns_service_add_for_host(instance, service, proto, NULL, port, txt, num_items);
 }
 
+esp_err_t mdns_service_add_for_host_with_len(const char *instance, const char *service, const char *proto, const char *host,
+                                    uint16_t port, mdns_txt_item_with_len_t txt[], size_t num_items)
+{
+    if (!s_server || mdns_utils_str_null_or_empty(service) || mdns_utils_str_null_or_empty(proto) || !s_server->hostname) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    mdns_priv_service_lock();
+    esp_err_t ret = ESP_OK;
+    const char *hostname = host ? host : s_server->hostname;
+    mdns_service_t *s = NULL;
+
+    ESP_GOTO_ON_FALSE(can_add_more_services(), ESP_ERR_NO_MEM, err, TAG,
+                      "Cannot add more services, please increase CONFIG_MDNS_MAX_SERVICES (%d)", CONFIG_MDNS_MAX_SERVICES);
+
+    mdns_srv_item_t *item = mdns_utils_get_service_item_instance(instance, service, proto, hostname);
+    ESP_GOTO_ON_FALSE(!item, ESP_ERR_INVALID_ARG, err, TAG, "Service already exists");
+
+    s = create_service_with_len(service, proto, hostname, port, instance, num_items, txt);
+    ESP_GOTO_ON_FALSE(s, ESP_ERR_NO_MEM, err, TAG, "Cannot create service: Out of memory");
+
+    item = (mdns_srv_item_t *)mdns_mem_malloc(sizeof(mdns_srv_item_t));
+    ESP_GOTO_ON_FALSE(item, ESP_ERR_NO_MEM, err, TAG, "Cannot create service: Out of memory");
+
+    item->service = s;
+    item->next = NULL;
+
+    item->next = s_server->services;
+    s_server->services = item;
+    mdns_priv_probe_all_pcbs(&item, 1, false, false);
+    mdns_priv_service_unlock();
+    return ESP_OK;
+
+err:
+    mdns_priv_service_unlock();
+    free_service(s);
+    if (ret == ESP_ERR_NO_MEM) {
+        HOOK_MALLOC_FAILED;
+    }
+    return ret;
+}
+
+esp_err_t mdns_service_add_with_len(const char *instance, const char *service, const char *proto, uint16_t port,
+                           mdns_txt_item_with_len_t txt[], size_t num_items)
+{
+    if (!s_server) {
+        return ESP_ERR_INVALID_STATE;
+    }
+    return mdns_service_add_for_host_with_len(instance, service, proto, NULL, port, txt, num_items);
+}
+
 bool mdns_service_exists(const char *service_type, const char *proto, const char *hostname)
 {
     bool ret = false;
@@ -1041,6 +1204,44 @@ esp_err_t mdns_service_txt_set(const char *service, const char *proto, mdns_txt_
         return ESP_ERR_INVALID_STATE;
     }
     return mdns_service_txt_set_for_host(NULL, service, proto, NULL, txt, num_items);
+}
+
+esp_err_t mdns_service_txt_set_for_host_with_len(const char *instance, const char *service, const char *proto, const char *host,
+                                        mdns_txt_item_with_len_t txt_items[], uint8_t num_items)
+{
+    mdns_priv_service_lock();
+    esp_err_t ret = ESP_OK;
+    const char *hostname = host ? host : s_server->hostname;
+    ESP_GOTO_ON_FALSE(s_server && s_server->services && !mdns_utils_str_null_or_empty(service) && !mdns_utils_str_null_or_empty(proto) && !(num_items && txt_items == NULL),
+                      ESP_ERR_INVALID_ARG, err, TAG, "Invalid state or arguments");
+    mdns_srv_item_t *s = mdns_utils_get_service_item_instance(instance, service, proto, hostname);
+    ESP_GOTO_ON_FALSE(s, ESP_ERR_NOT_FOUND, err, TAG, "Service doesn't exist");
+
+    mdns_txt_linked_item_t *new_txt = NULL;
+    if (num_items) {
+        new_txt = allocate_txt_with_len(num_items, txt_items);
+        if (!new_txt) {
+            return ESP_ERR_NO_MEM;
+        }
+    }
+    mdns_service_t *srv = s->service;
+    mdns_txt_linked_item_t *txt = srv->txt;
+    srv->txt = NULL;
+    free_linked_txt(txt);
+    srv->txt = new_txt;
+    announce_all_pcbs(&s, 1, false);
+
+err:
+    mdns_priv_service_unlock();
+    return ret;
+}
+
+esp_err_t mdns_service_txt_set_with_len(const char *service, const char *proto, mdns_txt_item_with_len_t txt[], uint8_t num_items)
+{
+    if (!s_server) {
+        return ESP_ERR_INVALID_STATE;
+    }
+    return mdns_service_txt_set_for_host_with_len(NULL, service, proto, NULL, txt, num_items);
 }
 
 esp_err_t mdns_service_txt_item_set_for_host_with_explicit_value_len(const char *instance, const char *service, const char *proto,


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description
The original API `mdns_service_add()` and `mdns_service_txt_set()` set TXT data from a `mdns_txt_item_t` array, where data are cloned and re-allocated with `allocate_txt()`, which treats all values as strings and clones them using `mdns_mem_strdup()`. 

For data obtained from Openthread API, there's no way figuring out whether a value is string or non-string binary data. When binary data go through `mdns_service_add()` or `mdns_service_txt_set()`, it may be cut off if one byte happens to be zero, since treated as C-string. The only way to avoid this using current API is to call `mdns_service_txt_item_set_with_explicit_value_len()` multiple times.

This PR introduces a new structure `mdns_txt_item_with_len_t`, adding a new field `value_len` compared with `mdns_txt_item_t`, and new APIs end with `_with_len` utilizing the new structure. Thus TXT data can be allocated with given value length using new APIs, while not introducing breaking changes.


<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes advertised mDNS TXT encoding paths and uses `malloc` for value buffers in `allocate_txt_with_len` while keys still use mdns allocators; incorrect `value_len` could corrupt announcements but existing APIs are untouched.
> 
> **Overview**
> Adds **`mdns_txt_item_with_len_t`** and parallel **`_with_len`** service APIs so mDNS TXT values can be registered or replaced using an explicit byte length instead of **`strlen`**, which fixes truncation when values contain embedded nulls (e.g. OpenThread-sourced binary TXT).
> 
> **`mdns_service_add_with_len`**, **`mdns_service_add_for_host_with_len`**, **`mdns_service_txt_set_with_len`**, and **`mdns_service_txt_set_for_host_with_len`** mirror the existing string-based add/set paths; the responder copies TXT payloads with **`memcpy`** via new **`allocate_txt_with_len`** / **`create_service_with_len`** helpers. Existing **`mdns_txt_item_t`** APIs are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb15a5e7ac62964688a24f6d7fc859687de4115e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->