### PR TITLE
fix(modem): UartTerminal::on_read usage/set data race

### DIFF
--- a/components/esp_modem/src/esp_modem_uart.cpp
+++ b/components/esp_modem/src/esp_modem_uart.cpp
@@ -13,6 +13,7 @@
 #include "esp_modem_config.h"
 #include "exception_stub.hpp"
 #include "cxx_include/esp_modem_dte.hpp"
+#include "cxx_include/esp_modem_primitives.hpp"
 #include "uart_resource.hpp"
 
 static const char *TAG = "uart_terminal";
@@ -64,6 +65,7 @@ public:
 
     void set_read_cb(std::function<bool(uint8_t *data, size_t len)> f) override
     {
+        Scoped<Lock> lock(on_read_lock);
         on_read = std::move(f);
     }
 
@@ -95,6 +97,10 @@ private:
     QueueHandle_t event_queue;
     uart_resource uart;
     SignalGroup signal;
+    /// Mutex to protect on_read callback from being updated while being called in \c task.
+    /// Must be recursive as the on_read callback may call set_read_cb to change the callback while being called.
+    /// Declared before task_handle so it outlives the UART task.
+    Lock on_read_lock;
     uart_task task_handle;
 };
 
@@ -121,8 +127,13 @@ void UartTerminal::task()
             switch (event.type) {
             case UART_DATA:
                 uart_get_buffered_data_len(uart.port, &len);
-                if (len && on_read) {
-                    on_read(nullptr, len);
+                {
+                    // Lock on_read_lock while checking and calling on_read to
+                    // prevent data-race between check and call
+                    Scoped<Lock> lock(on_read_lock);
+                    if (len && on_read) {
+                        on_read(nullptr, len);
+                    }
                 }
                 break;
             case UART_FIFO_OVF:
@@ -163,6 +174,8 @@ void UartTerminal::task()
             }
         } else {
             uart_get_buffered_data_len(uart.port, &len);
+
+            Scoped<Lock> lock(on_read_lock);
             if (len && on_read) {
                 on_read(nullptr, len);
             }


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

While testing esp_modem (v2.0.2) with a SIM7080 and ESP32-S3 I reproducibly got several crashes while calling `esp_modem_set_mode`. The stack traces showed either double-free or segfault. Further debugging with `CONFIG_HEAP_POISONING_COMPREHENSIVE` narrowed the problem down to this [`on_read()`](https://github.com/espressif/esp-protocols/blob/62cc0482b2ea077a0e1a25e306c2bd4e64fea258/components/esp_modem/src/esp_modem_uart.cpp#L125) callback being invoked even after it had already been set to `nullptr`.
The problem seems to originate from a data race where [`set_read_cb`](https://github.com/espressif/esp-protocols/blob/62cc0482b2ea077a0e1a25e306c2bd4e64fea258/components/esp_modem/src/esp_modem_uart.cpp#L65) is called between the check before usage of `on_read` and the call of `on_read`.

This PR fixes this issue by locking a mutex when `on_read` is either set or used.

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

A quick search found #1014 to be related: this bug is marked as `UART-003` but not fixed in the PR. I found no further mention of this bug.

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

Only manual testing pre- and post-fixing were done due to the bug being complex to test. The bug has not yet occurred after the fix and thorough manual testing.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches concurrency on the UART RX hot path; incorrect locking could deadlock or stall modem I/O, but the change is narrowly scoped and matches existing esp_modem Lock primitives.
> 
> **Overview**
> Fixes crashes during `esp_modem_set_mode` caused by a race: the UART task could invoke `on_read` after another thread cleared it via `set_read_cb`.
> 
> **UartTerminal** now holds a recursive `Lock` (`on_read_lock`) declared before the UART task so it outlives the task. `set_read_cb` takes the lock while swapping the callback; the UART `task` loop takes the same lock around the null-check and invocation of `on_read` on both the `UART_DATA` path and the polling timeout path. Recursion is required because `on_read` may call `set_read_cb` re-entrantly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cebfab0eb16f00b8c5f860cdc055d6caef726fb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->