### PR TITLE
[websocket] Fix host test & gcov issues

### DIFF
--- a/.github/workflows/websocket__build-target-test.yml
+++ b/.github/workflows/websocket__build-target-test.yml
@@ -13,7 +13,7 @@ jobs:
     name: Build
     strategy:
       matrix:
-        idf_ver: ["release-v5.0", "release-v5.1", "release-v5.2", "release-v5.3", "latest"]
+        idf_ver: ["release-v5.2", "release-v5.3", "release-v5.4", "release-v5.5", "release-v6.0", "release-v6.1", "latest"]
         test: [ { app: example, path: "examples/target" }, { app: unit_test, path: "tests/unit" } ]
     runs-on: ubuntu-22.04
     container: espressif/idf:${{ matrix.idf_ver }}
@@ -51,7 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        idf_ver: ["release-v5.0", "release-v5.1", "release-v5.2", "release-v5.3", "latest"]
+        idf_ver: ["release-v5.2", "release-v5.3", "release-v5.4", "release-v5.5", "release-v6.0", "release-v6.1", "latest"]
         idf_target: ["esp32"]
         test: [ { app: example, path: "examples/target" }, { app: unit_test, path: "tests/unit" } ]
     runs-on:

--- a/common_components/linux_compat/freertos/CMakeLists.txt
+++ b/common_components/linux_compat/freertos/CMakeLists.txt
@@ -6,7 +6,8 @@ set(coop_syscalls "${freertos_linux_port}/utils/linux_port_coop_syscalls.c")
 
 # Blocking host syscalls stall the FreeRTOS Linux simulator; redirect a small
 # set of libc entry points to the IDF cooperative layer via linker wrap.
-set(coop_wrap_functions socket accept fcntl close send read poll)
+# open/write/mkdir bypass IDF VFS so libgcov can write .gcda on host.
+set(coop_wrap_functions socket accept fcntl close send read poll open write mkdir)
 
 set(srcs freertos_linux.c
          osal/queue.cpp
@@ -43,6 +44,13 @@ if("${idf_target}" STREQUAL "linux" AND EXISTS "${coop_syscalls}")
             "-Wl,--wrap=${wrap}"
             "-Wl,-u,__wrap_${wrap}")
     endforeach()
+endif()
+
+# Host shim has no esp_startup_start_app(); apps provide their own main().
+# Suppress esp_system's weak main() so it cannot satisfy CRT first from the archive.
+if("${idf_target}" STREQUAL "linux")
+    idf_component_get_property(esp_system_lib esp_system COMPONENT_LIB)
+    target_compile_definitions(${esp_system_lib} PRIVATE ESP_SYSTEM_LINUX_NO_MAIN)
 endif()
 
 set_target_properties(${COMPONENT_LIB} PROPERTIES

--- a/common_components/linux_compat/freertos/freertos_linux.c
+++ b/common_components/linux_compat/freertos/freertos_linux.c
@@ -9,8 +9,10 @@
 #include "freertos/task.h"
 #include <pthread.h>
 #include <assert.h>
+#include <errno.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 #include "osal/osal_api.h"
 #include <semaphore.h>
 
@@ -19,6 +21,22 @@ static __thread bool s_in_freertos_task = false;
 bool linux_port_in_freertos_task(void)
 {
     return s_in_freertos_task;
+}
+
+/*
+ * IDF's linux_port_coop_syscalls.c overrides usleep/nanosleep to call
+ * vTaskDelay() inside FreeRTOS tasks. The host shim's vTaskDelay must not
+ * call those interposed symbols or it recurses until stack overflow.
+ * clock_nanosleep is not interposed.
+ */
+static void host_sleep_us(unsigned int usec)
+{
+    struct timespec ts = {
+        .tv_sec = usec / 1000000,
+        .tv_nsec = (long)(usec % 1000000) * 1000L,
+    };
+    while (clock_nanosleep(CLOCK_REALTIME, 0, &ts, &ts) == EINTR) {
+    }
 }
 
 static pthread_mutex_t s_critical_mutex;
@@ -217,7 +235,7 @@ TickType_t xTaskGetTickCount(void)
 
 void vTaskDelay(const TickType_t xTicksToDelay)
 {
-    usleep(xTicksToDelay * 1000);
+    host_sleep_us(xTicksToDelay * 1000);
 }
 
 void *pthread_task(void *params)
@@ -286,7 +304,7 @@ BaseType_t xTaskCreate(TaskFunction_t pvTaskCode, const char *const pcName, cons
 
     // just wait till the task started so we can unwind params from the stack
     while (pthread_params.started == false) {
-        usleep(1000);
+        host_sleep_us(1000);
     }
     if (pvCreatedTask) {
         *pvCreatedTask = pthread_params.handle;
@@ -309,7 +327,7 @@ void xTaskNotifyGive(TaskHandle_t task)
         if (++i == s_threads) {
             i = 0;
         }
-        usleep(1000);
+        host_sleep_us(1000);
     }
 }
 
@@ -368,6 +386,6 @@ void ulTaskNotifyTake(bool clear_on_exit, uint32_t xTicksToWait)
         if (++i == s_threads) {
             i = 0;
         }
-        usleep(1000);
+        host_sleep_us(1000);
     }
 }

--- a/common_components/linux_compat/freertos/linux_coop_linker_wrap.c
+++ b/common_components/linux_compat/freertos/linux_coop_linker_wrap.c
@@ -8,6 +8,8 @@
 #include <poll.h>
 #include <stdarg.h>
 #include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
 #include <unistd.h>
 
 #include "esp_private/freertos_linux_coop_syscalls.h"
@@ -86,4 +88,32 @@ ssize_t __wrap_read(int fd, void *buf, size_t count)
 int __wrap_poll(struct pollfd *fds, nfds_t nfds, int timeout)
 {
     return freertos_linux_coop_poll(fds, nfds, timeout);
+}
+
+/*
+ * Path open/mkdir/write must not go through IDF VFS on Linux host builds:
+ * VFS has no path mount for the host FS, so esp_vfs_open/mkdir return ENOENT
+ * and libgcov fails with "Cannot open" / empty .gcda (0% coverage).
+ * Use syscalls directly; sockets already use the wraps above.
+ */
+int __wrap_mkdir(const char *path, mode_t mode)
+{
+    return (int)syscall(SYS_mkdirat, AT_FDCWD, path, mode);
+}
+
+int __wrap_open(const char *path, int flags, ...)
+{
+    mode_t mode = 0;
+    if (flags & O_CREAT) {
+        va_list args;
+        va_start(args, flags);
+        mode = (mode_t)va_arg(args, int);
+        va_end(args);
+    }
+    return (int)syscall(SYS_openat, AT_FDCWD, path, flags, mode);
+}
+
+ssize_t __wrap_write(int fd, const void *buf, size_t count)
+{
+    return (ssize_t)syscall(SYS_write, fd, buf, count);
 }

--- a/components/esp_websocket_client/esp_websocket_client.c
+++ b/components/esp_websocket_client/esp_websocket_client.c
@@ -302,8 +302,15 @@ static esp_err_t esp_websocket_client_error(esp_websocket_client_handle_t client
     va_list myargs;
     va_start(myargs, format);
 
-    size_t needed_size = vsnprintf(NULL, 0, format, myargs);
-    needed_size++; // null terminator
+    va_list args_copy;
+    va_copy(args_copy, myargs);
+    int sized = vsnprintf(NULL, 0, format, args_copy);
+    va_end(args_copy);
+    if (sized < 0) {
+        va_end(myargs);
+        return ESP_FAIL;
+    }
+    size_t needed_size = (size_t)sized + 1; // null terminator
 
     if (needed_size > client->errormsg_size) {
         if (client->errormsg_buffer) {
@@ -312,6 +319,7 @@ static esp_err_t esp_websocket_client_error(esp_websocket_client_handle_t client
         client->errormsg_buffer = malloc(needed_size);
         if (client->errormsg_buffer == NULL) {
             client->errormsg_size = 0;
+            va_end(myargs);
             ESP_LOGE(TAG, "Failed to allocate...");
             return ESP_ERR_NO_MEM;
         }
@@ -319,7 +327,6 @@ static esp_err_t esp_websocket_client_error(esp_websocket_client_handle_t client
     }
 
     needed_size = vsnprintf(client->errormsg_buffer, client->errormsg_size, format, myargs);
-
     va_end(myargs);
 
     ESP_LOGE(TAG, "%s", client->errormsg_buffer);

--- a/components/esp_websocket_client/examples/linux/CMakeLists.txt
+++ b/components/esp_websocket_client/examples/linux/CMakeLists.txt
@@ -2,13 +2,10 @@ cmake_minimum_required(VERSION 3.5)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 
-set(common_component_dir ../../../../common_components)
-set(EXTRA_COMPONENT_DIRS
-   ../..
-  "${common_component_dir}/linux_compat/esp_timer"
-  "${common_component_dir}/linux_compat/freertos"
-   $ENV{IDF_PATH}/examples/protocols/linux_stubs/esp_stubs
-   $ENV{IDF_PATH}/examples/common_components/protocol_examples_common)
+if("${IDF_TARGET}" STREQUAL "linux")
+    list(APPEND EXTRA_COMPONENT_DIRS "../../../../common_components/linux_compat")
+endif()
 
-set(COMPONENTS main)
+idf_build_set_property(MINIMAL_BUILD ON)
+
 project(websocket)

--- a/components/esp_websocket_client/examples/linux/main/idf_component.yml
+++ b/components/esp_websocket_client/examples/linux/main/idf_component.yml
@@ -1,0 +1,6 @@
+dependencies:
+  espressif/esp_websocket_client:
+    version: "*"
+    override_path: "../../.."
+  protocol_examples_common:
+    path: ${IDF_PATH}/examples/common_components/protocol_examples_common

--- a/components/esp_websocket_client/tests/autobahn-testsuite/testee/main/autobahn_testee.c
+++ b/components/esp_websocket_client/tests/autobahn-testsuite/testee/main/autobahn_testee.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Unlicense OR CC0-1.0
  */
@@ -185,15 +185,9 @@ static void websocket_event_handler(void *handler_args,
         ESP_LOGI(TAG, "Disconnected");
         test_running = false;
         ws_accumulator_reset();
-#if CONFIG_IDF_TARGET_LINUX
-        if (test_done_sem) {
-            sem_post(test_done_sem);
-        }
-#else
-        if (test_done_sem) {
-            xSemaphoreGive(test_done_sem);
-        }
-#endif
+        /* Do not signal test_done here: ERROR/DISCONNECTED can fire while the
+         * client task still holds its lock mid-abort. Wait for FINISH so stop/destroy
+         * does not race the task teardown (hangs on Linux host). */
         break;
 
     case WEBSOCKET_EVENT_DATA: {
@@ -424,19 +418,11 @@ static void websocket_event_handler(void *handler_args,
         ESP_LOGW(TAG, "WebSocket error event");
         test_running = false;
         ws_accumulator_reset();  // Reset accumulator on error
-#if CONFIG_IDF_TARGET_LINUX
-        if (test_done_sem) {
-            sem_post(test_done_sem);
-        }
-#else
-        if (test_done_sem) {
-            xSemaphoreGive(test_done_sem);
-        }
-#endif
+        /* Same as DISCONNECTED: wait for FINISH before tearing down the client. */
         break;
 
     case WEBSOCKET_EVENT_FINISH:
-        ESP_LOGD(TAG, "WebSocket finish event");
+        ESP_LOGI(TAG, "WebSocket finish event");
         test_running = false;
         ws_accumulator_reset();  // Reset accumulator on finish
 #if CONFIG_IDF_TARGET_LINUX
@@ -539,7 +525,7 @@ static esp_err_t run_test_case(int case_num)
         .uri = uri,
         .buffer_size = BUFFER_SIZE,
         .network_timeout_ms = 10000,   // 10s for connection (default), 200ms was too short
-        .reconnect_timeout_ms = 500,
+        .disable_auto_reconnect = true, // Autobahn cases expect a clean stop on protocol errors
         .task_prio = 10,                // High prio → low latency
         .task_stack = 8144,
     };
@@ -576,21 +562,31 @@ static esp_err_t run_test_case(int case_num)
         return start_ret;
     }
 
-    /* Wait up to 60 s so server can close properly */
+    /* Wait up to 60 s for FINISH (client task exiting). */
 #if CONFIG_IDF_TARGET_LINUX
+    int wait_ret;
     {
         struct timespec ts;
         clock_gettime(CLOCK_REALTIME, &ts);
         ts.tv_sec += 60;  // absolute timeout (now + 60s)
-        (void)sem_timedwait(test_done_sem, &ts);
+        wait_ret = sem_timedwait(test_done_sem, &ts);
+    }
+    if (wait_ret != 0) {
+        /* Timed out without FINISH — force-stop a still-running task. */
+        esp_websocket_client_stop(client);
+    } else {
+        /* FINISH was posted just before transport_close + STOPPED_BIT.
+         * Calling stop() here races that teardown and can hang on Linux.
+         * Brief yield so destroy() sees STOPPED_BIT already set. */
+        usleep(100 * 1000);
     }
 #else
-    xSemaphoreTake(test_done_sem, pdMS_TO_TICKS(60000));
-#endif
-
-    if (esp_websocket_client_is_connected(client)) {
+    if (xSemaphoreTake(test_done_sem, pdMS_TO_TICKS(60000)) != pdTRUE) {
         esp_websocket_client_stop(client);
+    } else {
+        vTaskDelay(pdMS_TO_TICKS(100));
     }
+#endif
 
     esp_websocket_client_destroy(client);
 #if CONFIG_IDF_TARGET_LINUX


### PR DESCRIPTION
Fixes linux host tests
Fixes autobahn tests


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect Linux-only linker wraps, build layout, and client teardown timing; core embedded websocket logic changes are limited to error-string formatting.
> 
> **Overview**
> Fixes **Linux host** builds and coverage for `esp_websocket_client`, and stabilizes **Autobahn** runs on the simulator.
> 
> The **linux_compat** FreeRTOS shim now sleeps via `clock_nanosleep` instead of `usleep` to avoid recursion with IDF cooperative syscalls, wraps **`open`/`write`/`mkdir`** with direct syscalls so **libgcov** can write `.gcda` files, and sets **`ESP_SYSTEM_LINUX_NO_MAIN`** so host apps own `main()`. The **Linux example** switches to **minimal build** plus `idf_component.yml` dependencies instead of hard-coded component paths.
> 
> **CI** drops IDF v5.0/v5.1 and adds v5.4–v6.1 in the websocket workflow matrix. **`esp_websocket_client_error`** handles failed `vsnprintf` sizing safely. **Autobahn testee** waits for **`WEBSOCKET_EVENT_FINISH`** before destroy (avoids Linux hangs), uses **`disable_auto_reconnect`**, and only calls **`stop()`** on wait timeout—not after a normal finish.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2de1e2c46edac3706fc9dc6c91e672e73c27a0eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->