### PR TITLE
fix(modem): Add asserts and params error checks on create path

### DIFF
--- a/components/esp_modem/src/esp_modem_api.cpp
+++ b/components/esp_modem/src/esp_modem_api.cpp
@@ -26,6 +26,7 @@ static const char *TAG = "modem_api";
 std::shared_ptr<DTE> create_vfs_dte(const dte_config *config)
 {
     TRY_CATCH_RET_NULL(
+        ESP_MODEM_THROW_IF_FALSE(config != nullptr, "Invalid argument: dte config cannot be null");
         auto term = create_vfs_terminal(config);
         return std::make_shared<DTE>(config, std::move(term));
     )
@@ -37,6 +38,8 @@ create_modem_dce(dce_factory::ModemType m, const dce_config *config, std::shared
 {
     dce_factory::Factory f(m);
     TRY_CATCH_RET_NULL(
+        ESP_MODEM_THROW_IF_FALSE(config != nullptr, "Invalid argument: dce config cannot be null");
+        ESP_MODEM_THROW_IF_FALSE(dte != nullptr, "Invalid argument: dte cannot be null");
         return f.build_unique(config, std::move(dte), netif);
     )
 }

--- a/components/esp_modem/src/esp_modem_api_target.cpp
+++ b/components/esp_modem/src/esp_modem_api_target.cpp
@@ -23,6 +23,7 @@ static const char *TAG = "modem_api_target";
 std::shared_ptr<DTE> create_uart_dte(const dte_config *config)
 {
     TRY_CATCH_RET_NULL(
+        ESP_MODEM_THROW_IF_FALSE(config != nullptr, "Invalid argument: dte config cannot be null");
         auto term = create_uart_terminal(config);
         return std::make_shared<DTE>(config, std::move(term));
     )

--- a/components/esp_modem/src/esp_modem_c_api.cpp
+++ b/components/esp_modem/src/esp_modem_c_api.cpp
@@ -38,6 +38,9 @@ using namespace esp_modem;
 
 extern "C" esp_modem_dce_t *esp_modem_new_dev(esp_modem_dce_device_t module, const esp_modem_dte_config_t *dte_config, const esp_modem_dce_config_t *dce_config, esp_netif_t *netif)
 {
+    if (dte_config == nullptr || dce_config == nullptr) {
+        return nullptr;
+    }
     auto dce_wrap = new (std::nothrow) esp_modem_dce_wrap;
     if (dce_wrap == nullptr) {
         return nullptr;


### PR DESCRIPTION
Follow up from https://github.com/espressif/esp-protocols/pull/1102

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small guardrails on creation only; behavior for valid callers is unchanged and invalid null args now fail safely instead of undefined behavior.
> 
> **Overview**
> Adds **defensive null-pointer validation** on modem initialization so invalid callers fail early instead of dereferencing null configs or DTE handles.
> 
> On the **C++ factory path**, `create_vfs_dte`, `create_uart_dte`, and shared `create_modem_dce` now use `ESP_MODEM_THROW_IF_FALSE` for null `dte`/`dce` config and null `dte` before building terminals or DCE instances (still surfaced as `nullptr` via `TRY_CATCH_RET_NULL` when exceptions are enabled).
> 
> On the **C API**, `esp_modem_new_dev` returns `nullptr` immediately if `dte_config` or `dce_config` is null, before allocating the wrapper or calling into UART DTE creation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a435de4cb70617cf160257a6d523ad241c76190. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->