### PR TITLE
fix(mosq): Undef POSIX_C_SOURCE as mosquitto config defines it

### DIFF
--- a/components/mosquitto/.cz.yaml
+++ b/components/mosquitto/.cz.yaml
@@ -3,6 +3,6 @@ commitizen:
   bump_message: 'bump(mosq): $current_version -> $new_version'
   pre_bump_hooks: python ../../ci/changelog.py mosquitto
   tag_format: mosq-v$version
-  version: 2.0.20~7
+  version: 2.0.20~8
   version_files:
   - idf_component.yml

--- a/components/mosquitto/CHANGELOG.md
+++ b/components/mosquitto/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.0.20~8](https://github.com/espressif/esp-protocols/commits/mosq-v2.0.20_8)
+
+### Bug Fixes
+
+- Undef POSIX_C_SOURCE as mosquitto config defines it ([07de5c0e](https://github.com/espressif/esp-protocols/commit/07de5c0e))
+
 ## [2.0.20~7](https://github.com/espressif/esp-protocols/commits/mosq-v2.0.20_7)
 
 ### Features

--- a/components/mosquitto/idf_component.yml
+++ b/components/mosquitto/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.0.20~7"
+version: "2.0.20~8"
 url: https://github.com/espressif/esp-protocols/tree/master/components/mosquitto
 description: The component provides a simple ESP32 port of mosquitto broker
 dependencies:

--- a/components/mosquitto/port/priv_include/config.h
+++ b/components/mosquitto/port/priv_include/config.h
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
+#undef _POSIX_C_SOURCE    /* Note: mosquitto's config.h bug: defines _POSIX_C_SOURCE=200809L
+                           * - fixed in v2.1.0, but IDF port doesn't support yet (due to json deps)
+                           */
 #include_next "config.h"
 
 /*

--- a/components/mosquitto/port/priv_include/config.h
+++ b/components/mosquitto/port/priv_include/config.h
@@ -26,4 +26,4 @@
 #define isspace(__c) (__ctype_lookup((int)__c)&_S)
 #endif
 
-#define VERSION "v2.0.20~7"
+#define VERSION "v2.0.20~8"


### PR DESCRIPTION
* Fixed upstream in `v2.1.0`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single preprocessor workaround in the port header with a patch release; no auth, networking, or runtime logic changes.
> 
> **Overview**
> **Fixes a build/header interaction** where upstream Mosquitto’s `config.h` forces `_POSIX_C_SOURCE=200809L` before the ESP-IDF port’s wrapper includes it.
> 
> The port wrapper now **`#undef _POSIX_C_SOURCE`** immediately before `#include_next "config.h"`, with a note that upstream fixed this in v2.1.0 but this component still pins an older Mosquitto revision.
> 
> Releases **2.0.20~8** (version bumps in `.cz.yaml`, `idf_component.yml`, and the port `VERSION` macro) and documents the fix in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d41416cf07945742359c17012fc9a81011acbcf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->