### PR TITLE
bump(websocket): 1.7.0 -> 1.8.0

### DIFF
--- a/components/esp_websocket_client/.cz.yaml
+++ b/components/esp_websocket_client/.cz.yaml
@@ -3,6 +3,6 @@ commitizen:
   bump_message: 'bump(websocket): $current_version -> $new_version'
   pre_bump_hooks: python ../../ci/changelog.py esp_websocket_client
   tag_format: websocket-v$version
-  version: 1.7.0
+  version: 1.8.0
   version_files:
   - idf_component.yml

--- a/components/esp_websocket_client/CHANGELOG.md
+++ b/components/esp_websocket_client/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [1.8.0](https://github.com/espressif/esp-protocols/commits/websocket-v1.8.0)
+
+### Features
+
+- interruptable wait timeout ([848c6a19](https://github.com/espressif/esp-protocols/commit/848c6a19))
+- expose close status code in event data ([30f69321](https://github.com/espressif/esp-protocols/commit/30f69321))
+
+### Bug Fixes
+
+- set STOPPED_BIT before task create to avoid stop()/destroy() deadlock ([b2b86d73](https://github.com/espressif/esp-protocols/commit/b2b86d73))
+- fix CLOSE_FRAME_SENT_BIT stale on failed send with close_reconnect ([183bd5c7](https://github.com/espressif/esp-protocols/commit/183bd5c7))
+- Fix close function with auto-reconnect-on-close ([be97cd0a](https://github.com/espressif/esp-protocols/commit/be97cd0a))
+- correct IDF version guard for HTTP redirect support ([2500277d](https://github.com/espressif/esp-protocols/commit/2500277d))
+
+### Updated
+
+- docs: fix esp_websocket_client changelog formatting ([8b4db2c2](https://github.com/espressif/esp-protocols/commit/8b4db2c2))
+
 ## [1.7.0](https://github.com/espressif/esp-protocols/commits/websocket-v1.7.0)
 
 ### Features

--- a/components/esp_websocket_client/idf_component.yml
+++ b/components/esp_websocket_client/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.7.0"
+version: "1.8.0"
 description: WebSocket protocol client for ESP-IDF
 url: https://github.com/espressif/esp-protocols/tree/master/components/esp_websocket_client
 dependencies:


### PR DESCRIPTION
1.8.0
Features
- interruptable wait timeout (848c6a19)
- expose close status code in event data (30f69321) 

Bug Fixes
- set STOPPED_BIT before task create to avoid stop()/destroy() deadlock (b2b86d73)
- fix CLOSE_FRAME_SENT_BIT stale on failed send with close_reconnect (183bd5c7)
- Fix close function with auto-reconnect-on-close (be97cd0a)
- correct IDF version guard for HTTP redirect support (2500277d) Updated
- docs: fix esp_websocket_client changelog formatting (8b4db2c2)

<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only release bump with no runtime code changes in this PR.
> 
> **Overview**
> **Release bump** for `esp_websocket_client` from **1.7.0** to **1.8.0** in Commitizen config (`.cz.yaml`), `idf_component.yml`, and `CHANGELOG.md`.
> 
> The new changelog section documents what ships in this tag (already merged elsewhere): **interruptable wait timeout**, **close status code in event data**, lifecycle fixes around **stop/destroy deadlock**, **close_reconnect** / **CLOSE_FRAME_SENT_BIT**, **auto-reconnect-on-close**, and an **IDF version guard** for HTTP redirect support, plus a docs formatting fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9361ab2ea2a9a0b4d73c390c29b3e6187b9953d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->