### PR TITLE
fix(mosquitto): Fix mosquitto teardown race with lwt

### DIFF
--- a/components/mosquitto/.cz.yaml
+++ b/components/mosquitto/.cz.yaml
@@ -3,6 +3,6 @@ commitizen:
   bump_message: 'bump(mosq): $current_version -> $new_version'
   pre_bump_hooks: python ../../ci/changelog.py mosquitto
   tag_format: mosq-v$version
-  version: 2.0.20~8
+  version: 2.0.20~9
   version_files:
   - idf_component.yml

--- a/components/mosquitto/CHANGELOG.md
+++ b/components/mosquitto/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.0.20~9](https://github.com/espressif/esp-protocols/commits/mosq-v2.0.20_9)
+
+### Bug Fixes
+
+- Fix mosquitto teardown race with lwt ([92bead15](https://github.com/espressif/esp-protocols/commit/92bead15))
+- Remove __ctype_lookup config as it's supported in IDF ([1ee7f2f3](https://github.com/espressif/esp-protocols/commit/1ee7f2f3))
+
 ## [2.0.20~8](https://github.com/espressif/esp-protocols/commits/mosq-v2.0.20_8)
 
 ### Bug Fixes

--- a/components/mosquitto/CMakeLists.txt
+++ b/components/mosquitto/CMakeLists.txt
@@ -95,6 +95,8 @@ target_compile_options(${COMPONENT_LIB} PRIVATE "-Wno-format")
 # Enable linker wrapping for mosquitto_unpwd_check to allow connection callback interception
 # without modifying upstream code
 target_link_options(${COMPONENT_LIB} INTERFACE "-Wl,--wrap=mosquitto_unpwd_check")
+# Defer mux__cleanup until after post-loop Will delivery in port/broker.c
+target_link_options(${COMPONENT_LIB} INTERFACE "-Wl,--wrap=mux__cleanup")
 
 if(${idf_target} STREQUAL "linux")
     target_link_options(${COMPONENT_LIB} INTERFACE "-Wl,--wrap=main")

--- a/components/mosquitto/idf_component.yml
+++ b/components/mosquitto/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.0.20~8"
+version: "2.0.20~9"
 url: https://github.com/espressif/esp-protocols/tree/master/components/mosquitto
 description: The component provides a simple ESP32 port of mosquitto broker
 dependencies:

--- a/components/mosquitto/port/broker.c
+++ b/components/mosquitto/port/broker.c
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
- * SPDX-FileContributor: 2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileContributor: 2024-2026 Espressif Systems (Shanghai) CO LTD
  */
 #include "mosquitto.h"
 #include "mosquitto_broker_internal.h"
@@ -110,6 +110,30 @@ void mosq_broker_stop(void)
 extern mosq_message_cb_t g_mosq_message_callback;
 extern mosq_connect_cb_t g_mosq_connect_callback;
 
+/*
+ * mosquitto_main_loop() calls mux__cleanup() as its final action, which frees
+ * the pollfd table. mosq_broker_run() then delivers Last-Will messages, and
+ * packet__write() -> mux__add_out() would NULL-deref on the poll backend.
+ * Defer the real cleanup until after Will delivery (linker --wrap).
+ */
+static int s_mux_cleanup_deferred;
+
+int __real_mux__cleanup(void);
+
+int __wrap_mux__cleanup(void)
+{
+    s_mux_cleanup_deferred = 1;
+    return MOSQ_ERR_SUCCESS;
+}
+
+static void mux_cleanup_deferred_run(void)
+{
+    if (s_mux_cleanup_deferred) {
+        s_mux_cleanup_deferred = 0;
+        (void)__real_mux__cleanup();
+    }
+}
+
 int mosq_broker_run(struct mosq_broker_config *broker_config)
 {
 
@@ -184,6 +208,9 @@ int mosq_broker_run(struct mosq_broker_config *broker_config)
         context__send_will(ctxt);
     }
     will_delay__send_all();
+
+    /* Tear down mux after Will delivery (see __wrap_mux__cleanup). */
+    mux_cleanup_deferred_run();
 
 #ifdef WITH_PERSISTENCE
     persist__backup(true);

--- a/components/mosquitto/port/priv_include/config.h
+++ b/components/mosquitto/port/priv_include/config.h
@@ -21,4 +21,4 @@
 #include "net/if.h"
 #include "esp_idf_version.h"
 
-#define VERSION "v2.0.20~8"
+#define VERSION "v2.0.20~9"

--- a/components/mosquitto/test/README.md
+++ b/components/mosquitto/test/README.md
@@ -2,7 +2,9 @@
 
 ## Host test
 
-A simple Catch2 unit test runs on Linux and verifies the broker can start and stop. Build and run:
+A Catch2 unit test runs on Linux and verifies the broker can start, stop, restart,
+and shut down cleanly while clients with a Last-Will and matching subscribers are
+still connected. Build and run:
 
 ```bash
 cd host_test

--- a/components/mosquitto/test/host_test/main/test_mosq.cpp
+++ b/components/mosquitto/test/host_test/main/test_mosq.cpp
@@ -7,14 +7,208 @@
 #include <chrono>
 #include <cstdlib>
 #include <cstdio>
+#include <cstring>
+#include <vector>
+
+#include <unistd.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_session.hpp>
 #include "mosq_broker.h"
 
+namespace {
+
+bool mqtt_encode_length(size_t len, std::vector<uint8_t> &out)
+{
+    if (len > 268435455) {
+        return false;
+    }
+    do {
+        uint8_t b = len % 128;
+        len /= 128;
+        if (len > 0) {
+            b |= 0x80;
+        }
+        out.push_back(b);
+    } while (len > 0);
+    return true;
+}
+
+void mqtt_append_string(std::vector<uint8_t> &buf, const char *s)
+{
+    size_t n = strlen(s);
+    buf.push_back((uint8_t)((n >> 8) & 0xff));
+    buf.push_back((uint8_t)(n & 0xff));
+    buf.insert(buf.end(), s, s + n);
+}
+
+int mqtt_connect_tcp(const char *host, int port)
+{
+    int fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (fd < 0) {
+        return -1;
+    }
+    sockaddr_in addr = {};
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons((uint16_t)port);
+    if (inet_pton(AF_INET, host, &addr.sin_addr) != 1) {
+        close(fd);
+        return -1;
+    }
+    if (connect(fd, (sockaddr *)&addr, sizeof(addr)) != 0) {
+        close(fd);
+        return -1;
+    }
+    return fd;
+}
+
+bool mqtt_send_all(int fd, const uint8_t *data, size_t len)
+{
+    size_t off = 0;
+    while (off < len) {
+        ssize_t n = send(fd, data + off, len - off, 0);
+        if (n <= 0) {
+            return false;
+        }
+        off += (size_t)n;
+    }
+    return true;
+}
+
+bool mqtt_recv_exact(int fd, uint8_t *data, size_t len, int timeout_ms)
+{
+    size_t off = 0;
+    while (off < len) {
+        fd_set rfds;
+        FD_ZERO(&rfds);
+        FD_SET(fd, &rfds);
+        timeval tv = {};
+        tv.tv_sec = timeout_ms / 1000;
+        tv.tv_usec = (timeout_ms % 1000) * 1000;
+        int sel = select(fd + 1, &rfds, nullptr, nullptr, &tv);
+        if (sel <= 0) {
+            return false;
+        }
+        ssize_t n = recv(fd, data + off, len - off, 0);
+        if (n <= 0) {
+            return false;
+        }
+        off += (size_t)n;
+    }
+    return true;
+}
+
+bool mqtt_expect_packet(int fd, uint8_t type_mask, int timeout_ms)
+{
+    uint8_t hdr;
+    if (!mqtt_recv_exact(fd, &hdr, 1, timeout_ms)) {
+        return false;
+    }
+    if ((hdr & 0xf0) != type_mask) {
+        return false;
+    }
+    size_t remaining = 0;
+    size_t mult = 1;
+    for (int i = 0; i < 4; i++) {
+        uint8_t b;
+        if (!mqtt_recv_exact(fd, &b, 1, timeout_ms)) {
+            return false;
+        }
+        remaining += (size_t)(b & 0x7f) * mult;
+        if ((b & 0x80) == 0) {
+            break;
+        }
+        mult *= 128;
+    }
+    if (remaining == 0) {
+        return true;
+    }
+    std::vector<uint8_t> payload(remaining);
+    return mqtt_recv_exact(fd, payload.data(), remaining, timeout_ms);
+}
+
+/* MQTT 3.1.1 CONNECT with optional Last-Will. */
+bool mqtt_connect_with_will(int fd, const char *client_id,
+                            const char *will_topic, const char *will_payload, bool will_retain)
+{
+    std::vector<uint8_t> vh;
+    mqtt_append_string(vh, "MQTT");
+    vh.push_back(0x04); /* protocol level 3.1.1 */
+    uint8_t flags = 0x02; /* clean session */
+    if (will_topic && will_payload) {
+        flags |= 0x04; /* will */
+        if (will_retain) {
+            flags |= 0x20;
+        }
+    }
+    vh.push_back(flags);
+    vh.push_back(0x00);
+    vh.push_back(0x3c); /* keepalive 60s */
+
+    std::vector<uint8_t> payload;
+    mqtt_append_string(payload, client_id);
+    if (will_topic && will_payload) {
+        mqtt_append_string(payload, will_topic);
+        mqtt_append_string(payload, will_payload);
+    }
+
+    std::vector<uint8_t> pkt;
+    pkt.push_back(0x10);
+    if (!mqtt_encode_length(vh.size() + payload.size(), pkt)) {
+        return false;
+    }
+    pkt.insert(pkt.end(), vh.begin(), vh.end());
+    pkt.insert(pkt.end(), payload.begin(), payload.end());
+
+    if (!mqtt_send_all(fd, pkt.data(), pkt.size())) {
+        return false;
+    }
+    return mqtt_expect_packet(fd, 0x20, 2000); /* CONNACK */
+}
+
+bool mqtt_subscribe(int fd, const char *topic)
+{
+    std::vector<uint8_t> body;
+    body.push_back(0x00);
+    body.push_back(0x01); /* packet id */
+    mqtt_append_string(body, topic);
+    body.push_back(0x00); /* QoS 0 */
+
+    std::vector<uint8_t> pkt;
+    pkt.push_back(0x82);
+    if (!mqtt_encode_length(body.size(), pkt)) {
+        return false;
+    }
+    pkt.insert(pkt.end(), body.begin(), body.end());
+    if (!mqtt_send_all(fd, pkt.data(), pkt.size())) {
+        return false;
+    }
+    return mqtt_expect_packet(fd, 0x90, 2000); /* SUBACK */
+}
+
+void wait_broker_ready(const char *host, int port, int timeout_ms)
+{
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);
+    while (std::chrono::steady_clock::now() < deadline) {
+        int fd = mqtt_connect_tcp(host, port);
+        if (fd >= 0) {
+            close(fd);
+            return;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+    FAIL("broker did not accept connections in time");
+}
+
+} // namespace
+
 TEST_CASE("Start and stop mosquitto broker", "[mosquitto]")
 {
     struct mosq_broker_config config = {};
-    config.host = "0.0.0.0";
+    config.host = "127.0.0.1";
     config.port = 18833;
 
     int broker_rc = -1;
@@ -22,10 +216,8 @@ TEST_CASE("Start and stop mosquitto broker", "[mosquitto]")
         broker_rc = mosq_broker_run(&config);
     });
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(500));
-
+    wait_broker_ready(config.host, config.port, 3000);
     mosq_broker_stop();
-
     broker_thread.join();
 
     CHECK(broker_rc == 0);
@@ -34,7 +226,7 @@ TEST_CASE("Start and stop mosquitto broker", "[mosquitto]")
 TEST_CASE("Restart mosquitto broker after stop", "[mosquitto]")
 {
     struct mosq_broker_config config = {};
-    config.host = "0.0.0.0";
+    config.host = "127.0.0.1";
     config.port = 18834;
 
     auto run_broker = [&]() {
@@ -43,10 +235,8 @@ TEST_CASE("Restart mosquitto broker after stop", "[mosquitto]")
             broker_rc = mosq_broker_run(&config);
         });
 
-        std::this_thread::sleep_for(std::chrono::milliseconds(500));
-
+        wait_broker_ready(config.host, config.port, 3000);
         mosq_broker_stop();
-
         broker_thread.join();
 
         return broker_rc;
@@ -54,6 +244,45 @@ TEST_CASE("Restart mosquitto broker after stop", "[mosquitto]")
 
     CHECK(run_broker() == 0);
     CHECK(run_broker() == 0);
+}
+
+/*
+ * Regression: stopping the broker while a Will publisher and a matching
+ * subscriber are still connected used to NULL-deref in mux_poll__add()
+ * because mux was freed before post-loop Will delivery.
+ */
+TEST_CASE("Stop broker with connected Will client and subscriber", "[mosquitto]")
+{
+    struct mosq_broker_config config = {};
+    config.host = "127.0.0.1";
+    config.port = 18835;
+
+    int broker_rc = -1;
+    std::thread broker_thread([&]() {
+        broker_rc = mosq_broker_run(&config);
+    });
+
+    wait_broker_ready(config.host, config.port, 3000);
+
+    int sub_fd = mqtt_connect_tcp(config.host, config.port);
+    REQUIRE(sub_fd >= 0);
+    REQUIRE(mqtt_connect_with_will(sub_fd, "sub-client", nullptr, nullptr, false));
+    REQUIRE(mqtt_subscribe(sub_fd, "test/#"));
+
+    int pub_fd = mqtt_connect_tcp(config.host, config.port);
+    REQUIRE(pub_fd >= 0);
+    REQUIRE(mqtt_connect_with_will(pub_fd, "will-client", "test/will", "bye", true));
+
+    /* Let the broker register both sessions before teardown. */
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+    mosq_broker_stop();
+    broker_thread.join();
+
+    close(sub_fd);
+    close(pub_fd);
+
+    CHECK(broker_rc == 0);
 }
 
 extern "C" void app_main(void)


### PR DESCRIPTION
* Closes https://github.com/espressif/esp-protocols/issues/1115

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes broker teardown ordering via linker wrapping; low blast radius but affects shutdown paths where Will delivery still uses the mux layer.
> 
> **Overview**
> Fixes a **broker shutdown crash** when Last-Will (LWT) clients and subscribers are still connected: `mosquitto_main_loop()` used to tear down the mux poll backend before `mosq_broker_run()` delivered Wills, so outbound writes could NULL-deref in `mux_poll__add()`.
> 
> The port now **linker-wraps `mux__cleanup`** so the main loop only marks cleanup as deferred; the real `mux__cleanup` runs in `port/broker.c` **after** `context__send_will` / `will_delay__send_all()`. Component version is bumped to **2.0.20~9**.
> 
> Linux **host tests** were extended with lightweight MQTT framing helpers, readiness polling instead of fixed sleeps, and a regression case that stops the broker with a Will publisher and matching subscriber still connected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64fded25b83f5042d1f8ec38fcc43148f905b8d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->