### PR TITLE
[lws]: Bump v4.3.3~3

### DIFF
--- a/components/libwebsockets/.cz.yaml
+++ b/components/libwebsockets/.cz.yaml
@@ -3,6 +3,6 @@ commitizen:
   bump_message: 'bump(lws): $current_version -> $new_version'
   pre_bump_hooks: python ../../ci/changelog.py libwebsockets
   tag_format: lws-v$version
-  version: 4.3.3~2
+  version: 4.3.3~3
   version_files:
   - idf_component.yml

--- a/components/libwebsockets/CHANGELOG.md
+++ b/components/libwebsockets/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [4.3.3~3](https://github.com/espressif/esp-protocols/commits/lws-v4.3.3_3)
+
+### Features
+
+- add LWS_WITH_CUSTOM_HEADERS option and UTC timegm ([8fd4febf](https://github.com/espressif/esp-protocols/commit/8fd4febf))
+
 ## [4.3.3~2](https://github.com/espressif/esp-protocols/commits/lws-v4.3.3_2)
 
 ### Features

--- a/components/libwebsockets/idf_component.yml
+++ b/components/libwebsockets/idf_component.yml
@@ -1,4 +1,4 @@
-version: "4.3.3~2"
+version: "4.3.3~3"
 url: https://github.com/espressif/esp-protocols/tree/master/components/libwebsockets
 description: The component provides a simple ESP-IDF port of libwebsockets client.
 dependencies:


### PR DESCRIPTION
## [4.3.3~3](https://github.com/espressif/esp-protocols/commits/lws-v4.3.3_3)

### Features

- add LWS_WITH_CUSTOM_HEADERS option and UTC timegm ([8fd4febf](https://github.com/espressif/esp-protocols/commit/8fd4febf))

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-metadata only in this diff (version strings and changelog); no source changes in the PR itself.
> 
> **Overview**
> **Releases libwebsockets component `4.3.3~3`** by bumping the version in `idf_component.yml` and `.cz.yaml` and adding a **4.3.3~3** section to `CHANGELOG.md`.
> 
> The changelog entry records the feature work in the referenced commit: optional **`LWS_WITH_CUSTOM_HEADERS`** (Kconfig-driven custom HTTP header APIs) and a **UTC `timegm()`** port fix so HTTP `Date` parsing does not use local-time `mktime()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a41f33528d062730cafc12c29bb41610287d4f72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->