### PR TITLE
feat(websocket): add PSRAM allocation options

### DIFF
--- a/components/esp_websocket_client/Kconfig
+++ b/components/esp_websocket_client/Kconfig
@@ -20,4 +20,46 @@ menu "ESP WebSocket client"
         default 2000
         help
             Timeout for acquiring the TX lock when using separate TX lock.
+    config ESP_WS_CLIENT_ALLOC_IN_EXT_RAM
+        bool "Allocate WebSocket client structures in PSRAM"
+        default n
+        depends on SPIRAM
+        depends on (SPIRAM_USE_CAPS_ALLOC || SPIRAM_USE_MALLOC)
+        help
+            Allocate the main esp_websocket_client structure and its internal
+            configuration storage in external RAM (PSRAM).
+
+            This option does not move duplicated configuration strings, RX/TX
+            buffers, transports, event groups, mutexes, or other internal
+            allocations to PSRAM.
+
+            If PSRAM allocation fails, esp_websocket_client_init() returns NULL.
+            There is no fallback to internal RAM.
+
+    config ESP_WS_CLIENT_TASK_STACK_IN_EXT_RAM
+        bool "Allocate WebSocket task stack in PSRAM"
+        default n
+        depends on SPIRAM
+        depends on (SPIRAM_USE_CAPS_ALLOC || SPIRAM_USE_MALLOC)
+        depends on FREERTOS_SUPPORT_STATIC_ALLOCATION
+        depends on (FREERTOS_TASK_CREATE_ALLOW_EXT_MEM || SPIRAM_ALLOW_STACK_EXTERNAL_MEMORY)
+        help
+            Allocate the WebSocket task stack in external RAM (PSRAM) using
+            xTaskCreatePinnedToCoreWithCaps().
+
+            Only the task stack is allocated in PSRAM. The task control block
+            (TCB) remains in internal RAM.
+
+            This implementation requires ESP-IDF v5.3.1 or newer because the
+            WebSocket task self-deletes using vTaskDeleteWithCaps(NULL).
+
+            If PSRAM stack allocation fails,
+            esp_websocket_client_start() returns ESP_FAIL. There is no fallback
+            to an internal-RAM task stack.
+
+            External memory is inaccessible while the flash cache is disabled, so with this option
+            the WebSocket task must not run any code that disables the cache. In particular, flash and
+            NVS operations, and entering deep or light sleep, are not allowed from the WebSocket task
+            context. This includes user code running in an event handler dispatched by the WebSocket
+            task.
 endmenu

--- a/components/esp_websocket_client/esp_websocket_client.c
+++ b/components/esp_websocket_client/esp_websocket_client.c
@@ -6,6 +6,7 @@
 
 #include <stdio.h>
 
+#include "esp_heap_caps.h"
 #include "esp_websocket_client.h"
 #include "esp_transport.h"
 #include "esp_transport_tcp.h"
@@ -24,6 +25,30 @@
 #include <arpa/inet.h>
 
 static const char *TAG = "websocket_client";
+
+#define ESP_WS_CLIENT_EXT_RAM_CAPS (MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT)
+
+#ifdef CONFIG_ESP_WS_CLIENT_ALLOC_IN_EXT_RAM
+#define ESP_WS_CLIENT_OBJ_MEMORY ESP_WS_CLIENT_EXT_RAM_CAPS
+#else
+#define ESP_WS_CLIENT_OBJ_MEMORY MALLOC_CAP_DEFAULT
+#endif
+
+#ifdef CONFIG_ESP_WS_CLIENT_TASK_STACK_IN_EXT_RAM
+#define ESP_WS_CLIENT_TASK_STACK_ON_EXTERNAL_MEMORY 1
+#else
+#define ESP_WS_CLIENT_TASK_STACK_ON_EXTERNAL_MEMORY 0
+#endif
+
+/* The PSRAM task-stack option relies on the capability-aware FreeRTOS helpers
+ * xTaskCreatePinnedToCoreWithCaps() / vTaskDeleteWithCaps() so that IDF owns the
+ * stack (PSRAM) and TCB (internal RAM) allocations. ESP-IDF v5.3.1 or newer is
+ * required because it supports safe WithCaps self-deletion. */
+#if ESP_WS_CLIENT_TASK_STACK_ON_EXTERNAL_MEMORY
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 3, 1)
+#error "CONFIG_ESP_WS_CLIENT_TASK_STACK_IN_EXT_RAM requires ESP-IDF v5.3.1 or newer."
+#endif
+#endif
 
 #define WEBSOCKET_TCP_DEFAULT_PORT      (80)
 #define WEBSOCKET_SSL_DEFAULT_PORT      (443)
@@ -488,7 +513,7 @@ static esp_err_t esp_websocket_client_destroy_config(esp_websocket_client_handle
     free(cfg->user_agent);
     free(cfg->headers);
     memset(cfg, 0, sizeof(websocket_config_storage_t));
-    free(client->config);
+    heap_caps_free(client->config);
     client->config = NULL;
     return ESP_OK;
 }
@@ -535,7 +560,7 @@ static void destroy_and_free_resources(esp_websocket_client_handle_t client)
         vEventGroupDelete(client->status_bits);
         client->status_bits = NULL;
     }
-    free(client);
+    heap_caps_free(client);
     client = NULL;
 }
 
@@ -554,7 +579,6 @@ static esp_err_t stop_wait_task(esp_websocket_client_handle_t client)
     client->state = WEBSOCKET_STATE_UNKNOW;
     return ESP_OK;
 }
-
 #if WS_TRANSPORT_HEADER_CALLBACK_SUPPORT
 static void websocket_header_hook(void * client, const char * line, int line_len)
 {
@@ -785,7 +809,7 @@ unlock_and_return:
 
 esp_websocket_client_handle_t esp_websocket_client_init(const esp_websocket_client_config_t *config)
 {
-    esp_websocket_client_handle_t client = calloc(1, sizeof(struct esp_websocket_client));
+    esp_websocket_client_handle_t client = heap_caps_calloc(1, sizeof(struct esp_websocket_client), ESP_WS_CLIENT_OBJ_MEMORY);
     ESP_WS_CLIENT_MEM_CHECK(TAG, client, return NULL);
 
     esp_event_loop_args_t event_args = {
@@ -795,7 +819,7 @@ esp_websocket_client_handle_t esp_websocket_client_init(const esp_websocket_clie
 
     if (esp_event_loop_create(&event_args, &client->event_handle) != ESP_OK) {
         ESP_LOGE(TAG, "Error create event handler for websocket client");
-        free(client);
+        heap_caps_free(client);
         return NULL;
     }
 
@@ -820,7 +844,7 @@ esp_websocket_client_handle_t esp_websocket_client_init(const esp_websocket_clie
     ESP_WS_CLIENT_MEM_CHECK(TAG, client->tx_lock, goto _websocket_init_fail);
 #endif
 
-    client->config = calloc(1, sizeof(websocket_config_storage_t));
+    client->config = heap_caps_calloc(1, sizeof(websocket_config_storage_t), ESP_WS_CLIENT_OBJ_MEMORY);
     ESP_WS_CLIENT_MEM_CHECK(TAG, client->config, goto _websocket_init_fail);
 
     if (config->transport == WEBSOCKET_TRANSPORT_OVER_TCP) {
@@ -1450,7 +1474,13 @@ static void esp_websocket_client_task(void *pv)
     } else {
         xEventGroupSetBits(client->status_bits, STOPPED_BIT);
     }
+#if ESP_WS_CLIENT_TASK_STACK_ON_EXTERNAL_MEMORY
+    /* A task created with xTaskCreatePinnedToCoreWithCaps() must be deleted
+     * with vTaskDeleteWithCaps(). */
+    vTaskDeleteWithCaps(NULL);
+#else
     vTaskDelete(NULL);
+#endif
 }
 
 esp_err_t esp_websocket_client_start(esp_websocket_client_handle_t client)
@@ -1458,6 +1488,7 @@ esp_err_t esp_websocket_client_start(esp_websocket_client_handle_t client)
     if (client == NULL) {
         return ESP_ERR_INVALID_ARG;
     }
+
     if (client->state >= WEBSOCKET_STATE_INIT) {
         ESP_LOGE(TAG, "The client has started");
         return ESP_FAIL;
@@ -1472,8 +1503,28 @@ esp_err_t esp_websocket_client_start(esp_websocket_client_handle_t client)
     }
 
     xEventGroupClearBits(client->status_bits, STOPPED_BIT | CLOSE_FRAME_SENT_BIT | REQUESTED_STOP_BIT | WAKEUP_BIT);
-    if (xTaskCreatePinnedToCore(esp_websocket_client_task, client->config->task_name ? client->config->task_name : "websocket_task",
-                                client->config->task_stack, client, client->config->task_prio, &client->task_handle, client->config->task_core_id) != pdTRUE) {
+
+    client->task_handle = NULL;
+    BaseType_t res;
+#if ESP_WS_CLIENT_TASK_STACK_ON_EXTERNAL_MEMORY
+    /* Let FreeRTOS allocate the task stack in PSRAM. The TCB remains in
+     * internal RAM. There is no fallback to internal RAM if allocation fails. */
+    res = xTaskCreatePinnedToCoreWithCaps(
+              esp_websocket_client_task,
+              client->config->task_name ? client->config->task_name : "websocket_task",
+              client->config->task_stack,
+              client,
+              client->config->task_prio,
+              &client->task_handle,
+              client->config->task_core_id,
+              ESP_WS_CLIENT_EXT_RAM_CAPS);
+#else
+    res = xTaskCreatePinnedToCore(esp_websocket_client_task, client->config->task_name ? client->config->task_name : "websocket_task",
+                                  client->config->task_stack, client, client->config->task_prio, &client->task_handle, client->config->task_core_id);
+#endif
+
+    if (res != pdPASS) {
+        client->task_handle = NULL;
         ESP_LOGE(TAG, "Error create websocket task");
         xEventGroupSetBits(client->status_bits, STOPPED_BIT);
         return ESP_FAIL;


### PR DESCRIPTION
Add Kconfig options for PSRAM allocations in esp_websocket_client, including external-memory task stack gating with FREERTOS_TASK_CREATE_ALLOW_EXT_MEM.

# Related
This PR builds on https://github.com/espressif/esp-protocols/pull/980 and simplifies the external task-stack implementation.




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> PSRAM task stacks impose cache-disabled constraints on WebSocket task and event-handler code; misconfiguration can cause subtle runtime faults, though options are off by default and failures fail closed without internal-RAM fallback.
> 
> **Overview**
> Adds optional **PSRAM** placement for `esp_websocket_client` to reduce internal RAM use on SPIRAM-enabled builds.
> 
> **`ESP_WS_CLIENT_ALLOC_IN_EXT_RAM`** moves the main client object and its `websocket_config_storage_t` to PSRAM via `heap_caps_calloc` / `heap_caps_free` (no fallback—`esp_websocket_client_init()` returns NULL on failure). Other allocations (strings, RX/TX buffers, transports, mutexes, etc.) stay on internal RAM.
> 
> **`ESP_WS_CLIENT_TASK_STACK_IN_EXT_RAM`** creates the WebSocket worker with `xTaskCreatePinnedToCoreWithCaps()` so only the **stack** lives in PSRAM (TCB stays internal). The task exits with `vTaskDeleteWithCaps(NULL)`; this path requires **ESP-IDF ≥ 5.3.1** (compile-time `#error` otherwise). Failed stack allocation makes `esp_websocket_client_start()` return `ESP_FAIL`. Kconfig documents cache-off restrictions for code running on that task (including event handlers).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25129502bb11a0b8328b41bc20e656de1eea1def. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->