### PR TITLE
fix(sock_utils): Force vfs_lib linkage for host/tests

### DIFF
--- a/components/sock_utils/test/host/main/CMakeLists.txt
+++ b/components/sock_utils/test/host/main/CMakeLists.txt
@@ -2,5 +2,16 @@ idf_component_register(SRCS "test_sock_utils.cpp"
                         INCLUDE_DIRS "$ENV{IDF_PATH}/tools"
                         WHOLE_ARCHIVE)
 
-target_compile_options(${COMPONENT_LIB} PUBLIC -fsanitize=address -fconcepts)
+target_compile_options(${COMPONENT_LIB} PUBLIC -fsanitize=address)
 target_link_options(${COMPONENT_LIB} PUBLIC -fsanitize=address)
+
+# IDF 6.x Linux: freertos coop syscalls define weak POSIX write/read/… which
+# satisfy the linker before vfs_linux.c (strong VFS overrides) is pulled from
+# libvfs.a. Without those overrides, write()/read() hit libc on lwIP FDs and
+# fail with EBADF (socketpair/pipe tests). Link VFS objects explicitly so the
+# strong symbols win. Not needed on IDF ≤5.5 (no coop weak stubs).
+set(_coop_syscalls "$ENV{IDF_PATH}/components/freertos/FreeRTOS-Kernel/portable/linux/utils/linux_port_coop_syscalls.c")
+if(EXISTS "${_coop_syscalls}")
+    idf_component_get_property(vfs_lib vfs COMPONENT_LIB)
+    target_link_libraries(${COMPONENT_LIB} INTERFACE "$<TARGET_OBJECTS:${vfs_lib}>")
+endif()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only CMake/linker tweak for the Linux host target; no firmware or runtime behavior change on device.
> 
> **Overview**
> Fixes **Linux host** `sock_utils` tests on **IDF 6.x** where `socketpair`/`pipe` cases failed with **EBADF** because weak FreeRTOS coop `read`/`write` stubs were linked before the strong **VFS** overrides in `vfs_linux.c`.
> 
> When `linux_port_coop_syscalls.c` is present, the test component now links **VFS object files** explicitly so VFS wins at link time. The change is gated behind that file existing, so **IDF ≤5.5** builds are unchanged.
> 
> Also drops **`-fconcepts`** from the host test compile flags (AddressSanitizer flags stay).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3edaa261f2a4903012da25324247dd6cbcfc0991. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->