### PR TITLE
bump(aft_netif): Initial release v4.4.0

### DIFF
--- a/.github/workflows/publish-docs-component.yml
+++ b/.github/workflows/publish-docs-component.yml
@@ -108,5 +108,6 @@ jobs:
             components/esp_dns;
             components/net_connect;
             components/libsrtp;
+            components/freertos_tcp;
           namespace: "espressif"
           api_token: ${{ secrets.IDF_COMPONENT_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -82,3 +82,7 @@ Please refer to instructions in [ESP-IDF](https://github.com/espressif/esp-idf)
 ### libsrtp
 
 * Brief introduction [README](components/libsrtp/README.md)
+
+### freertos_tcp
+
+* Brief introduction [README](components/freertos_tcp/README.md)

--- a/components/freertos_tcp/.cz.yaml
+++ b/components/freertos_tcp/.cz.yaml
@@ -1,0 +1,8 @@
+---
+commitizen:
+  bump_message: 'bump(aft_netif): $current_version -> $new_version'
+  pre_bump_hooks: python ../../ci/changelog.py freertos_tcp
+  tag_format: aft_netif-v$version
+  version: 4.4.0
+  version_files:
+  - idf_component.yml

--- a/components/freertos_tcp/CHANGELOG.md
+++ b/components/freertos_tcp/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## [4.4.0](https://github.com/espressif/esp-protocols/commits/aft_netif-v4.4.0)
+
+### Features
+
+- Introduction of esp_netif with FreeRTOS+TCP stack ([2a8f84f0](https://github.com/espressif/esp-protocols/commit/2a8f84f0))

--- a/components/freertos_tcp/LICENSE.txt
+++ b/components/freertos_tcp/LICENSE.txt
@@ -1,0 +1,3 @@
+This project is licensed under the MIT and Apache-2.0
+* Upstream FreeRTOS-Plus-TCP is licensed under the MIT license: [FreeRTOS-Plus-TCP](./FreeRTOS-Plus-TCP/LICENSE.md)
+* Port layer/esp_netif is licensed under Apache-2.0

--- a/components/freertos_tcp/README.md
+++ b/components/freertos_tcp/README.md
@@ -27,8 +27,8 @@ ESP-IDF port of Amazon FreeRTOS-Plus-TCP - a lightweight TCP/IP stack providing 
 
 This component integrates [FreeRTOS-Plus-TCP](https://github.com/FreeRTOS/FreeRTOS-Plus-TCP) as a custom TCP/IP stack for ESP-IDF. It provides a Berkeley sockets-like interface with fully scalable features and RAM footprint, making it suitable for various ESP32 applications.
 
-**Version**: 0.1.0
-**Minimum ESP-IDF**: 5.0
+**Version**: 4.4.0
+**Minimum ESP-IDF**: 5.5
 
 ## Architecture
 

--- a/components/freertos_tcp/idf_component.yml
+++ b/components/freertos_tcp/idf_component.yml
@@ -1,6 +1,23 @@
-version: 0.1.0
+version: "4.4.0"
+description: "ESP-IDF port of FreeRTOS-Plus-TCP — lightweight TCP/IP stack as an alternative to lwIP."
 url: https://github.com/espressif/esp-protocols/tree/master/components/freertos_tcp
-description: The component provides FreeRTOS-plus-TCP port as a custom TCP/IP stack to esp-idf
+issues: https://github.com/espressif/esp-protocols/issues
+documentation: https://github.com/espressif/esp-protocols/blob/master/components/freertos_tcp/README.md
+repository: https://github.com/espressif/esp-protocols.git
+tags:
+  - freertos
+  - tcp
+  - freertos-plus-tcp
 dependencies:
   idf:
-    version: '>=5.0'
+    version: '>=5.5'
+
+# Files excluded from the registry tarball (saves bytes, avoids confusion).
+files:
+  exclude:
+    - "FreeRTOS-Plus-TCP/test/**"
+    - "FreeRTOS-Plus-TCP/tools/**"
+    - "FreeRTOS-Plus-TCP/docs/**"
+    - "FreeRTOS-Plus-TCP/**/.git*"
+    - "test_app/build*"
+    - "examples/*/build*"


### PR DESCRIPTION
## 4.4.0

### Features
- Introduction of esp_netif with FreeRTOS+TCP stack (2a8f84f0)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release and documentation/CI wiring only; no runtime or networking code changes in this diff.
> 
> **Overview**
> **Initial registry release** for the FreeRTOS-Plus-TCP / `esp_netif` component at **v4.4.0**, aligned with upstream FreeRTOS-Plus-TCP v4.4.0.
> 
> Adds **Commitizen** config (`.cz.yaml`, tag `aft_netif-v$version`), **CHANGELOG**, and **LICENSE** text. Updates **`idf_component.yml`**: version `4.4.0`, richer registry metadata (description, tags, issues/docs URLs), **minimum ESP-IDF `>=5.5`** (was `>=5.0`), and **tarball excludes** for upstream tests/tools/docs and local build dirs.
> 
> **README** version/IDF minimum match the manifest. Root **README** links the component; **publish-docs-component** workflow now uploads `components/freertos_tcp` with the other Espressif components.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68b8f131cc2fa12672b1b239b697f29178ae2272. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->