### PR TITLE
fix(mdns): Fix potential zero instance issue caught by mdns fuzzer

### DIFF
--- a/components/mdns/.cz.yaml
+++ b/components/mdns/.cz.yaml
@@ -3,6 +3,6 @@ commitizen:
   bump_message: 'bump(mdns): $current_version -> $new_version'
   pre_bump_hooks: python ../../ci/changelog.py mdns
   tag_format: mdns-v$version
-  version: 1.11.2
+  version: 1.11.3
   version_files:
   - idf_component.yml

--- a/components/mdns/CHANGELOG.md
+++ b/components/mdns/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [1.11.3](https://github.com/espressif/esp-protocols/commits/mdns-v1.11.3)
+
+### Features
+
+- Add a structure and APIs for allocating TXT items with given value length ([234f9f00](https://github.com/espressif/esp-protocols/commit/234f9f00))
+
+### Bug Fixes
+
+- Fix potential browse null instance crash caught by fuzzer ([953c3a78](https://github.com/espressif/esp-protocols/commit/953c3a78))
+- fix deadlock caused by re-acquiring the service lock ([88c68330](https://github.com/espressif/esp-protocols/commit/88c68330))
+- free dropped TXT query results when max results reached ([f81720b7](https://github.com/espressif/esp-protocols/commit/f81720b7))
+
 ## [1.11.2](https://github.com/espressif/esp-protocols/commits/mdns-v1.11.2)
 
 ### Bug Fixes

--- a/components/mdns/idf_component.yml
+++ b/components/mdns/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.11.2"
+version: "1.11.3"
 description: "Multicast UDP service used to provide local network service and host discovery."
 url: "https://github.com/espressif/esp-protocols/tree/master/components/mdns"
 issues: "https://github.com/espressif/esp-protocols/issues"

--- a/components/mdns/mdns_browser.c
+++ b/components/mdns/mdns_browser.c
@@ -319,7 +319,9 @@ void mdns_priv_browse_result_add_ptr(mdns_browse_t *browse, const char *instance
                                      mdns_if_t tcpip_if, mdns_ip_protocol_t ip_protocol, uint32_t ttl,
                                      mdns_browse_sync_t *out_sync_browse)
 {
-    if (!browse || !out_sync_browse || out_sync_browse->browse != browse) {
+    if (!browse || !out_sync_browse || out_sync_browse->browse != browse
+            || mdns_utils_str_null_or_empty(instance) || mdns_utils_str_null_or_empty(service)
+            || mdns_utils_str_null_or_empty(proto)) {
         return;
     }
     mdns_result_t *r = browse->result;
@@ -593,12 +595,10 @@ void mdns_priv_browse_result_add_txt(mdns_browse_t *browse, const char *instance
                                      mdns_txt_item_t *txt, uint8_t *txt_value_len, size_t txt_count, mdns_if_t tcpip_if, mdns_ip_protocol_t ip_protocol,
                                      uint32_t ttl, mdns_browse_sync_t *out_sync_browse)
 {
-    if (out_sync_browse->browse == NULL) {
-        return;
-    } else {
-        if (out_sync_browse->browse != browse) {
-            return;
-        }
+    if (out_sync_browse->browse == NULL || out_sync_browse->browse != browse
+            || mdns_utils_str_null_or_empty(instance) || mdns_utils_str_null_or_empty(service)
+            || mdns_utils_str_null_or_empty(proto)) {
+        goto free_txt;
     }
     mdns_result_t *r = browse->result;
     while (r) {
@@ -660,11 +660,12 @@ void mdns_priv_browse_result_add_txt(mdns_browse_t *browse, const char *instance
     r->service_type = mdns_mem_strdup(service);
     r->proto = mdns_mem_strdup(proto);
     if (!r->instance_name || !r->service_type || !r->proto) {
+        HOOK_MALLOC_FAILED;
         mdns_mem_free(r->instance_name);
         mdns_mem_free(r->service_type);
         mdns_mem_free(r->proto);
         mdns_mem_free(r);
-        return;
+        goto free_txt;
     }
     r->txt = txt;
     r->txt_value_len = txt_value_len;
@@ -718,13 +719,19 @@ void mdns_priv_browse_result_add_srv(mdns_browse_t *browse, const char *hostname
             return;
         }
     }
+    if (mdns_utils_str_null_or_empty(instance) || mdns_utils_str_null_or_empty(service)
+            || mdns_utils_str_null_or_empty(proto)) {
+        return;
+    }
     mdns_result_t *r = browse->result;
     while (r) {
         if (r->esp_netif == mdns_priv_get_esp_netif(tcpip_if) && r->ip_protocol == ip_protocol &&
                 !mdns_utils_str_null_or_empty(r->instance_name) && !strcasecmp(instance, r->instance_name) &&
                 !mdns_utils_str_null_or_empty(r->service_type) && !strcasecmp(service, r->service_type) &&
                 !mdns_utils_str_null_or_empty(r->proto) && !strcasecmp(proto, r->proto)) {
-            if (mdns_utils_str_null_or_empty(r->hostname) || strcasecmp(hostname, r->hostname)) {
+            if (mdns_utils_str_null_or_empty(r->hostname)
+                    || mdns_utils_str_null_or_empty(hostname)
+                    || strcasecmp(hostname, r->hostname)) {
                 mdns_mem_free((char *)r->hostname);
                 r->hostname = mdns_mem_strdup(hostname);
                 r->port = port;

--- a/components/mdns/mdns_receive.c
+++ b/components/mdns/mdns_receive.c
@@ -764,6 +764,8 @@ static void mdns_parse_packet(mdns_rx_packet_t *packet)
         uint16_t recordIndex = 0;
 
         while (content < (data + len)) {
+            search_result = NULL;
+            browse_result = NULL;
 
             content = mdns_utils_parse_fqdn(data, content, name, len);
             if (!content) {
@@ -959,7 +961,9 @@ static void mdns_parse_packet(mdns_rx_packet_t *packet)
                 uint16_t weight = mdns_utils_read_u16(data_ptr, MDNS_SRV_WEIGHT_OFFSET);
                 uint16_t port = mdns_utils_read_u16(data_ptr, MDNS_SRV_PORT_OFFSET);
 
-                if (browse_result) {
+                if (browse_result && !mdns_utils_str_null_or_empty(browse_result_instance)
+                        && !mdns_utils_str_null_or_empty(browse_result_service)
+                        && !mdns_utils_str_null_or_empty(browse_result_proto)) {
                     mdns_priv_browse_result_add_srv(browse_result, name->host, browse_result_instance,
                                                     browse_result_service,
                                                     browse_result_proto, port, packet->tcpip_if, packet->ip_protocol,
@@ -1037,7 +1041,9 @@ static void mdns_parse_packet(mdns_rx_packet_t *packet)
                 size_t txt_count = 0;
 
                 mdns_result_t *result = NULL;
-                if (browse_result) {
+                if (browse_result && !mdns_utils_str_null_or_empty(browse_result_instance)
+                        && !mdns_utils_str_null_or_empty(browse_result_service)
+                        && !mdns_utils_str_null_or_empty(browse_result_proto)) {
                     result_txt_create(data_ptr, data_len, &txt, &txt_value_len, &txt_count);
                     mdns_priv_browse_result_add_txt(browse_result, browse_result_instance, browse_result_service,
                                                     browse_result_proto,


### PR DESCRIPTION
## [1.11.3](https://github.com/espressif/esp-protocols/commits/mdns-v1.11.3)

### Features

- Add a structure and APIs for allocating TXT items with given value length ([234f9f00](https://github.com/espressif/esp-protocols/commit/234f9f00))

### Bug Fixes

- Fix potential browse null instance crash caught by fuzzer ([953c3a78](https://github.com/espressif/esp-protocols/commit/953c3a78))
- fix deadlock caused by re-acquiring the service lock ([88c68330](https://github.com/espressif/esp-protocols/commit/88c68330))
- free dropped TXT query results when max results reached ([f81720b7](https://github.com/espressif/esp-protocols/commit/f81720b7))


<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes live in the packet parser and browse result cache on malformed input; behavior for valid packets should be unchanged, but browse/SRV edge cases are security-sensitive.
> 
> **Overview**
> Bumps the mDNS component to **1.11.3** (version metadata and changelog only in this diff).
> 
> Hardens **service browse** when parsing hostile or incomplete DNS records: PTR/TXT/SRV browse updates now bail out if `instance`, `service`, or `proto` are null or empty, and the receiver only calls browse SRV/TXT handlers when those cached browse fields are populated. **SRV** hostname updates no longer treat a null target host like a change from a valid one.
> 
> On the receive path, **`search_result` and `browse_result` are cleared at the start of each resource record** so stale matches from an earlier RR cannot drive the next one. **TXT** browse failures (bad args or strdup errors) route through a shared cleanup path so allocated TXT data is not leaked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8299a22398326035ef77641b02df1d2cacb13cf9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->