### PR TITLE
feat(libsrtp): bump submodule for mbedTLS 4 support; allow IDF v6.0

### DIFF
--- a/.github/workflows/libsrtp__build.yml
+++ b/.github/workflows/libsrtp__build.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        idf_ver: ["release-v5.4", "release-v5.5"]
+        idf_ver: ["release-v5.4", "release-v5.5", "release-v6.0"]
         app:
           - { name: "get_started",  path: "components/libsrtp/examples/get_started" }
           - { name: "test_apps",    path: "components/libsrtp/test_apps" }

--- a/components/libsrtp/.build-test-rules.yml
+++ b/components/libsrtp/.build-test-rules.yml
@@ -5,11 +5,9 @@
 # disable rules below skip the build on older IDF releases so the repo-wide
 # CI matrix (v5.1 / v5.2 / v5.3 / v5.4 / v5.5 / latest) doesn't try them.
 #
-# IDF v6+ is also disabled for now: libsrtp 2.x's mbedTLS adapters
-# (aes_gcm_mbedtls.c, aes_icm_mbedtls.c, hmac_mbedtls.c) include the
-# classic <mbedtls/aes.h> / <mbedtls/gcm.h> headers which moved under the
-# TF-PSA-Crypto split in mbedTLS 4.x (shipped by IDF v6+). Re-enable once
-# libsrtp adapts or we ship a port-side compatibility shim.
+# IDF v6+ (mbedTLS 4.x) is supported: the submodule pin (2_x_dev,
+# post-v2.8.0) carries mbedTLS 4 / PSA Crypto adapters (cisco/libsrtp#813)
+# which self-select on MBEDTLS_VERSION_MAJOR.
 
 components/libsrtp/examples/get_started:
   enable:
@@ -18,8 +16,6 @@ components/libsrtp/examples/get_started:
   disable:
     - if: IDF_VERSION_MAJOR <= 5 and IDF_VERSION_MINOR < 4
       reason: "libsrtp requires ESP-IDF 5.4+."
-    - if: IDF_VERSION_MAJOR >= 6
-      reason: "libsrtp 2.x mbedTLS adapters not yet ported to mbedTLS 4.x (TF-PSA-Crypto split)."
 
 components/libsrtp/test_apps:
   enable:
@@ -28,8 +24,6 @@ components/libsrtp/test_apps:
   disable:
     - if: IDF_VERSION_MAJOR <= 5 and IDF_VERSION_MINOR < 4
       reason: "libsrtp requires ESP-IDF 5.4+."
-    - if: IDF_VERSION_MAJOR >= 6
-      reason: "libsrtp 2.x mbedTLS adapters not yet ported to mbedTLS 4.x (TF-PSA-Crypto split)."
 
 components/libsrtp/host_test:
   enable:
@@ -39,4 +33,4 @@ components/libsrtp/host_test:
     - if: IDF_VERSION_MAJOR <= 5 and IDF_VERSION_MINOR < 4
       reason: "libsrtp requires ESP-IDF 5.4+."
     - if: IDF_VERSION_MAJOR >= 6
-      reason: "libsrtp 2.x mbedTLS adapters not yet ported to mbedTLS 4.x (TF-PSA-Crypto split)."
+      reason: "IDF v6 linux target fails to link PSA apps: libtfpsacrypto.a needs mbedtls_ms_time/esp_mbedtls_mem_* from archives earlier on the link line (IDF-side ordering issue, not libsrtp)."

--- a/components/libsrtp/.cz.yaml
+++ b/components/libsrtp/.cz.yaml
@@ -3,6 +3,6 @@ commitizen:
   bump_message: 'bump(libsrtp): $current_version -> $new_version'
   pre_bump_hooks: python ../../ci/changelog.py libsrtp
   tag_format: libsrtp-v$version
-  version: 2.8.0
+  version: 2.8.0~1
   version_files:
   - idf_component.yml

--- a/components/libsrtp/CHANGELOG.md
+++ b/components/libsrtp/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.8.0~1](https://github.com/espressif/esp-protocols/commits/libsrtp-v2.8.0_1)
+
+### Features
+
+- bump submodule for mbedTLS 4 support; allow IDF v6.0 ([0174d34a](https://github.com/espressif/esp-protocols/commit/0174d34a))
+
 ## [2.8.0](https://github.com/espressif/esp-protocols/commits/libsrtp-v2.8.0)
 
 ### Features

--- a/components/libsrtp/idf_component.yml
+++ b/components/libsrtp/idf_component.yml
@@ -11,12 +11,11 @@ tags:
   - webrtc
   - mbedtls
 dependencies:
-  # Upper bound is intentional. libsrtp v2.x's mbedTLS adapters use the
-  # legacy <mbedtls/aes.h> / <mbedtls/gcm.h> headers; ESP-IDF v6 ships
-  # mbedTLS 4 which reorganised those into the TF-PSA-Crypto split.
-  # Bump the bound once the component tracks a libsrtp release that
-  # speaks mbedTLS 4 (see cisco/libsrtp#812 for context).
-  idf: ">=5.4,<6"
+  # The submodule pin (2_x_dev, post-v2.8.0) carries mbedTLS 4 / PSA
+  # Crypto support (cisco/libsrtp#813), so ESP-IDF v6 (mbedTLS 4) is
+  # supported alongside v5.x (mbedTLS 3) — the adapters self-select on
+  # MBEDTLS_VERSION_MAJOR.
+  idf: ">=5.4"
 
 # SBOM manifest for the wrapped upstream — see sbom_libsrtp.yml.
 sbom:

--- a/components/libsrtp/idf_component.yml
+++ b/components/libsrtp/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.8.0"
+version: "2.8.0~1"
 description: "libsrtp (Cisco) wrapper for ESP-IDF — mbedTLS crypto backend with AES-GCM + AES-CM + HMAC-SHA1. SRTP/SRTCP packet protection for WebRTC and other RTP-based protocols."
 url: https://github.com/espressif/esp-protocols/tree/master/components/libsrtp
 issues: https://github.com/espressif/esp-protocols/issues

--- a/components/libsrtp/sbom_libsrtp.yml
+++ b/components/libsrtp/sbom_libsrtp.yml
@@ -2,9 +2,9 @@ name: libsrtp
 version: 2.8.0
 cpe: cpe:2.3:a:cisco:libsrtp:{}:*:*:*:*:*:*:*
 supplier: 'Organization: Cisco Systems, Inc. <https://github.com/cisco/libsrtp>'
-description: Library for the Secure Real-time Transport Protocol (SRTP, RFC 3711) and Secure RTCP (SRTCP). Submodule pinned at upstream release tag v2.8.0 (commit 24b3bf8). One small ESP-IDF specific delta lives in port/crypto_kernel.c — it opts out of the AES-ICM-192 cipher registration when GCM is enabled (saves binary size; AES-CM-128 and AES-GCM cover all WebRTC SRTP suites).
+description: Library for the Secure Real-time Transport Protocol (SRTP, RFC 3711) and Secure RTCP (SRTCP). Submodule pinned at upstream 2_x_dev commit d33b8ff (post-v2.8.0; adds mbedTLS 4 / PSA Crypto support, cisco/libsrtp#813). One small ESP-IDF specific delta lives in port/crypto_kernel.c — it opts out of the AES-ICM-192 cipher registration when GCM is enabled (saves binary size; AES-CM-128 and AES-GCM cover all WebRTC SRTP suites).
 url: https://github.com/cisco/libsrtp
-hash: 24b3bf8f19b6f5ab4cd2bcceb4f4064efca86fd5
+hash: d33b8ffb1491a0b4b58a206889f09800cf7310ab
 cve-exclude-list:
   - cve: CVE-2023-31222
     reason: Resolved in 2.6.0; current pin (v2.8.0) is well past.


### PR DESCRIPTION
## Summary

- Bump **libsrtp** submodule from the `v2.8.0` release tag (`24b3bf8`) to **`2_x_dev` HEAD `d33b8ff`** — the merge of cisco/libsrtp#813, which adds **mbedTLS 4 / PSA Crypto support** to the 2.x mbedTLS adapters. The adapters self-select on `MBEDTLS_VERSION_MAJOR`, so mbedTLS 3 (IDF v5.x) code paths are untouched.
- Drop the **`idf <6`** cap from `idf_component.yml` — this was gated on exactly this upstream work (the manifest comment referenced cisco/libsrtp#812). Component version `2.8.0` → `2.8.0~1`.
- CI: build `get_started` + `test_apps` on **release-v6.0** in addition to v5.4/v5.5.

## Verification

- `test_apps` builds clean on **IDF v6.0.2** (target esp32, mbedTLS 4.1.0) — full link, exit 0.
- mbedTLS 4 runtime behaviour is covered upstream by cisco/libsrtp#813's CI (srtp_driver roundtrips against mbedTLS 4.1.0); the mbedTLS 3 path continues to be exercised by this repo's host_test on v5.4/v5.5.

## Notes

- **host_test stays on IDF v5.x**: the IDF v6 linux target currently fails to link any PSA-using app — `libtfpsacrypto.a` references `mbedtls_ms_time` / `esp_mbedtls_mem_*` that live in archives earlier on the link line (static archive ordering, IDF-side; reproduced with IDF's own libs, independent of libsrtp). `.build-test-rules.yml` documents this next to the disable rule.
- No upstream 2.x release tag carries cisco/libsrtp#813 yet (latest is v2.8.0), so this pins the merge commit by SHA; switch to the tag when upstream cuts v2.8.1 / v2.9.
- Sequenced after #1060 (component introduction, merged).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches SRTP crypto integration and moves off a release tag to a dev commit; scope is mostly CI/manifest with upstream adapters handling mbedTLS 3 vs 4.
> 
> **Overview**
> **Enables the libsrtp ESP-IDF component on ESP-IDF v6** by advancing the upstream submodule pin from **v2.8.0** to **`2_x_dev` `d33b8ff`** (cisco/libsrtp#813), which adds mbedTLS 4 / PSA Crypto adapters that pick paths at compile time via `MBEDTLS_VERSION_MAJOR`.
> 
> The manifest **`idf: ">=5.4,<6"`** upper bound is removed so v6 is allowed; component version is **`2.8.0~1`** with SBOM/metadata updated for the new pin. **CI** builds `get_started` and `test_apps` on **`release-v6.0`**, and **`.build-test-rules.yml`** no longer skips v6 for those apps. **`host_test` remains disabled on IDF v6** with a clarified reason (IDF linux link ordering for PSA apps, not libsrtp).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf40da3095fe18f249a01ec04b8168e25fa29012. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->