### PR TITLE
fix(modem): Make set_apn() update the PDP context

### DIFF
--- a/components/esp_modem/.cz.yaml
+++ b/components/esp_modem/.cz.yaml
@@ -3,6 +3,6 @@ commitizen:
   bump_message: 'bump(modem): $current_version -> $new_version'
   pre_bump_hooks: python ../../ci/changelog.py esp_modem
   tag_format: modem-v$version
-  version: 2.0.2
+  version: 2.1.0
   version_files:
   - idf_component.yml

--- a/components/esp_modem/CHANGELOG.md
+++ b/components/esp_modem/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [2.1.0](https://github.com/espressif/esp-protocols/commits/modem-v2.1.0)
+
+### Features
+
+- Support for custom APN/proto config ([3684abae](https://github.com/espressif/esp-protocols/commit/3684abae))
+
+### Bug Fixes
+
+- Fix test loopback tear-down race ([6e98171b](https://github.com/espressif/esp-protocols/commit/6e98171b))
+- Make set_apn() update the PDP context ([b7087f86](https://github.com/espressif/esp-protocols/commit/b7087f86))
+- Fix terminal-callback use-after-free and harden task teardown ([01004182](https://github.com/espressif/esp-protocols/commit/01004182))
+- Update CI API check to ignore C comments ([ccc3d4a8](https://github.com/espressif/esp-protocols/commit/ccc3d4a8))
+- Add URC-handler host test ([93db64db](https://github.com/espressif/esp-protocols/commit/93db64db))
+
+### Updated
+
+- ci(modem): Use large app partition in examples ([a1d26ca7](https://github.com/espressif/esp-protocols/commit/a1d26ca7))
+- Reset last URC processed on consume all ([311611fe](https://github.com/espressif/esp-protocols/commit/311611fe))
+
 ## [2.0.2](https://github.com/espressif/esp-protocols/commits/modem-v2.0.2)
 
 ### Features

--- a/components/esp_modem/command/include/cxx_include/esp_modem_dce_module.hpp
+++ b/components/esp_modem/command/include/cxx_include/esp_modem_dce_module.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2021-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -92,6 +92,17 @@ public:
     void configure_pdp_context(std::unique_ptr<PdpContext> new_pdp)
     {
         pdp = std::move(new_pdp);
+    }
+    /**
+     * @brief Update only the APN on the stored PDP context (keeps protocol type and CID)
+     */
+    void set_apn(const std::string &apn)
+    {
+        if (pdp) {
+            pdp->apn = apn;
+        } else {
+            pdp = std::make_unique<PdpContext>(apn);
+        }
     }
     /**
      * @brief Simplified version of operator name (without the ACT, which is included in the command library)

--- a/components/esp_modem/command/include/esp_modem_api.h
+++ b/components/esp_modem/command/include/esp_modem_api.h
@@ -104,8 +104,8 @@ esp_err_t esp_modem_send_sms(esp_modem_dce_t *dce, const char *number, const cha
  */
 esp_err_t esp_modem_resume_data_mode(esp_modem_dce_t *dce);
 /**
- * @brief Sets php context
- * @param[in] p1 PdP context struct to setup modem cellular connection
+ * @brief Sets PDP context (sends AT+CGDCONT and stores it for later set_mode(DATA))
+ * @param[in] pdp PDP context (APN, protocol type, context id) used for cellular connection
  * @return OK, FAIL or TIMEOUT
  */
 esp_err_t esp_modem_set_pdp_context(esp_modem_dce_t *dce, esp_modem_PdpContext_t *pdp);

--- a/components/esp_modem/command/src/esp_modem_modules.cpp
+++ b/components/esp_modem/command/src/esp_modem_modules.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2021-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -11,7 +11,15 @@
 
 namespace esp_modem {
 GenericModule::GenericModule(std::shared_ptr<DTE> dte, const dce_config *config) :
-    dte(std::move(dte)), pdp(std::make_unique<PdpContext>(config->apn)) {}
+    dte(std::move(dte)), pdp(std::make_unique<PdpContext>(config->apn ? config->apn : ""))
+{
+    if (config->context_id != 0) {
+        pdp->context_id = config->context_id;
+    }
+    if (config->protocol_type != nullptr) {
+        pdp->protocol_type = config->protocol_type;
+    }
+}
 /**
  * @brief Sends the initial AT sequence to sync up with the device
  * @return OK, FAIL or TIMEOUT

--- a/components/esp_modem/generate/include/cxx_include/esp_modem_dce_module.hpp
+++ b/components/esp_modem/generate/include/cxx_include/esp_modem_dce_module.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2021-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -100,6 +100,18 @@ public:
     void configure_pdp_context(std::unique_ptr<PdpContext> new_pdp)
     {
         pdp = std::move(new_pdp);
+    }
+
+    /**
+     * @brief Update only the APN on the stored PDP context (keeps protocol type and CID)
+     */
+    void set_apn(const std::string &apn)
+    {
+        if (pdp) {
+            pdp->apn = apn;
+        } else {
+            pdp = std::make_unique<PdpContext>(apn);
+        }
     }
 
     /**

--- a/components/esp_modem/generate/src/esp_modem_modules.cpp
+++ b/components/esp_modem/generate/src/esp_modem_modules.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2021-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -13,7 +13,15 @@
 namespace esp_modem {
 
 GenericModule::GenericModule(std::shared_ptr<DTE> dte, const dce_config *config) :
-    dte(std::move(dte)), pdp(std::make_unique<PdpContext>(config->apn)) {}
+    dte(std::move(dte)), pdp(std::make_unique<PdpContext>(config->apn ? config->apn : ""))
+{
+    if (config->context_id != 0) {
+        pdp->context_id = config->context_id;
+    }
+    if (config->protocol_type != nullptr) {
+        pdp->protocol_type = config->protocol_type;
+    }
+}
 
 
 #include "esp_modem_command_declare_helper.inc"

--- a/components/esp_modem/idf_component.yml
+++ b/components/esp_modem/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.0.2"
+version: "2.1.0"
 description: Library for communicating with cellular modems in command and data modes
 url: https://github.com/espressif/esp-protocols/tree/master/components/esp_modem
 issues: https://github.com/espressif/esp-protocols/issues

--- a/components/esp_modem/include/cxx_include/esp_modem_types.hpp
+++ b/components/esp_modem/include/cxx_include/esp_modem_types.hpp
@@ -74,6 +74,10 @@ typedef std::function<command_result(uint8_t *data, size_t len)> got_line_cb;
 
 /**
  * @brief PDP context used for configuring and setting the data mode up
+ *
+ * Sent as AT+CGDCONT=<context_id>,"<protocol_type>","<apn>" when entering data mode.
+ * protocol_type is typically "IP" (IPv4), "IPV6", or "IPV4V6" (dual stack).
+ * context_id is usually 1; some carriers (e.g. Verizon) require 3.
  */
 struct PdpContext {
     explicit PdpContext(std::string apn) : apn(std::move(apn)) {}

--- a/components/esp_modem/include/esp_modem_c_api_types.h
+++ b/components/esp_modem/include/esp_modem_c_api_types.h
@@ -20,10 +20,18 @@ extern "C" {
 
 typedef struct esp_modem_dce_wrap esp_modem_dce_t;
 
+/**
+ * @brief PDP context for AT+CGDCONT / network attach
+ *
+ * @note protocol_type: "IP" (IPv4), "IPV6", or "IPV4V6" (dual stack).
+ *       context_id: typically 1; some carriers (e.g. Verizon) use 3.
+ *       Zero context_id / NULL protocol_type keep defaults (1 / "IP"),
+ *       matching esp_modem_dce_config.
+ */
 typedef struct esp_modem_PdpContext_t {
-    size_t context_id;
-    const char *protocol_type;
-    const char *apn;
+    size_t context_id;          /*!< PDP context id (CID); 0 keeps default 1 */
+    const char *protocol_type;  /*!< "IP", "IPV6", or "IPV4V6"; NULL keeps default "IP" */
+    const char *apn;            /*!< Access Point Name */
 } esp_modem_PdpContext_t;
 
 /**
@@ -161,11 +169,13 @@ esp_err_t esp_modem_set_mode(esp_modem_dce_t *dce, esp_modem_dce_mode_t mode);
 esp_err_t esp_modem_command(esp_modem_dce_t *dce, const char *command, esp_err_t(*got_line_cb)(uint8_t *data, size_t len), uint32_t timeout_ms);
 
 /**
- * @brief Sets the APN and configures it into the modem's PDP context
+ * @brief Sets the APN on the stored PDP context (keeps protocol type and CID)
  *
  * @param dce Modem DCE handle
  * @param apn Access Point Name
  * @return ESP_OK on success
+ *
+ * @note To change protocol type or CID as well, use esp_modem_set_pdp_context().
  */
 esp_err_t esp_modem_set_apn(esp_modem_dce_t *dce, const char *apn);
 

--- a/components/esp_modem/include/esp_modem_dce_config.h
+++ b/components/esp_modem/include/esp_modem_dce_config.h
@@ -1,10 +1,12 @@
 /*
- * SPDX-FileCopyrightText: 2021-2022 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2021-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #pragma once
+
+#include <stddef.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -17,19 +19,30 @@ extern "C" {
 /**
  * @brief ESP Modem DCE Default Configuration
  *
+ * Defaults: PDP context id 1, protocol type "IP" (IPv4).
+ * Override context_id / protocol_type for other carriers or IP stacks,
+ * e.g. context_id=3 (Verizon), protocol_type="IPV6" or "IPV4V6".
  */
 #define ESP_MODEM_DCE_DEFAULT_CONFIG(APN)       \
     {                                           \
-        .apn = APN                              \
+        .apn = APN,                             \
+        .context_id = 1,                        \
+        .protocol_type = "IP"                   \
     }
 
 typedef struct esp_modem_dce_config esp_modem_dce_config_t;
 
 /**
  * @brief DCE configuration structure
+ *
+ * Holds the PDP context parameters used when entering data mode
+ * (AT+CGDCONT). Zero-initialized context_id / NULL protocol_type
+ * fall back to defaults (1 / "IP").
  */
 struct esp_modem_dce_config {
-    const char *apn;  /*!< APN: Logical name of the Access point */
+    const char *apn;            /*!< APN: Logical name of the Access point */
+    size_t context_id;          /*!< PDP context id (CID), typically 1; some carriers use 3 */
+    const char *protocol_type;  /*!< PDP type: "IP", "IPV6", or "IPV4V6" */
 };
 
 /**

--- a/components/esp_modem/src/esp_modem_c_api.cpp
+++ b/components/esp_modem/src/esp_modem_c_api.cpp
@@ -585,12 +585,16 @@ extern "C" esp_err_t esp_modem_reset(esp_modem_dce_t *dce_wrap)
 
 extern "C" esp_err_t esp_modem_set_pdp_context(esp_modem_dce_t *dce_wrap, esp_modem_PdpContext_t *c_api_pdp)
 {
-    if (dce_wrap == nullptr || dce_wrap->dce == nullptr || c_api_pdp == nullptr) {
+    if (dce_wrap == nullptr || dce_wrap->dce == nullptr || c_api_pdp == nullptr || c_api_pdp->apn == nullptr) {
         return ESP_ERR_INVALID_ARG;
     }
-    esp_modem::PdpContext pdp{c_api_pdp->apn};
-    pdp.context_id = c_api_pdp->context_id;
-    pdp.protocol_type = c_api_pdp->protocol_type;
+    auto new_pdp = std::make_unique<PdpContext>(c_api_pdp->apn);
+    new_pdp->context_id = c_api_pdp->context_id;
+    if (c_api_pdp->protocol_type != nullptr) {
+        new_pdp->protocol_type = c_api_pdp->protocol_type;
+    }
+    PdpContext pdp = *new_pdp;
+    dce_wrap->dce->get_module()->configure_pdp_context(std::move(new_pdp));
     return command_response_to_esp_err(dce_wrap->dce->set_pdp_context(pdp));
 }
 

--- a/components/esp_modem/src/esp_modem_c_api.cpp
+++ b/components/esp_modem/src/esp_modem_c_api.cpp
@@ -570,8 +570,12 @@ extern "C" esp_err_t esp_modem_sqn_gm02s_connect(esp_modem_dce_t *dce_wrap, cons
     }
 
     esp_modem::PdpContext pdp{pdp_context->apn};
-    pdp.context_id = pdp_context->context_id;
-    pdp.protocol_type = pdp_context->protocol_type;
+    if (pdp_context->context_id != 0) {
+        pdp.context_id = pdp_context->context_id;
+    }
+    if (pdp_context->protocol_type != nullptr) {
+        pdp.protocol_type = pdp_context->protocol_type;
+    }
     return command_response_to_esp_err(static_cast<SQNGM02S *>(dce_wrap->dce->get_module())->connect(pdp));
 }
 
@@ -589,7 +593,9 @@ extern "C" esp_err_t esp_modem_set_pdp_context(esp_modem_dce_t *dce_wrap, esp_mo
         return ESP_ERR_INVALID_ARG;
     }
     auto new_pdp = std::make_unique<PdpContext>(c_api_pdp->apn);
-    new_pdp->context_id = c_api_pdp->context_id;
+    if (c_api_pdp->context_id != 0) {
+        new_pdp->context_id = c_api_pdp->context_id;
+    }
     if (c_api_pdp->protocol_type != nullptr) {
         new_pdp->protocol_type = c_api_pdp->protocol_type;
     }
@@ -629,8 +635,7 @@ extern "C" esp_err_t esp_modem_set_apn(esp_modem_dce_t *dce_wrap, const char *ap
     if (dce_wrap == nullptr || dce_wrap->dce == nullptr || apn == nullptr) {
         return ESP_ERR_INVALID_ARG;
     }
-    auto new_pdp = std::unique_ptr<PdpContext>(new PdpContext(apn));
-    dce_wrap->dce->get_module()->configure_pdp_context(std::move(new_pdp));
+    dce_wrap->dce->get_module()->set_apn(apn);
     return ESP_OK;
 }
 

--- a/components/esp_modem/test/host_test/main/LoopbackTerm.cpp
+++ b/components/esp_modem/test/host_test/main/LoopbackTerm.cpp
@@ -10,18 +10,21 @@
 
 void LoopbackTerm::start()
 {
+    stopping = false;
     status = status_t::STARTED;
 }
 
 void LoopbackTerm::stop()
 {
     status = status_t::STOPPED;
+    // DTE::~DTE() calls stop() before clearing the read callback and expects that no callback
+    // is in flight once it returns, so the pending async replies must be joined here
+    finish_async();
 }
 
 int LoopbackTerm::write(uint8_t *data, size_t len)
 {
     if (inject_by) {    // injection test: ignore what we write, but respond with injected data
-        signal.clear(1);
         auto ret = std::async(&LoopbackTerm::batch_read, this);
         async_results.push_back(std::move(ret));
         return len;
@@ -86,7 +89,6 @@ int LoopbackTerm::write(uint8_t *data, size_t len)
             data_len = response.length();
             loopback_data.resize(data_len);
             memcpy(&loopback_data[0], &response[0], data_len);
-            signal.clear(1);
             auto ret = std::async(on_read, nullptr, data_len);
             return len;
         }
@@ -105,7 +107,6 @@ int LoopbackTerm::write(uint8_t *data, size_t len)
     loopback_data.resize(data_len + len);
     memcpy(&loopback_data[data_len], data, len);
     data_len += len;
-    signal.clear(1);
     auto ret = std::async(on_read, nullptr, data_len);
     return len;
 }
@@ -127,14 +128,12 @@ int LoopbackTerm::read(uint8_t *data, size_t len)
     return read_len;
 }
 
-LoopbackTerm::LoopbackTerm(bool is_bg96): loopback_data(), data_len(0), pin_ok(false), needs_puk(false), is_bg96(is_bg96), inject_by(0)
+LoopbackTerm::LoopbackTerm(bool is_bg96): loopback_data(), data_len(0), pin_ok(false), needs_puk(false), is_bg96(is_bg96), inject_by(0), stopping(false)
 {
-    init_signal();
 }
 
-LoopbackTerm::LoopbackTerm(): loopback_data(), data_len(0), pin_ok(false), needs_puk(false), is_bg96(false), inject_by(0)
+LoopbackTerm::LoopbackTerm(): loopback_data(), data_len(0), pin_ok(false), needs_puk(false), is_bg96(false), inject_by(0), stopping(false)
 {
-    init_signal();
 }
 
 int LoopbackTerm::inject(uint8_t *data, size_t len, size_t injected_by, size_t delay_before, size_t delay_after)
@@ -155,37 +154,34 @@ int LoopbackTerm::inject(uint8_t *data, size_t len, size_t injected_by, size_t d
 
 void LoopbackTerm::batch_read()
 {
-    while (data_len > 0) {
+    while (!stopping && data_len > 0) {
         Task::Delay(delay_before_inject);
         {
-            Scoped<Lock> lock(on_read_guard);
+            // cb_lock is what Terminal uses to serialize (re)assignment of on_read against its
+            // invocation, so holding it here is what makes set_read_cb(nullptr) wait for us
+            Scoped<Lock> lock(cb_lock);
+            if (!on_read) {
+                break;      // callback cleared, nobody would consume the data anymore
+            }
             on_read(nullptr, std::min(inject_by, data_len));
         }
         Task::Delay(delay_after_inject);
     }
-    signal.set(1);
+}
+
+void LoopbackTerm::finish_async()
+{
+    stopping = true;
+    for (auto &result : async_results) {
+        if (result.valid()) {
+            result.wait();
+        }
+    }
+    async_results.clear();
+    data_len = 0;
 }
 
 LoopbackTerm::~LoopbackTerm()
 {
-    data_len = 0;
-    signal.wait(1, INT32_MAX); // wait "very long" to let the std::async() finish
-}
-
-void LoopbackTerm::init_signal()
-{
-    // This indicates, that we can safely exit
-    // we clear the signal upon an async operation, so the destructor needs to wait until
-    // it's finished
-    signal.set(1);
-}
-
-void LoopbackTerm::set_read_cb(std::function<bool(uint8_t *, size_t)> f)
-{
-    user_on_read = std::move(f);
-    on_read = [this](uint8_t *data, size_t len) {
-        auto ret = user_on_read(data, len);
-        signal.set(1);
-        return ret;
-    };
+    finish_async();
 }

--- a/components/esp_modem/test/host_test/main/LoopbackTerm.cpp
+++ b/components/esp_modem/test/host_test/main/LoopbackTerm.cpp
@@ -28,6 +28,7 @@ int LoopbackTerm::write(uint8_t *data, size_t len)
     }
     if (len > 2 && (data[len - 1] == '\r' || data[len - 1] == '+')) {  // Simple AT responder
         std::string command((char *)data, len);
+        last_command = command;
         std::string response;
         if (command == "+++") {
             response = "NO CARRIER\r\n";

--- a/components/esp_modem/test/host_test/main/LoopbackTerm.h
+++ b/components/esp_modem/test/host_test/main/LoopbackTerm.h
@@ -39,6 +39,11 @@ public:
         pin_ok = false;
     }
 
+    const std::string &get_last_command() const
+    {
+        return last_command;
+    }
+
 private:
     enum class status_t {
         STARTED,
@@ -59,5 +64,6 @@ private:
     size_t delay_after_inject;
     std::vector<std::future<void>> async_results;
     Lock on_read_guard;
+    std::string last_command;
 
 };

--- a/components/esp_modem/test/host_test/main/LoopbackTerm.h
+++ b/components/esp_modem/test/host_test/main/LoopbackTerm.h
@@ -5,6 +5,7 @@
  */
 #pragma once
 
+#include <atomic>
 #include "cxx_include/esp_modem_api.hpp"
 #include "cxx_include/esp_modem_terminal.hpp"
 
@@ -31,8 +32,6 @@ public:
 
     int read(uint8_t *data, size_t len) override;
 
-    void set_read_cb(std::function<bool(uint8_t *data, size_t len)> f) override;
-
     void set_sim_puk_locked(bool locked)
     {
         needs_puk = locked;
@@ -50,10 +49,16 @@ private:
         STOPPED
     };
     void batch_read();
-    std::function<bool(uint8_t *data, size_t len)> user_on_read;
+
+    /**
+     * @brief Stops the injection loop and waits for all pending async replies to complete
+     *
+     * Must be called before the read callback's owner (DTE) starts tearing itself down,
+     * so that no callback can fire into a half-destroyed object.
+     */
+    void finish_async();
+
     status_t status;
-    SignalGroup signal;
-    void init_signal();
     std::vector<uint8_t> loopback_data;
     size_t data_len;
     bool pin_ok;
@@ -63,7 +68,7 @@ private:
     size_t delay_before_inject;
     size_t delay_after_inject;
     std::vector<std::future<void>> async_results;
-    Lock on_read_guard;
+    std::atomic<bool> stopping;
     std::string last_command;
 
 };

--- a/components/esp_modem/test/host_test/main/test_modem.cpp
+++ b/components/esp_modem/test/host_test/main/test_modem.cpp
@@ -67,6 +67,45 @@ TEST_CASE("Test polymorphic delete for custom device/dte", "[esp_modem]")
     delete custom_dte;
 }
 
+TEST_CASE("PDP context protocol and CID from DCE config", "[esp_modem]")
+{
+    auto term = std::make_unique<LoopbackTerm>(true);
+    auto loopback = term.get();
+    auto dte = std::make_shared<DTE>(std::move(term));
+    esp_modem_dce_config_t dce_config = ESP_MODEM_DCE_DEFAULT_CONFIG("telstra.internet");
+    dce_config.protocol_type = "IPV6";
+    dce_config.context_id = 3;
+    auto device = std::make_unique<GenericModule>(dte, &dce_config);
+
+    CHECK(device->setup_data_mode());
+    CHECK(loopback->get_last_command() == "AT+CGDCONT=3,\"IPV6\",\"telstra.internet\"\r");
+
+    // set_apn keeps protocol type and CID
+    device->set_apn("other.apn");
+    CHECK(device->setup_data_mode());
+    CHECK(loopback->get_last_command() == "AT+CGDCONT=3,\"IPV6\",\"other.apn\"\r");
+
+    // Full PDP replace (dual stack, default CID)
+    auto new_pdp = std::make_unique<PdpContext>("verizon");
+    new_pdp->protocol_type = "IPV4V6";
+    device->configure_pdp_context(std::move(new_pdp));
+    CHECK(device->setup_data_mode());
+    CHECK(loopback->get_last_command() == "AT+CGDCONT=1,\"IPV4V6\",\"verizon\"\r");
+}
+
+TEST_CASE("PDP context defaults when CID/protocol omitted", "[esp_modem]")
+{
+    auto term = std::make_unique<LoopbackTerm>(true);
+    auto loopback = term.get();
+    auto dte = std::make_shared<DTE>(std::move(term));
+    esp_modem_dce_config_t dce_config = {};
+    dce_config.apn = "internet";
+    auto device = std::make_unique<GenericModule>(dte, &dce_config);
+
+    CHECK(device->setup_data_mode());
+    CHECK(loopback->get_last_command() == "AT+CGDCONT=1,\"IP\",\"internet\"\r");
+}
+
 TEST_CASE("DCE AT parser", "[esp_modem]")
 {
     auto term = std::make_unique<LoopbackTerm>(true);

--- a/docs/esp_modem/en/README.rst
+++ b/docs/esp_modem/en/README.rst
@@ -220,6 +220,20 @@ Is defined using standard configuration structures for ``DTE`` and
 - :cpp:class:``esp_modem_dte_config_t``
 - :cpp:class:``esp_modem_dce_config_t``
 
+The DCE config holds the PDP context used when entering data mode
+(``AT+CGDCONT``): APN, protocol type (``"IP"`` / ``"IPV6"`` / ``"IPV4V6"``),
+and context id (CID). Defaults are IPv4 and CID ``1``. Override at create time:
+
+.. code-block:: c
+
+    esp_modem_dce_config_t dce_config = ESP_MODEM_DCE_DEFAULT_CONFIG("telstra.internet");
+    dce_config.protocol_type = "IPV6";  // or "IPV4V6" for dual stack
+    dce_config.context_id = 3;          // e.g. Verizon
+
+Or update at runtime with ``esp_modem_set_pdp_context()`` (persists for later
+``esp_modem_set_mode(DATA)``). ``esp_modem_set_apn()`` changes only the APN
+and keeps the configured protocol type and CID.
+
 Known issues
 ------------
 


### PR DESCRIPTION
Closes https://github.com/espressif/esp-protocols/issues/1077

* [fix(modem): Make set_apn() update the PDP context](https://github.com/espressif/esp-protocols/pull/1102/changes/b7087f86f34899e05c0d963779e69e0b69ca87f0)
 - The bugfix part

* [feat(modem): Support for custom APN/proto config](https://github.com/espressif/esp-protocols/pull/1102/changes/3684abae0a0d3036fcc7e74f7f535f8cd8d77dea)
 - The feature part

* [fix(modem): Fix test loopback tear-down race](https://github.com/espressif/esp-protocols/pull/1102/changes/6e98171bb4689b4bbfa34eea0866d797a7880426)
 - host test issue in mock-terminal


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect cellular attach (`AT+CGDCONT`) and stored PDP state on every data-mode entry; `set_apn` behavior is intentionally different but fixes a real bug. Teardown fixes are test-only but touch async callback lifetime.
> 
> **Overview**
> **esp_modem 2.1.0** extends cellular attach configuration and fixes how the stored PDP context is updated at runtime.
> 
> **PDP / APN configuration:** `esp_modem_dce_config` and `ESP_MODEM_DCE_DEFAULT_CONFIG` now include **context id (CID)** and **protocol type** (`IP` / `IPV6` / `IPV4V6`), with `0` / `NULL` keeping defaults (1 / `IP`). `GenericModule` applies these when building the internal `PdpContext`, so `setup_data_mode()` emits the matching `AT+CGDCONT`. C API paths (`esp_modem_set_pdp_context`, `esp_modem_sqn_gm02s_connect`) use the same defaulting rules and **persist** the context on the module before sending AT.
> 
> **`set_apn` fix:** New `GenericModule::set_apn()` updates only the APN on the existing PDP context. **`esp_modem_set_apn()`** now calls that instead of replacing the whole context (which previously dropped protocol type and CID). Full PDP changes remain on **`esp_modem_set_pdp_context()`**.
> 
> **Tests / teardown:** Host **`LoopbackTerm`** joins pending `std::async` work in `stop()`/`finish_async()`, uses `cb_lock` and a `stopping` flag to avoid use-after-free when clearing read callbacks, and records **`get_last_command()`** for new PDP host tests. Docs describe runtime vs create-time PDP configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef7991881bcb0486eebb1fd3d248f1853640acdb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->