### PR TITLE
[tls_cxx]: 0.1.0 -> 0.2.0 (mbedtls-v4/PSA support)

### DIFF
--- a/components/mbedtls_cxx/.cz.yaml
+++ b/components/mbedtls_cxx/.cz.yaml
@@ -3,6 +3,6 @@ commitizen:
   bump_message: 'bump(tls_cxx): $current_version -> $new_version'
   pre_bump_hooks: python ../../ci/changelog.py mbedtls_cxx
   tag_format: tls_cxx-v$version
-  version: 0.1.0
+  version: 0.2.0
   version_files:
   - idf_component.yml

--- a/components/mbedtls_cxx/CHANGELOG.md
+++ b/components/mbedtls_cxx/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.2.0](https://github.com/espressif/esp-protocols/commits/tls_cxx-v0.2.0)
+
+### Bug Fixes
+
+- Add support for mbedtls psa api ([884d8fe6](https://github.com/espressif/esp-protocols/commit/884d8fe6))
+- Remove unnnecessary warning ignore ([f8d2ed2e](https://github.com/espressif/esp-protocols/commit/f8d2ed2e))
+- Enable mbedtls cookie support ([479122b2](https://github.com/espressif/esp-protocols/commit/479122b2))
+
 ## [0.1.0](https://github.com/espressif/esp-protocols/commits/tls_cxx-v0.1.0)
 
 ### Features

--- a/components/mbedtls_cxx/idf_component.yml
+++ b/components/mbedtls_cxx/idf_component.yml
@@ -1,4 +1,4 @@
-version: 0.1.0
+version: 0.2.0
 url: https://github.com/espressif/esp-protocols/tree/master/components/mbedtls_cxx
 description: C++ wrapper of mbedtls to perform (D)TLS connection
 license: Apache-2.0


### PR DESCRIPTION
# 0.2.0

## Bug Fixes

- Add support for mbedtls psa api (884d8fe6)
- Remove unnnecessary warning ignore (f8d2ed2e)
- Enable mbedtls cookie support (479122b2)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version and changelog updates; no source or behavioral changes in this diff.
> 
> **Overview**
> **Bumps the `mbedtls_cxx` component from 0.1.0 to 0.2.0** across Commitizen config (`.cz.yaml`) and the ESP-IDF registry manifest (`idf_component.yml`).
> 
> Adds a **0.2.0** section to `CHANGELOG.md` documenting the release fixes: mbedTLS **PSA API** support (mbedTLS v4), **DTLS cookie** support, and removal of an unnecessary compiler warning suppression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7850b6ed7a6c6239d27f34a7274974e1de0ac08a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->