### PR TITLE
fix(websocket): set STOPPED_BIT before task create to avoid stop()/de…

### DIFF
--- a/components/esp_websocket_client/esp_websocket_client.c
+++ b/components/esp_websocket_client/esp_websocket_client.c
@@ -1464,12 +1464,13 @@ esp_err_t esp_websocket_client_start(esp_websocket_client_handle_t client)
         }
     }
 
+    xEventGroupClearBits(client->status_bits, STOPPED_BIT | CLOSE_FRAME_SENT_BIT | REQUESTED_STOP_BIT | WAKEUP_BIT);
     if (xTaskCreatePinnedToCore(esp_websocket_client_task, client->config->task_name ? client->config->task_name : "websocket_task",
                                 client->config->task_stack, client, client->config->task_prio, &client->task_handle, client->config->task_core_id) != pdTRUE) {
         ESP_LOGE(TAG, "Error create websocket task");
+        xEventGroupSetBits(client->status_bits, STOPPED_BIT);
         return ESP_FAIL;
     }
-    xEventGroupClearBits(client->status_bits, STOPPED_BIT | CLOSE_FRAME_SENT_BIT | REQUESTED_STOP_BIT | WAKEUP_BIT);
     ESP_LOGI(TAG, "Started");
     return ESP_OK;
 }


### PR DESCRIPTION
Related https://github.com/espressif/esp-protocols/issues/1096

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches client start/stop synchronization in embedded networking code; incorrect bit ordering could cause hangs or premature teardown, but the change is small and targeted.
> 
> **Overview**
> Fixes a lifecycle race in `esp_websocket_client_start()` where `stop()` or `destroy()` could mis-handle a client that was mid-start or had a failed task spawn (see espressif/esp-protocols#1096).
> 
> **`STOPPED_BIT` is cleared before** `xTaskCreatePinnedToCore`, so callers no longer treat the client as fully stopped while a websocket task may already exist or start is in progress. **`STOPPED_BIT` is set again** if task creation fails, restoring the initialized “stopped” state so `stop()`/`destroy()` do not block forever waiting for a task that never started.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2b86d7388de0d7335ff21df1cc15e6ea278caf1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->