### PR TITLE
feat(mdns): Use internal cache for browser update

### DIFF
--- a/components/mdns/CMakeLists.txt
+++ b/components/mdns/CMakeLists.txt
@@ -16,7 +16,7 @@ set(MDNS_CORE "mdns_responder.c" "mdns_receive.c" "mdns_utils.c" "mdns_debug.c" 
                 "mdns_querier.c" "mdns_pcb.c" "mdns_service.c")
 
 if(CONFIG_MDNS_ENABLE_BROWSE)
-    list(APPEND MDNS_CORE "mdns_browser.c")
+    list(APPEND MDNS_CORE "mdns_browser.c" "mdns_cache.c")
 endif()
 
 idf_build_get_property(target IDF_TARGET)

--- a/components/mdns/include/mdns.h
+++ b/components/mdns/include/mdns.h
@@ -141,32 +141,22 @@ typedef void (*mdns_query_notify_t)(mdns_search_once_t *search);
 /**
  * @brief Browse result change notifier
  *
- * Called once per browse result that changed in a given response packet (not
- * once per packet). The @p result argument points at the changed entry, but it
- * remains a live node in the internal browse cache until the callback returns.
+ * Called once for every matching browse result changed by a received response,
+ * or once for every currently cached result when a new browse is registered.
  *
- * @warning @p result->next links other cached instances for this browse, not
- *          necessarily other results that changed in the same packet. For
- *          ordinary add/update notifications, use only @p result; do not walk
- *          @c next, because unchanged instances may appear there.
+ * The @p result is a temporary projection of the internal mDNS cache, which is only valid
+ * during the lifetime of this callback and is freed immediately after the callback returns.
  *
- * @warning Batch PTR TTL=0 ("goodbye") responses (for example when a peer
- *          exits and Bonjour sends many removals in one packet) may invoke the
- *          notifier once while several instances in the cache are updated.
- *          Until this is improved, applications may walk @c next and treat
- *          entries with @c ttl == 0 as removals. Do not assume every node on
- *          @c next changed in the current packet.
+ * @warning @p result->next is always NULL. Other instances cannot be obtained from @p result.
  *
- * @warning If handling is deferred outside this callback, copy @p result first
- *          (including strings and addresses). Goodbye entries may be freed when
- *          the callback returns.
+ * @warning If handling is deferred outside this callback, applications must make a deep copy
+ *          of @p result with all components, including strings, TXT entries, and address list.
  *
  * @warning This callback runs in the mDNS service task and holds the mDNS service lock.
  *          Users must not call APIs that acquire mDNS service lock in this callback.
  *          For example, mdns_browse_new() and mdns_browse_delete().
  *
- * @param result  The browse result that changed. See the warnings above for
- *                use of @c result->next.
+ * @param result  Temporary result of the browse that changed.
  */
 typedef void (*mdns_browse_notify_t)(mdns_result_t *result);
 
@@ -1091,16 +1081,12 @@ esp_err_t mdns_netif_action(esp_netif_t *esp_netif, mdns_event_actions_t event_a
  * @return mdns_browse_t pointer to new browse object if initiated successfully.
  *         NULL otherwise.
  *
- * @note When several service instances share the same SRV target hostname, A/AAAA
- *       addresses from a response are attached only to the first matching browse
- *       result for that hostname (per interface and IP protocol). Other instances
- *       with the same target host are not populated automatically; applications
- *       that need host-level addresses for every instance must resolve or cache
- *       them separately until this behavior is improved.
+ * @note If matching services already present in the internal mDNS cache,
+ *       the notifier will be called once for each cached service after this browse
+ *       is registered.
  *
- * @note If one response packet contains answers for multiple active browses,
- *       only one browse is synchronized for that packet. This should not affect
- *       typical browse traffic, where packets answer one service type.
+ * @note The notifier receives a temporary result that is valid only during the callback.
+ *       See @ref mdns_browse_notify_t for ownership and lifetime details.
  *
  * @note Available when CONFIG_MDNS_ENABLE_BROWSE is enabled (default); can be disabled to reduce binary size.
  *

--- a/components/mdns/mdns_browser.c
+++ b/components/mdns/mdns_browser.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <string.h>
-#include "sdkconfig.h"
 #include "mdns_private.h"
 #include "mdns_browser.h"
 #include "mdns_mem_caps.h"
@@ -15,6 +14,13 @@
 #include "mdns_netif.h"
 #include "mdns_service.h"
 #include "esp_log.h"
+#include "mdns_cache.h"
+
+#define MDNS_CACHE_RECORD_BROWSE_MASK \
+    ((mdns_cache_record_mask_t)(MDNS_CACHE_RECORD_PTR | \
+                                MDNS_CACHE_RECORD_SRV | \
+                                MDNS_CACHE_RECORD_TXT | \
+                                MDNS_CACHE_RECORD_ADDR))
 
 static const char *TAG = "mdns_browser";
 
@@ -48,82 +54,13 @@ static esp_err_t send_browse_action(mdns_action_type_t type, mdns_browse_t *brow
  */
 static void browse_item_free(mdns_browse_t *browse)
 {
-    mdns_mem_free(browse->service);
-    mdns_mem_free(browse->proto);
-    if (browse->result) {
-        mdns_priv_query_results_free(browse->result);
-    }
-    mdns_mem_free(browse);
-}
-
-/**
- * @brief Check that a browse is still linked in @c s_browse
- *
- * Sync batches borrow @c browse_sync->browse. ACTION_BROWSE_END may detach and
- * free that browse while a later ACTION_BROWSE_SYNC is still queued, so the
- * sync handler must not touch the pointer without checking.
- */
-static bool browse_is_in_list(const mdns_browse_t *browse)
-{
-    for (const mdns_browse_t *b = s_browse; b != NULL; b = b->next) {
-        if (b == browse) {
-            return true;
-        }
-    }
-    return false;
-}
-
-/**
- * @brief Check that a result node is still linked in the browse cache
- *
- * Sync entries hold a borrowed pointer to a node in @c browse->result. One node
- * can be referenced by several queued sync batches, and the first batch to see
- * it with @c ttl==0 detaches and frees it, so a later batch must not use its
- * pointer without checking.
- */
-static bool result_is_cached(const mdns_browse_t *browse, const mdns_result_t *result)
-{
-    for (const mdns_result_t *r = browse->result; r != NULL; r = r->next) {
-        if (r == result) {
-            return true;
-        }
-    }
-    return false;
-}
-
-/**
- * @brief Deliver browse updates to the user notifier
- *
- * Invokes the notifier once per changed result accumulated for the current
- * packet. The passed @c result pointer is a live node in @c browse->result;
- * @c result->next is not cleared before the callback (only after TTL=0 removal).
- * See @ref mdns_browse_notify_t for how callers should use @c next.
- */
-static void browse_sync(mdns_browse_sync_t *browse_sync)
-{
-    mdns_browse_t *browse = browse_sync->browse;
-    // END may have already detached+freed this browse, or delete marked it off
-    if (!browse_is_in_list(browse) || browse->state != BROWSE_RUNNING) {
+    if (!browse) {
         return;
     }
-    mdns_browse_result_sync_t *sync_result = browse_sync->sync_result;
-    while (sync_result) {
-        mdns_result_t *result = sync_result->result;
-        if (!result_is_cached(browse, result)) {
-            // Already removed and freed by an earlier sync batch
-            sync_result = sync_result->next;
-            continue;
-        }
-        DBG_BROWSE_RESULTS(result, browse_sync->browse);
-        browse->notifier(result);
-        if (result->ttl == 0) {
-            queueDetach(mdns_result_t, browse->result, result);
-            // Just free current result
-            result->next = NULL;
-            mdns_priv_query_results_free(result);
-        }
-        sync_result = sync_result->next;
-    }
+
+    mdns_mem_free(browse->service);
+    mdns_mem_free(browse->proto);
+    mdns_mem_free(browse);
 }
 
 /**
@@ -169,6 +106,29 @@ void mdns_priv_browse_free(void)
     }
 }
 
+static bool names_equal(const char *a, const char *b)
+{
+    return !mdns_utils_str_null_or_empty(a) && !mdns_utils_str_null_or_empty(b) && strcasecmp(a, b) == 0;
+}
+
+/**
+ * @brief Check if a browse matches a given service and proto.
+ */
+static bool browse_matches_identity(const mdns_browse_t *browse, const char *service, const char *proto)
+{
+    return browse && names_equal(browse->service, service) && names_equal(browse->proto, proto);
+}
+
+bool mdns_priv_browse_has_service(const char *service, const char *proto)
+{
+    for (const mdns_browse_t *it = s_browse; it; it = it->next) {
+        if (it->state != BROWSE_OFF && browse_matches_identity(it, service, proto)) {
+            return true;
+        }
+    }
+    return false;
+}
+
 /**
  * @brief  Remove and free the browse from browse linked list
  */
@@ -181,6 +141,7 @@ static void browse_finish(mdns_browse_t *browse)
     for (mdns_browse_t *it = s_browse; it; it = it->next) {
         if (it == browse) {
             queueDetach(mdns_browse_t, s_browse, it);
+            mdns_priv_cache_remove_service_cache_if_unused(it->service, it->proto);
             browse_item_free(it);
             return;
         }
@@ -209,7 +170,6 @@ static mdns_browse_t *browse_init(const char *service, const char *proto, mdns_b
             return NULL;
         }
     }
-
     if (!mdns_utils_str_null_or_empty(proto)) {
         browse->proto = mdns_mem_strndup(proto, MDNS_NAME_BUF_LEN - 1);
         if (!browse->proto) {
@@ -227,14 +187,17 @@ static mdns_browse_t *browse_init(const char *service, const char *proto, mdns_b
  */
 static void browse_start(mdns_browse_t *browse)
 {
+    if (!browse || browse->state != BROWSE_INIT) {
+        return;
+    }
+    browse->state = BROWSE_RUNNING;
+    mdns_priv_cache_notify_browse(browse);
     for (uint8_t interface_idx = 0; interface_idx < MDNS_MAX_INTERFACES; interface_idx++) {
         for (uint8_t protocol_idx = 0; protocol_idx < MDNS_IP_PROTOCOL_MAX; protocol_idx++) {
             browse_send(browse, (mdns_if_t) interface_idx, (mdns_ip_protocol_t) protocol_idx);
         }
     }
 }
-
-static esp_err_t add_browse_result(mdns_browse_sync_t *sync_browse, mdns_result_t *r);
 
 /**
  * @brief  Called from packet parser to find matching running search
@@ -259,139 +222,6 @@ mdns_browse_t *mdns_priv_browse_find_ptr(mdns_name_t *name)
     return NULL;
 }
 
-/**
- * @note Only one browse sync object is kept per parsed packet.  If @p sync
- *       is already allocated for a *different* browse, this function returns
- *       the existing object unchanged — callers that compare
- *       out_sync_browse->browse against the current browse will silently
- *       skip the update.  This is acceptable because mDNS answers for
- *       multiple browsed service types in a single packet are uncommon.
- *       The returned object must still be checked by the caller because NULL
- *       means allocation failed when @p browse was non-NULL.
- */
-mdns_browse_sync_t *mdns_priv_browse_ensure_sync(mdns_browse_t *browse, mdns_browse_sync_t *sync)
-{
-    if (!browse) {
-        return sync;
-    }
-    if (!sync) {
-        sync = (mdns_browse_sync_t *)mdns_mem_malloc(sizeof(mdns_browse_sync_t));
-        if (!sync) {
-            HOOK_MALLOC_FAILED;
-            return NULL;
-        }
-        sync->browse = browse;
-        sync->sync_result = NULL;
-    }
-    return sync;
-}
-
-void mdns_priv_browse_staged_ip_free(mdns_browse_staged_ip_t *staged)
-{
-    while (staged) {
-        mdns_browse_staged_ip_t *next = staged->next;
-        mdns_mem_free(staged);
-        staged = next;
-    }
-}
-
-esp_err_t mdns_priv_browse_stage_ip(mdns_browse_staged_ip_t **staged, const char *hostname, esp_ip_addr_t *ip,
-                                    mdns_if_t tcpip_if, mdns_ip_protocol_t ip_protocol, uint32_t ttl)
-{
-    mdns_browse_staged_ip_t *item = (mdns_browse_staged_ip_t *)mdns_mem_malloc(sizeof(mdns_browse_staged_ip_t));
-    if (!item) {
-        HOOK_MALLOC_FAILED;
-        return ESP_ERR_NO_MEM;
-    }
-    memset(item, 0, sizeof(mdns_browse_staged_ip_t));
-    strncpy(item->hostname, hostname, MDNS_NAME_BUF_LEN - 1);
-    item->hostname[MDNS_NAME_BUF_LEN - 1] = '\0';
-    item->ip = *ip;
-    item->tcpip_if = tcpip_if;
-    item->ip_protocol = ip_protocol;
-    item->ttl = ttl;
-    item->next = *staged;
-    *staged = item;
-    return ESP_OK;
-}
-
-/**
- * @brief Apply packet-staged A/AAAA records after SRV hostnames are known
- *
- * @note Each staged address is applied via mdns_priv_browse_result_add_ip(), which
- *       attaches the address only to the first browse result with a matching
- *       hostname on the same interface and IP protocol. Additional instances that
- *       share the same target host do not receive a copy automatically.
- */
-void mdns_priv_browse_apply_staged_ips(mdns_browse_t *browse, mdns_browse_staged_ip_t *staged,
-                                       mdns_browse_sync_t *out_sync_browse)
-{
-    if (!browse || !staged || !out_sync_browse || out_sync_browse->browse != browse) {
-        return;
-    }
-    while (staged) {
-        mdns_priv_browse_result_add_ip(browse, staged->hostname, &staged->ip, staged->tcpip_if,
-                                       staged->ip_protocol, staged->ttl, out_sync_browse);
-        staged = staged->next;
-    }
-}
-
-void mdns_priv_browse_result_add_ptr(mdns_browse_t *browse, const char *instance, const char *service, const char *proto,
-                                     mdns_if_t tcpip_if, mdns_ip_protocol_t ip_protocol, uint32_t ttl,
-                                     mdns_browse_sync_t *out_sync_browse)
-{
-    if (!browse || !out_sync_browse || out_sync_browse->browse != browse
-            || mdns_utils_str_null_or_empty(instance) || mdns_utils_str_null_or_empty(service)
-            || mdns_utils_str_null_or_empty(proto)) {
-        return;
-    }
-    mdns_result_t *r = browse->result;
-    while (r) {
-        if (r->esp_netif == mdns_priv_get_esp_netif(tcpip_if) && r->ip_protocol == ip_protocol &&
-                !mdns_utils_str_null_or_empty(r->instance_name) && !strcasecmp(instance, r->instance_name) &&
-                !mdns_utils_str_null_or_empty(r->service_type) && !strcasecmp(service, r->service_type) &&
-                !mdns_utils_str_null_or_empty(r->proto) && !strcasecmp(proto, r->proto)) {
-            if (r->ttl != ttl) {
-                uint32_t previous_ttl = r->ttl;
-                if (r->ttl == 0) {
-                    r->ttl = ttl;
-                } else {
-                    mdns_priv_query_update_result_ttl(r, ttl);
-                }
-                if (previous_ttl != r->ttl) {
-                    add_browse_result(out_sync_browse, r);
-                }
-            }
-            return;
-        }
-        r = r->next;
-    }
-
-    r = (mdns_result_t *)mdns_mem_malloc(sizeof(mdns_result_t));
-    if (!r) {
-        HOOK_MALLOC_FAILED;
-        return;
-    }
-    memset(r, 0, sizeof(mdns_result_t));
-    r->instance_name = mdns_mem_strdup(instance);
-    r->service_type = mdns_mem_strdup(service);
-    r->proto = mdns_mem_strdup(proto);
-    if (!r->instance_name || !r->service_type || !r->proto) {
-        HOOK_MALLOC_FAILED;
-        mdns_mem_free(r->instance_name);
-        mdns_mem_free(r->service_type);
-        mdns_mem_free(r->proto);
-        mdns_mem_free(r);
-        return;
-    }
-    r->esp_netif = mdns_priv_get_esp_netif(tcpip_if);
-    r->ip_protocol = ip_protocol;
-    r->ttl = ttl;
-    r->next = browse->result;
-    browse->result = r;
-    add_browse_result(out_sync_browse, r);
-}
-
 mdns_browse_t *mdns_priv_browse_find(mdns_name_t *name, uint16_t type, mdns_if_t tcpip_if, mdns_ip_protocol_t ip_protocol)
 {
     mdns_browse_t *b = s_browse;
@@ -399,7 +229,7 @@ mdns_browse_t *mdns_priv_browse_find(mdns_name_t *name, uint16_t type, mdns_if_t
     if (type != MDNS_TYPE_SRV && type != MDNS_TYPE_A && type != MDNS_TYPE_AAAA && type != MDNS_TYPE_TXT) {
         return NULL;
     }
-    mdns_result_t *r = NULL;
+
     while (b) {
         if (b->state != BROWSE_RUNNING) {
             b = b->next;
@@ -414,38 +244,15 @@ mdns_browse_t *mdns_priv_browse_find(mdns_name_t *name, uint16_t type, mdns_if_t
             }
             return b;
         } else if (type == MDNS_TYPE_A || type == MDNS_TYPE_AAAA) {
-            r = b->result;
-            while (r) {
-                if (r->esp_netif == mdns_priv_get_esp_netif(tcpip_if) && r->ip_protocol == ip_protocol && !mdns_utils_str_null_or_empty(r->hostname) && !strcasecmp(name->host, r->hostname)) {
-                    return b;
-                }
-                r = r->next;
+            if (mdns_priv_cache_host_has_service(name->host, mdns_priv_get_esp_netif(tcpip_if),
+                                                 ip_protocol, b->service, b->proto)) {
+                return b;
             }
             b = b->next;
             continue;
         }
     }
-    return b;
-}
-
-static void sync_browse_result_link_free(mdns_browse_sync_t *browse_sync)
-{
-    mdns_browse_result_sync_t *current = browse_sync->sync_result;
-    mdns_browse_result_sync_t *need_free;
-    while (current) {
-        need_free = current;
-        current = current->next;
-        mdns_mem_free(need_free);
-    }
-    mdns_mem_free(browse_sync);
-}
-
-void mdns_priv_browse_sync_free(mdns_browse_sync_t *browse_sync)
-{
-    if (!browse_sync) {
-        return;
-    }
-    sync_browse_result_link_free(browse_sync);
+    return NULL;
 }
 
 void mdns_priv_browse_action(mdns_action_t *action, mdns_action_subtype_t type)
@@ -454,10 +261,6 @@ void mdns_priv_browse_action(mdns_action_t *action, mdns_action_subtype_t type)
         switch (action->type) {
         case ACTION_BROWSE_START:
             browse_start(action->data.browse_add.browse);
-            break;
-        case ACTION_BROWSE_SYNC:
-            browse_sync(action->data.browse_sync.browse_sync);
-            sync_browse_result_link_free(action->data.browse_sync.browse_sync);
             break;
         case ACTION_BROWSE_END:
             browse_finish(action->data.browse_add.browse);
@@ -474,9 +277,6 @@ void mdns_priv_browse_action(mdns_action_t *action, mdns_action_subtype_t type)
             // Browse actions do not own the browse item.
             // If a queued action is discarded during shutdown, the linked browse item is released by mdns_priv_browse_free().
             break;
-        case ACTION_BROWSE_SYNC:
-            sync_browse_result_link_free(action->data.browse_sync.browse_sync);
-            break;
         default:
             abort();
         }
@@ -485,367 +285,6 @@ void mdns_priv_browse_action(mdns_action_t *action, mdns_action_subtype_t type)
 
 }
 
-/**
- * @brief  Add result to browse, only add when the result is a new one.
- */
-static esp_err_t add_browse_result(mdns_browse_sync_t *sync_browse, mdns_result_t *r)
-{
-    mdns_browse_result_sync_t *sync_r = sync_browse->sync_result;
-    while (sync_r) {
-        if (sync_r->result == r) {
-            break;
-        }
-        sync_r = sync_r->next;
-    }
-    if (!sync_r) {
-        // Do not find, need to add the result to the list
-        mdns_browse_result_sync_t *new = (mdns_browse_result_sync_t *)mdns_mem_malloc(sizeof(mdns_browse_result_sync_t));
-
-        if (!new) {
-            HOOK_MALLOC_FAILED;
-            return ESP_ERR_NO_MEM;
-        }
-        new->result = r;
-        new->next = sync_browse->sync_result;
-        sync_browse->sync_result = new;
-    }
-    return ESP_OK;
-}
-
-/**
- * @brief  Called from parser to add A/AAAA data to browse result
- *
- * @note Only the first browse result with a matching @p hostname (same interface
- *       and IP protocol) receives the address. This predates browse staging and
- *       also limits mdns_priv_browse_apply_staged_ips() when several instances
- *       share one target host.
- */
-void mdns_priv_browse_result_add_ip(mdns_browse_t *browse, const char *hostname, esp_ip_addr_t *ip,
-                                    mdns_if_t tcpip_if, mdns_ip_protocol_t ip_protocol, uint32_t ttl, mdns_browse_sync_t *out_sync_browse)
-{
-    if (out_sync_browse->browse == NULL) {
-        return;
-    } else {
-        if (out_sync_browse->browse != browse) {
-            return;
-        }
-    }
-    mdns_result_t *r = NULL;
-    mdns_ip_addr_t *r_a = NULL;
-    if (browse) {
-        r = browse->result;
-        while (r) {
-            if (r->ip_protocol == ip_protocol) {
-                // Find the target result in browse result.
-                if (r->esp_netif == mdns_priv_get_esp_netif(tcpip_if) && !mdns_utils_str_null_or_empty(r->hostname) && !strcasecmp(hostname, r->hostname)) {
-                    r_a = r->addr;
-                    // Check if the address has already added in result.
-                    while (r_a) {
-#ifdef CONFIG_LWIP_IPV4
-                        if (r_a->addr.type == ip->type && r_a->addr.type == ESP_IPADDR_TYPE_V4 && r_a->addr.u_addr.ip4.addr == ip->u_addr.ip4.addr) {
-                            break;
-                        }
-#endif
-#ifdef CONFIG_LWIP_IPV6
-                        if (r_a->addr.type == ip->type && r_a->addr.type == ESP_IPADDR_TYPE_V6 && !memcmp(r_a->addr.u_addr.ip6.addr, ip->u_addr.ip6.addr, 16)) {
-                            break;
-                        }
-#endif
-                        r_a = r_a->next;
-                    }
-                    if (!r_a) {
-                        // The current IP is a new one, add it to the link list.
-                        mdns_ip_addr_t *a = NULL;
-                        a = mdns_priv_result_addr_create_ip(ip);
-                        if (!a) {
-                            return;
-                        }
-                        a->next = r->addr;
-                        r->addr = a;
-                        if (r->ttl != ttl) {
-                            if (r->ttl == 0) {
-                                r->ttl = ttl;
-                            } else {
-                                mdns_priv_query_update_result_ttl(r, ttl);
-                            }
-                        }
-                        if (add_browse_result(out_sync_browse, r) != ESP_OK) {
-                            return;
-                        }
-                        break;
-                    }
-                }
-            }
-            r = r->next;
-        }
-    }
-}
-
-static bool txt_values_equal(const char *a, const char *b, uint8_t len)
-{
-    if (len == 0) {
-        return true;
-    }
-    if (!a || !b) {
-        return a == b;
-    }
-    return memcmp(a, b, len) == 0;
-}
-
-static bool is_txt_item_in_list(mdns_txt_item_t txt, uint8_t txt_value_len, mdns_txt_item_t *txt_list, uint8_t *txt_value_len_list, size_t txt_count)
-{
-    for (size_t i = 0; i < txt_count; i++) {
-        if (mdns_utils_str_null_or_empty(txt.key) || mdns_utils_str_null_or_empty(txt_list[i].key)) {
-            if (mdns_utils_str_null_or_empty(txt.key) != mdns_utils_str_null_or_empty(txt_list[i].key)) {
-                continue;
-            }
-        } else if (strcmp(txt.key, txt_list[i].key) != 0) {
-            continue;
-        }
-        if (txt_value_len != txt_value_len_list[i]) {
-            return false;
-        }
-        if (txt_values_equal(txt.value, txt_list[i].value, txt_value_len)) {
-            return true;
-        }
-        // The key value is unique, so there is no need to continue searching.
-        return false;
-    }
-    return false;
-}
-
-/**
- * @brief  Called from parser to add TXT data to search result
- */
-void mdns_priv_browse_result_add_txt(mdns_browse_t *browse, const char *instance, const char *service, const char *proto,
-                                     mdns_txt_item_t *txt, uint8_t *txt_value_len, size_t txt_count, mdns_if_t tcpip_if, mdns_ip_protocol_t ip_protocol,
-                                     uint32_t ttl, mdns_browse_sync_t *out_sync_browse)
-{
-    if (out_sync_browse->browse == NULL || out_sync_browse->browse != browse
-            || mdns_utils_str_null_or_empty(instance) || mdns_utils_str_null_or_empty(service)
-            || mdns_utils_str_null_or_empty(proto)) {
-        goto free_txt;
-    }
-    mdns_result_t *r = browse->result;
-    while (r) {
-        if (r->esp_netif == mdns_priv_get_esp_netif(tcpip_if) && r->ip_protocol == ip_protocol &&
-                !mdns_utils_str_null_or_empty(r->instance_name) && !strcasecmp(instance, r->instance_name) &&
-                !mdns_utils_str_null_or_empty(r->service_type) && !strcasecmp(service, r->service_type) &&
-                !mdns_utils_str_null_or_empty(r->proto) && !strcasecmp(proto, r->proto)) {
-            bool should_update = false;
-            if (r->txt) {
-                // Check if txt changed
-                if (txt_count != r->txt_count) {
-                    should_update = true;
-                } else {
-                    for (size_t txt_index = 0; txt_index < txt_count; txt_index++) {
-                        if (!is_txt_item_in_list(txt[txt_index], txt_value_len[txt_index], r->txt, r->txt_value_len, r->txt_count)) {
-                            should_update = true;
-                            break;
-                        }
-                    }
-                }
-                // If the result has a previous txt entry, we delete it and re-add.
-                for (size_t i = 0; i < r->txt_count; i++) {
-                    mdns_mem_free((char *)(r->txt[i].key));
-                    mdns_mem_free((char *)(r->txt[i].value));
-                }
-                mdns_mem_free(r->txt);
-                mdns_mem_free(r->txt_value_len);
-            }
-            r->txt = txt;
-            r->txt_value_len = txt_value_len;
-            r->txt_count = txt_count;
-            if (r->ttl != ttl) {
-                uint32_t previous_ttl = r->ttl;
-                if (r->ttl == 0) {
-                    r->ttl = ttl;
-                } else {
-                    mdns_priv_query_update_result_ttl(r, ttl);
-                }
-                if (previous_ttl != r->ttl) {
-                    should_update = true;
-                }
-            }
-            if (should_update) {
-                if (add_browse_result(out_sync_browse, r) != ESP_OK) {
-                    return;
-                }
-            }
-            return;
-        }
-        r = r->next;
-    }
-    r = (mdns_result_t *)mdns_mem_malloc(sizeof(mdns_result_t));
-    if (!r) {
-        HOOK_MALLOC_FAILED;
-        goto free_txt;
-    }
-    memset(r, 0, sizeof(mdns_result_t));
-    r->instance_name = mdns_mem_strdup(instance);
-    r->service_type = mdns_mem_strdup(service);
-    r->proto = mdns_mem_strdup(proto);
-    if (!r->instance_name || !r->service_type || !r->proto) {
-        HOOK_MALLOC_FAILED;
-        mdns_mem_free(r->instance_name);
-        mdns_mem_free(r->service_type);
-        mdns_mem_free(r->proto);
-        mdns_mem_free(r);
-        goto free_txt;
-    }
-    r->txt = txt;
-    r->txt_value_len = txt_value_len;
-    r->txt_count = txt_count;
-    r->esp_netif = mdns_priv_get_esp_netif(tcpip_if);
-    r->ip_protocol = ip_protocol;
-    r->ttl = ttl;
-    r->next = browse->result;
-    browse->result = r;
-    add_browse_result(out_sync_browse, r);
-    return;
-
-free_txt:
-    for (size_t i = 0; i < txt_count; i++) {
-        mdns_mem_free((char *)(txt[i].key));
-        mdns_mem_free((char *)(txt[i].value));
-    }
-    mdns_mem_free(txt);
-    mdns_mem_free(txt_value_len);
-    return;
-}
-
-static esp_err_t copy_address_in_previous_result(mdns_result_t *result_list, mdns_result_t *r)
-{
-    while (result_list) {
-        if (!mdns_utils_str_null_or_empty(result_list->hostname) && !mdns_utils_str_null_or_empty(r->hostname) && !strcasecmp(result_list->hostname, r->hostname) &&
-                result_list->ip_protocol == r->ip_protocol && result_list->addr && !r->addr) {
-            // If there is a same hostname in previous result, we need to copy the address here.
-            r->addr = mdns_utils_copy_address_list(result_list->addr);
-            if (!r->addr) {
-                return ESP_ERR_NO_MEM;
-            }
-            break;
-        } else {
-            result_list = result_list->next;
-        }
-    }
-    return ESP_OK;
-}
-
-/**
- * @brief  Called from parser to add SRV data to search result
- */
-void mdns_priv_browse_result_add_srv(mdns_browse_t *browse, const char *hostname, const char *instance, const char *service, const char *proto,
-                                     uint16_t port, mdns_if_t tcpip_if, mdns_ip_protocol_t ip_protocol, uint32_t ttl, mdns_browse_sync_t *out_sync_browse)
-{
-    if (out_sync_browse->browse == NULL) {
-        return;
-    } else {
-        if (out_sync_browse->browse != browse) {
-            return;
-        }
-    }
-    if (mdns_utils_str_null_or_empty(instance) || mdns_utils_str_null_or_empty(service)
-            || mdns_utils_str_null_or_empty(proto)) {
-        return;
-    }
-    mdns_result_t *r = browse->result;
-    while (r) {
-        if (r->esp_netif == mdns_priv_get_esp_netif(tcpip_if) && r->ip_protocol == ip_protocol &&
-                !mdns_utils_str_null_or_empty(r->instance_name) && !strcasecmp(instance, r->instance_name) &&
-                !mdns_utils_str_null_or_empty(r->service_type) && !strcasecmp(service, r->service_type) &&
-                !mdns_utils_str_null_or_empty(r->proto) && !strcasecmp(proto, r->proto)) {
-            if (mdns_utils_str_null_or_empty(r->hostname)
-                    || mdns_utils_str_null_or_empty(hostname)
-                    || strcasecmp(hostname, r->hostname)) {
-                mdns_mem_free((char *)r->hostname);
-                r->hostname = mdns_mem_strdup(hostname);
-                r->port = port;
-                if (!r->hostname) {
-                    HOOK_MALLOC_FAILED;
-                    return;
-                }
-                if (!r->addr) {
-                    esp_err_t err = copy_address_in_previous_result(browse->result, r);
-                    if (err == ESP_ERR_NO_MEM) {
-                        return;
-                    }
-                }
-                if (add_browse_result(out_sync_browse, r) != ESP_OK) {
-                    return;
-                }
-            }
-            if (r->ttl != ttl) {
-                uint32_t previous_ttl = r->ttl;
-                if (r->ttl == 0) {
-                    r->ttl = ttl;
-                } else {
-                    mdns_priv_query_update_result_ttl(r, ttl);
-                }
-                if (previous_ttl != r->ttl) {
-                    if (add_browse_result(out_sync_browse, r) != ESP_OK) {
-                        return;
-                    }
-                }
-            }
-            return;
-        }
-        r = r->next;
-    }
-    r = (mdns_result_t *)mdns_mem_malloc(sizeof(mdns_result_t));
-    if (!r) {
-        HOOK_MALLOC_FAILED;
-        return;
-    }
-
-    memset(r, 0, sizeof(mdns_result_t));
-    r->hostname = mdns_mem_strdup(hostname);
-    r->instance_name = mdns_mem_strdup(instance);
-    r->service_type = mdns_mem_strdup(service);
-    r->proto = mdns_mem_strdup(proto);
-    if (!r->hostname || !r->instance_name || !r->service_type || !r->proto) {
-        HOOK_MALLOC_FAILED;
-        mdns_mem_free(r->hostname);
-        mdns_mem_free(r->instance_name);
-        mdns_mem_free(r->service_type);
-        mdns_mem_free(r->proto);
-        mdns_mem_free(r);
-        return;
-    }
-    r->port = port;
-    r->esp_netif = mdns_priv_get_esp_netif(tcpip_if);
-    r->ip_protocol = ip_protocol;
-    r->ttl = ttl;
-    r->next = browse->result;
-    browse->result = r;
-    add_browse_result(out_sync_browse, r);
-}
-
-/**
- * @brief  Browse sync result
- */
-esp_err_t mdns_priv_browse_sync(mdns_browse_sync_t *browse_sync)
-{
-    mdns_action_t *action = NULL;
-
-    action = (mdns_action_t *)mdns_mem_malloc(sizeof(mdns_action_t));
-    if (!action) {
-        HOOK_MALLOC_FAILED;
-        return ESP_ERR_NO_MEM;
-    }
-
-    action->type = ACTION_BROWSE_SYNC;
-    action->data.browse_sync.browse_sync = browse_sync;
-    if (!mdns_priv_queue_action(action)) {
-        mdns_mem_free(action);
-        return ESP_ERR_NO_MEM;
-    }
-    return ESP_OK;
-}
-
-/**
- * @defgroup MDNS_PUBCLIC_API
- */
 mdns_browse_t *mdns_browse_new(const char *service, const char *proto, mdns_browse_notify_t notifier)
 {
     mdns_browse_t *browse = NULL;
@@ -862,9 +301,7 @@ mdns_browse_t *mdns_browse_new(const char *service, const char *proto, mdns_brow
     mdns_priv_service_lock();
     // Check if the browse already exists before sending action
     for (mdns_browse_t *it = s_browse; it; it = it->next) {
-        if (it->state == BROWSE_RUNNING
-                && strlen(it->service) == strlen(browse->service) && memcmp(it->service, browse->service, strlen(it->service)) == 0
-                && strlen(it->proto) == strlen(browse->proto) && memcmp(it->proto, browse->proto, strlen(it->proto)) == 0) {
+        if (it->state != BROWSE_OFF && browse_matches_identity(it, service, proto)) {
             ESP_LOGW(TAG, "Browse already exists: %s.%s", browse->service, browse->proto);
             goto error;
         }
@@ -875,7 +312,6 @@ mdns_browse_t *mdns_browse_new(const char *service, const char *proto, mdns_brow
         goto error;
     }
 
-    browse->state = BROWSE_RUNNING;
     browse->next = s_browse;
     s_browse = browse;
     mdns_priv_service_unlock();
@@ -897,9 +333,7 @@ esp_err_t mdns_browse_delete(const char *service, const char *proto)
 
     mdns_priv_service_lock();
     for (mdns_browse_t *it = s_browse; it; it = it->next) {
-        if (it->state == BROWSE_RUNNING
-                && strlen(it->service) == strlen(service) && memcmp(it->service, service, strlen(it->service)) == 0
-                && strlen(it->proto) == strlen(proto) && memcmp(it->proto, proto, strlen(it->proto)) == 0) {
+        if (it->state != BROWSE_OFF && browse_matches_identity(it, service, proto)) {
             browse = it;
             break;
         }
@@ -910,14 +344,107 @@ esp_err_t mdns_browse_delete(const char *service, const char *proto)
         return ESP_FAIL;
     }
 
+    mdns_browse_state_t prev_state = browse->state;
     browse->state = BROWSE_OFF;
 
     if (send_browse_action(ACTION_BROWSE_END, browse) != ESP_OK) {
-        browse->state = BROWSE_RUNNING;
+        browse->state = prev_state;
         mdns_priv_service_unlock();
         return ESP_ERR_NO_MEM;
     }
 
     mdns_priv_service_unlock();
     return ESP_OK;
+}
+
+static bool browse_matches_service_cache(const mdns_browse_t *browse, const mdns_service_cache_t *service)
+{
+    return browse && service && browse->state == BROWSE_RUNNING && browse->notifier && service->ptr_present
+           && !mdns_utils_str_null_or_empty(browse->service)
+           && !mdns_utils_str_null_or_empty(browse->proto)
+           && !mdns_utils_str_null_or_empty(service->service)
+           && !mdns_utils_str_null_or_empty(service->proto)
+           && !strcasecmp(browse->service, service->service)
+           && !strcasecmp(browse->proto, service->proto);
+}
+
+/**
+ * @brief Build a temporary result from the service cache and queue it for sync.
+ */
+static bool browse_build_and_notify_temp_result(mdns_browse_t *browse, const mdns_cache_entry_t *entry,
+                                                const mdns_service_cache_t *service, bool goodbye)
+{
+    mdns_result_t *result = NULL;
+    esp_err_t ret = mdns_priv_service_cache_to_result(entry, service, &result);
+    if (ret != ESP_OK) {
+        return false;
+    }
+
+    result->next = NULL;
+    if (goodbye) {
+        result->ttl = 0;
+    }
+
+    DBG_BROWSE_RESULTS(result, browse);
+    if (browse->notifier) {
+        browse->notifier(result);
+    }
+
+    mdns_priv_query_results_free(result);
+    return true;
+}
+
+bool mdns_priv_browse_update_from_service_cache(const mdns_cache_entry_t *entry, const mdns_service_cache_t *service,
+                                                mdns_cache_record_mask_t records)
+{
+    if (!entry || !service) {
+        return false;
+    }
+
+    if (!(records & MDNS_CACHE_RECORD_BROWSE_MASK)) {
+        return true;
+    }
+
+    bool updated = true;
+
+    for (mdns_browse_t *browse = s_browse; browse; browse = browse->next) {
+        if (browse_matches_service_cache(browse, service)) {
+            updated &= browse_build_and_notify_temp_result(browse, entry, service, false);
+        }
+    }
+
+    return updated;
+}
+
+bool mdns_priv_browse_notify_from_service_cache(const mdns_cache_entry_t *entry, const mdns_service_cache_t *service,
+                                                mdns_browse_t *browse)
+{
+    if (!entry || !service || !browse) {
+        return false;
+    }
+
+    if (!browse_matches_service_cache(browse, service)) {
+        return true;
+    }
+
+    return browse_build_and_notify_temp_result(browse, entry, service, false);
+}
+
+bool mdns_priv_browse_notify_ptr_goodbye_from_service_cache(const mdns_cache_entry_t *entry,
+                                                            const mdns_service_cache_t *service)
+{
+    if (!entry || !service) {
+        return false;
+    }
+    bool notified = true;
+
+    for (mdns_browse_t *browse = s_browse; browse; browse = browse->next) {
+        if (!browse_matches_service_cache(browse, service)) {
+            continue;
+        }
+
+        notified &= browse_build_and_notify_temp_result(browse, entry, service, true);
+    }
+
+    return notified;
 }

--- a/components/mdns/mdns_cache.c
+++ b/components/mdns/mdns_cache.c
@@ -1,0 +1,977 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <string.h>
+#include <strings.h>
+#include "esp_check.h"
+#include "esp_log.h"
+#include "mdns_browser.h"
+#include "mdns_cache.h"
+#include "mdns_mem_caps.h"
+#include "mdns_querier.h"
+#include "mdns_utils.h"
+
+static const char *TAG = "mdns_cache";
+
+static mdns_cache_entry_t *s_cache;
+
+static inline bool names_equal(const char *a, const char *b)
+{
+    return !mdns_utils_str_null_or_empty(a) && !mdns_utils_str_null_or_empty(b) && strcasecmp(a, b) == 0;
+}
+
+static inline bool nullable_names_equal(const char *a, const char *b)
+{
+    return (mdns_utils_str_null_or_empty(a) && mdns_utils_str_null_or_empty(b)) || names_equal(a, b);
+}
+
+static bool update_ttl(uint32_t *cached_ttl, uint32_t ttl)
+{
+    if (*cached_ttl == ttl) {
+        return false;
+    }
+    *cached_ttl = ttl;
+    return true;
+}
+
+static bool service_match(const mdns_service_cache_t *cache, const char *instance, const char *service, const char *proto)
+{
+    return names_equal(cache->instance_name, instance) && names_equal(cache->service, service)
+           && names_equal(cache->proto, proto);
+}
+
+static bool addr_equal(const esp_ip_addr_t *a, const esp_ip_addr_t *b)
+{
+    if (a->type != b->type) {
+        return false;
+    }
+
+#ifdef CONFIG_LWIP_IPV6
+    if (a->type == ESP_IPADDR_TYPE_V6) {
+        return !memcmp(a->u_addr.ip6.addr, b->u_addr.ip6.addr, sizeof(a->u_addr.ip6.addr));
+    }
+#endif
+#ifdef CONFIG_LWIP_IPV4
+    if (a->type == ESP_IPADDR_TYPE_V4) {
+        return a->u_addr.ip4.addr == b->u_addr.ip4.addr;
+    }
+#endif
+
+    return false;
+}
+
+/**
+ * @note Ensure service is not NULL before calling this function.
+ */
+static bool service_cache_is_empty(const mdns_service_cache_t *service)
+{
+    return service && (!service->ptr_present && !service->srv_present && !service->txt_present);
+}
+
+/**
+ * @brief Mark sync out flags for a service cache.
+ *
+ * @param service_entry Service cache entry to mark sync out flags for.
+ * @param result Result of the update operation.
+ * @param record_type Record type to mark sync out flags for.
+ * @param consumer Consumer type to mark sync out flags for.
+ */
+static void service_cache_mark_sync_out(mdns_service_cache_t *service_entry, mdns_cache_update_result_t result,
+                                        mdns_cache_record_type_t record_type, mdns_cache_consumer_mask_t consumer)
+{
+    if (service_entry && (result == MDNS_CACHE_ADDED || result == MDNS_CACHE_UPDATED)) {
+        service_entry->sync_records |= (mdns_cache_record_mask_t)record_type;
+        service_entry->sync_consumers |= consumer;
+    }
+}
+
+/**
+ * @brief Clear sync out flags for a service cache.
+ *
+ * @note For browsers, only clear MDNS_CACHE_CONSUMER_BROWSE from sync_consumers.
+ *
+ * @param service_entry Service cache entry to clear sync out flags for.
+ * @param consumer Consumer type to clear sync out flags for.
+ * @param record_type Record type to clear sync out flags for.
+ */
+static void service_cache_clear_sync_out(mdns_service_cache_t *service_entry, mdns_cache_consumer_type_t consumer,
+                                         mdns_cache_record_mask_t records)
+{
+    if (!service_entry) {
+        return;
+    }
+
+    switch (consumer) {
+    case MDNS_CACHE_CONSUMER_BROWSE:
+        service_entry->sync_consumers &= ~(mdns_cache_consumer_mask_t)consumer;
+        break;
+    default:
+        return;
+    }
+
+    if (service_entry->sync_consumers == 0) {
+        service_entry->sync_records = 0;
+    }
+}
+
+/**
+ * @brief Find a cache entry by hostname, esp_netif, and ip_protocol.
+ *
+ * @param hostname      The hostname to find.
+ * @param esp_netif     Pointer to the esp_netif to find.
+ * @param ip_protocol   IP protocol to find.
+ *
+ * @return Pointer to the cache entry if found, NULL otherwise.
+ */
+static mdns_cache_entry_t *cache_find_entry(const char *hostname, const esp_netif_t *esp_netif,
+                                            mdns_ip_protocol_t ip_protocol)
+{
+    mdns_cache_entry_t *entry = s_cache;
+    while (entry) {
+        if (nullable_names_equal(entry->hostname, hostname) && entry->esp_netif == esp_netif
+                && entry->ip_protocol == ip_protocol) {
+            return entry;
+        }
+        entry = entry->next;
+    }
+    return NULL;
+}
+
+/**
+ * @brief Find a service cache entry by esp_netif, ip_protocol, instance, service, and proto.
+ *
+ * @param esp_netif     Pointer to the esp_netif to find.
+ * @param ip_protocol   IP protocol to find.
+ * @param instance      The instance name to find.
+ * @param service       The service name to find.
+ * @param proto         The protocol to find.
+ * @param owner_entry   Receives the pointer to the cache entry that owns the service cache.
+ *
+ * @return Pointer to the service cache entry if found, NULL otherwise.
+ */
+static mdns_service_cache_t *cache_find_service(const esp_netif_t *esp_netif, mdns_ip_protocol_t ip_protocol,
+                                                const char *instance, const char *service, const char *proto,
+                                                mdns_cache_entry_t **owner_entry)
+{
+    mdns_cache_entry_t *entry = s_cache;
+    if (owner_entry) {
+        *owner_entry = NULL;
+    }
+
+    while (entry) {
+        if (entry->esp_netif == esp_netif && entry->ip_protocol == ip_protocol) {
+            mdns_service_cache_t *service_entry = entry->service_cache_list;
+            while (service_entry) {
+                if (service_match(service_entry, instance, service, proto)) {
+                    if (owner_entry) {
+                        *owner_entry = entry;
+                    }
+                    return service_entry;
+                }
+                service_entry = service_entry->next;
+            }
+        }
+        entry = entry->next;
+    }
+    return NULL;
+}
+
+bool mdns_priv_cache_host_has_service(const char *hostname, const esp_netif_t *esp_netif, mdns_ip_protocol_t ip_protocol,
+                                      const char *service, const char *proto)
+{
+    mdns_cache_entry_t *entry = cache_find_entry(hostname, esp_netif, ip_protocol);
+    if (!entry) {
+        return false;
+    }
+
+    for (const mdns_service_cache_t *it = entry->service_cache_list; it; it = it->next) {
+        if (names_equal(it->service, service) && names_equal(it->proto, proto)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static void service_entry_free(mdns_service_cache_t *service_entry)
+{
+    mdns_mem_free(service_entry->instance_name);
+    mdns_mem_free(service_entry->service);
+    mdns_mem_free(service_entry->proto);
+    while (service_entry->txt_list) {
+        mdns_txt_linked_item_t *txt = service_entry->txt_list;
+        service_entry->txt_list = service_entry->txt_list->next;
+        mdns_mem_free((char *)txt->key);
+        mdns_mem_free(txt->value);
+        mdns_mem_free(txt);
+    }
+    mdns_mem_free(service_entry);
+}
+
+static void cache_entry_free(mdns_cache_entry_t *entry)
+{
+    mdns_mem_free(entry->hostname);
+    while (entry->addr_list) {
+        mdns_cache_addr_t *addr = entry->addr_list;
+        entry->addr_list = entry->addr_list->next;
+        mdns_mem_free(addr);
+    }
+    while (entry->service_cache_list) {
+        mdns_service_cache_t *service_entry = entry->service_cache_list;
+        entry->service_cache_list = entry->service_cache_list->next;
+        service_entry_free(service_entry);
+    }
+    mdns_mem_free(entry);
+}
+
+static bool cache_remove_entry(mdns_cache_entry_t *entry)
+{
+    if (!entry) {
+        return false;
+    }
+
+    mdns_cache_entry_t **entry_ptr = &s_cache;
+    while (*entry_ptr) {
+        if (*entry_ptr == entry) {
+            *entry_ptr = entry->next;
+            cache_entry_free(entry);
+            return true;
+        }
+        entry_ptr = &(*entry_ptr)->next;
+    }
+
+    return false;
+}
+
+static bool cache_remove_entry_if_empty(mdns_cache_entry_t *entry)
+{
+    if (!entry || entry->addr_list || entry->service_cache_list) {
+        return false;
+    }
+    return cache_remove_entry(entry);
+}
+
+static mdns_cache_entry_t *cache_add_entry(const char *hostname, const esp_netif_t *esp_netif,
+                                           mdns_ip_protocol_t ip_protocol)
+{
+    mdns_cache_entry_t *entry = mdns_mem_calloc(1, sizeof(mdns_cache_entry_t));
+    if (!entry) {
+        HOOK_MALLOC_FAILED;
+        return NULL;
+    }
+
+    if (!mdns_utils_str_null_or_empty(hostname)) {
+        entry->hostname = mdns_mem_strdup(hostname);
+        if (!entry->hostname) {
+            HOOK_MALLOC_FAILED;
+            mdns_mem_free(entry);
+            return NULL;
+        }
+    }
+
+    entry->esp_netif = (esp_netif_t *)esp_netif;
+    entry->ip_protocol = ip_protocol;
+    entry->next = s_cache;
+    s_cache = entry;
+    return entry;
+}
+
+static mdns_cache_entry_t *cache_get_or_add_entry(const char *hostname, const esp_netif_t *esp_netif,
+                                                  mdns_ip_protocol_t ip_protocol)
+{
+    mdns_cache_entry_t *entry = cache_find_entry(hostname, esp_netif, ip_protocol);
+    return entry ? entry : cache_add_entry(hostname, esp_netif, ip_protocol);
+}
+
+static mdns_service_cache_t *cache_add_service(mdns_cache_entry_t *entry, const char *instance, const char *service,
+                                               const char *proto)
+{
+    if (!entry) {
+        return NULL;
+    }
+
+    mdns_service_cache_t *service_entry = mdns_mem_calloc(1, sizeof(mdns_service_cache_t));
+    if (!service_entry) {
+        HOOK_MALLOC_FAILED;
+        return NULL;
+    }
+
+    if (!mdns_utils_str_null_or_empty(instance)) {
+        service_entry->instance_name = mdns_mem_strdup(instance);
+        if (!service_entry->instance_name) {
+            HOOK_MALLOC_FAILED;
+            service_entry_free(service_entry);
+            return NULL;
+        }
+    }
+
+    if (!mdns_utils_str_null_or_empty(service)) {
+        service_entry->service = mdns_mem_strdup(service);
+        if (!service_entry->service) {
+            HOOK_MALLOC_FAILED;
+            service_entry_free(service_entry);
+            return NULL;
+        }
+    }
+
+    if (!mdns_utils_str_null_or_empty(proto)) {
+        service_entry->proto = mdns_mem_strdup(proto);
+        if (!service_entry->proto) {
+            HOOK_MALLOC_FAILED;
+            service_entry_free(service_entry);
+            return NULL;
+        }
+    }
+
+    service_entry->next = entry->service_cache_list;
+    entry->service_cache_list = service_entry;
+    return service_entry;
+}
+
+static bool cache_move_service(mdns_cache_entry_t *old_entry, mdns_cache_entry_t *new_entry, mdns_service_cache_t *cache)
+{
+    if (!old_entry || !new_entry || !cache) {
+        return false;
+    }
+
+    mdns_service_cache_t **old_entry_cache = &old_entry->service_cache_list;
+
+    while (*old_entry_cache) {
+        if (*old_entry_cache == cache) {
+            *old_entry_cache = cache->next;
+            cache->next = new_entry->service_cache_list;
+            new_entry->service_cache_list = cache;
+
+            if (!old_entry->service_cache_list) {
+                cache_remove_entry(old_entry);
+            }
+            return true;
+        }
+        old_entry_cache = &(*old_entry_cache)->next;
+    }
+
+    ESP_LOGE(TAG, "No target service in old entry");
+    return false;
+}
+
+static bool cache_remove_service(mdns_cache_entry_t *entry, mdns_service_cache_t *service_entry)
+{
+    if (!entry || !service_entry) {
+        return false;
+    }
+
+    mdns_service_cache_t **service_entry_ptr = &entry->service_cache_list;
+    while (*service_entry_ptr) {
+        if (*service_entry_ptr == service_entry) {
+            *service_entry_ptr = service_entry->next;
+            service_entry_free(service_entry);
+            if (!entry->service_cache_list) {
+                cache_remove_entry(entry);
+            }
+            return true;
+        }
+        service_entry_ptr = &(*service_entry_ptr)->next;
+    }
+
+    return false;
+}
+
+/**
+ * @brief Remove all service caches by service and proto.
+ *
+ * @param service       The service name to remove.
+ * @param proto         The protocol to remove.
+ */
+static void remove_service_caches(const char *service, const char *proto)
+{
+    mdns_cache_entry_t **entry_ptr = &s_cache;
+
+    while (*entry_ptr) {
+        mdns_cache_entry_t *entry = *entry_ptr;
+        mdns_service_cache_t **service_ptr = &entry->service_cache_list;
+
+        while (*service_ptr) {
+            mdns_service_cache_t *cache = *service_ptr;
+            if (names_equal(cache->service, service) && names_equal(cache->proto, proto)) {
+                *service_ptr = cache->next;
+                service_entry_free(cache);
+                continue;
+            }
+            service_ptr = &(*service_ptr)->next;
+        }
+
+        if (!entry->service_cache_list) {
+            *entry_ptr = entry->next;
+            cache_entry_free(entry);
+            continue;
+        }
+        entry_ptr = &(*entry_ptr)->next;
+    }
+}
+
+mdns_cache_update_result_t mdns_priv_cache_update_ptr(const esp_netif_t *esp_netif, mdns_ip_protocol_t ip_protocol,
+                                                      const char *instance, const char *service, const char *proto,
+                                                      uint32_t ttl)
+{
+    if (mdns_utils_str_null_or_empty(instance) || mdns_utils_str_null_or_empty(service)
+            || mdns_utils_str_null_or_empty(proto)) {
+        return MDNS_CACHE_NO_CHANGE;
+    }
+
+    mdns_cache_entry_t *owner_entry = NULL;
+    mdns_service_cache_t *service_entry = cache_find_service(esp_netif, ip_protocol, instance,
+                                                             service, proto, &owner_entry);
+    mdns_cache_update_result_t result = MDNS_CACHE_NO_CHANGE;
+    bool new_service = false;
+
+    if (ttl == 0) {
+        if (!service_entry) {
+            return MDNS_CACHE_NO_CHANGE;
+        }
+
+        if (service_entry->ptr_present) {
+            // Notify PTR goodbye before the service cache is removed.
+            bool notified = mdns_priv_browse_notify_ptr_goodbye_from_service_cache(owner_entry, service_entry);
+            if (!notified) {
+                ESP_LOGE(TAG, "Failed to notify PTR goodbye");
+            }
+        }
+
+        // A PTR goodbye removes the whole service cache entry.
+        return cache_remove_service(owner_entry, service_entry) ? MDNS_CACHE_REMOVED : MDNS_CACHE_NO_CHANGE;
+    }
+
+    if (!service_entry) {
+        // Uncached PTR records will all be stored in hostname == NULL entry temporarily
+        owner_entry = cache_get_or_add_entry(NULL, esp_netif, ip_protocol);
+        if (!owner_entry) {
+            return MDNS_CACHE_ERROR;
+        }
+
+        service_entry = cache_add_service(owner_entry, instance, service, proto);
+        if (!service_entry) {
+            cache_remove_entry_if_empty(owner_entry);
+            return MDNS_CACHE_ERROR;
+        }
+        new_service = true;
+    }
+
+    bool changed = !service_entry->ptr_present;
+    service_entry->ptr_present = true;
+    changed |= update_ttl(&service_entry->ptr_ttl, ttl);
+
+    if (changed) {
+        result = MDNS_CACHE_UPDATED;
+    }
+
+    if (new_service) {
+        result = MDNS_CACHE_ADDED;
+    }
+
+    service_cache_mark_sync_out(service_entry, result, MDNS_CACHE_RECORD_PTR, MDNS_CACHE_CONSUMER_BROWSE);
+    return result;
+}
+
+static mdns_cache_update_result_t service_cache_srv_update(mdns_service_cache_t *cache, uint16_t priority, uint16_t weight,
+                                                           uint16_t port, uint32_t ttl)
+{
+    mdns_cache_update_result_t result = MDNS_CACHE_NO_CHANGE;
+
+    if (!cache->srv_present) {
+        cache->srv_present = true;
+        result = MDNS_CACHE_UPDATED;
+    }
+    if (cache->priority != priority) {
+        cache->priority = priority;
+        result = MDNS_CACHE_UPDATED;
+    }
+    if (cache->weight != weight) {
+        cache->weight = weight;
+        result = MDNS_CACHE_UPDATED;
+    }
+    if (cache->port != port) {
+        cache->port = port;
+        result = MDNS_CACHE_UPDATED;
+    }
+    if (update_ttl(&cache->srv_ttl, ttl)) {
+        result = MDNS_CACHE_UPDATED;
+    }
+
+    return result;
+}
+
+mdns_cache_update_result_t mdns_priv_cache_update_srv(const esp_netif_t *esp_netif, mdns_ip_protocol_t ip_protocol,
+                                                      const char *hostname, const char *instance, const char *service,
+                                                      const char *proto, uint16_t priority, uint16_t weight,
+                                                      uint16_t port, uint32_t ttl)
+{
+    mdns_cache_entry_t *owner_entry = NULL;
+    mdns_service_cache_t *service_entry = cache_find_service(esp_netif, ip_protocol, instance, service,
+                                                             proto, &owner_entry);
+    mdns_cache_entry_t *host_entry = NULL;
+    mdns_cache_update_result_t result = MDNS_CACHE_NO_CHANGE;
+
+    if (ttl == 0) {
+        if (!service_entry || !service_entry->srv_present) {
+            return MDNS_CACHE_NO_CHANGE;
+        }
+
+        service_entry->srv_present = false;
+        service_entry->priority = 0;
+        service_entry->weight = 0;
+        service_entry->port = 0;
+        service_entry->srv_ttl = 0;
+
+        if (service_cache_is_empty(service_entry)) {
+            return cache_remove_service(owner_entry, service_entry) ? MDNS_CACHE_REMOVED : MDNS_CACHE_NO_CHANGE;
+        }
+
+        service_cache_mark_sync_out(service_entry, MDNS_CACHE_UPDATED, MDNS_CACHE_RECORD_SRV, MDNS_CACHE_CONSUMER_BROWSE);
+
+        return MDNS_CACHE_UPDATED;
+    }
+
+    if (owner_entry && names_equal(owner_entry->hostname, hostname)) {
+        host_entry = owner_entry;
+    } else {
+        host_entry = cache_get_or_add_entry(hostname, esp_netif, ip_protocol);
+        if (!host_entry) {
+            return MDNS_CACHE_ERROR;
+        }
+    }
+
+    if (!service_entry) {
+        service_entry = cache_add_service(host_entry, instance, service, proto);
+        if (!service_entry) {
+            cache_remove_entry_if_empty(host_entry);
+            return MDNS_CACHE_ERROR;
+        }
+        result = MDNS_CACHE_ADDED;
+    } else if (owner_entry != host_entry) {
+        if (!cache_move_service(owner_entry, host_entry, service_entry)) {
+            return MDNS_CACHE_ERROR;
+        }
+        result = MDNS_CACHE_UPDATED;
+    }
+
+    mdns_cache_update_result_t srv_result = service_cache_srv_update(service_entry, priority, weight, port, ttl);
+    if (result == MDNS_CACHE_NO_CHANGE) {
+        result = srv_result;
+    }
+
+    service_cache_mark_sync_out(service_entry, result, MDNS_CACHE_RECORD_SRV, MDNS_CACHE_CONSUMER_BROWSE);
+    return result;
+}
+
+static bool txt_item_equal(const mdns_txt_linked_item_t *a, const mdns_txt_linked_item_t *b)
+{
+    if (!a || !b || !names_equal(a->key, b->key)) {
+        return false;
+    }
+    if (a->value_len != b->value_len) {
+        return false;
+    }
+    if (!a->value && !b->value) {
+        return true;
+    }
+    return a->value && b->value && memcmp(a->value, b->value, a->value_len) == 0;
+}
+
+static bool txt_list_contains(const mdns_txt_linked_item_t *txt_list, const mdns_txt_linked_item_t *item)
+{
+    while (txt_list) {
+        if (txt_item_equal(txt_list, item)) {
+            return true;
+        }
+        txt_list = txt_list->next;
+    }
+    return false;
+}
+
+static size_t txt_list_count(const mdns_txt_linked_item_t *txt_list)
+{
+    size_t count = 0;
+    while (txt_list) {
+        count++;
+        txt_list = txt_list->next;
+    }
+    return count;
+}
+
+static bool txt_list_equal(const mdns_txt_linked_item_t *a, const mdns_txt_linked_item_t *b)
+{
+    if (a == b) {
+        return true;
+    }
+
+    if (txt_list_count(a) != txt_list_count(b)) {
+        return false;
+    }
+
+    for (const mdns_txt_linked_item_t *it = a; it; it = it->next) {
+        if (!txt_list_contains(b, it)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+static mdns_cache_update_result_t service_cache_txt_update(mdns_service_cache_t *service_entry,
+                                                           mdns_txt_linked_item_t *new_txt, uint32_t ttl)
+{
+    if (!service_entry) {
+        mdns_utils_free_txt_linked_list(new_txt);
+        return MDNS_CACHE_ERROR;
+    }
+
+    if (txt_list_equal(service_entry->txt_list, new_txt) && service_entry->txt_present
+            && !update_ttl(&service_entry->txt_ttl, ttl)) {
+        mdns_utils_free_txt_linked_list(new_txt);
+        return MDNS_CACHE_NO_CHANGE;
+    }
+
+    service_entry->txt_present = true;
+    service_entry->txt_ttl = ttl;
+    mdns_txt_linked_item_t *old_txt = service_entry->txt_list;
+    service_entry->txt_list = new_txt;
+    mdns_utils_free_txt_linked_list(old_txt);
+    return MDNS_CACHE_UPDATED;
+}
+
+mdns_cache_update_result_t mdns_priv_cache_update_txt(const esp_netif_t *esp_netif, mdns_ip_protocol_t ip_protocol,
+                                                      const char *instance, const char *service, const char *proto,
+                                                      mdns_txt_linked_item_t *txt, uint32_t ttl)
+{
+    mdns_cache_entry_t *owner_entry = NULL;
+    mdns_service_cache_t *service_entry = cache_find_service(esp_netif, ip_protocol, instance,
+                                                             service, proto, &owner_entry);
+    mdns_cache_update_result_t result = MDNS_CACHE_NO_CHANGE;
+    bool new_service = false;
+
+    if (ttl == 0) {
+        mdns_utils_free_txt_linked_list(txt);
+        if (!service_entry || !service_entry->txt_present) {
+            return MDNS_CACHE_NO_CHANGE;
+        }
+
+        mdns_utils_free_txt_linked_list(service_entry->txt_list);
+        service_entry->txt_list = NULL;
+        service_entry->txt_present = false;
+        service_entry->txt_ttl = 0;
+
+        if (service_cache_is_empty(service_entry)) {
+            return cache_remove_service(owner_entry, service_entry) ? MDNS_CACHE_REMOVED : MDNS_CACHE_NO_CHANGE;
+        }
+
+        service_cache_mark_sync_out(service_entry, MDNS_CACHE_UPDATED, MDNS_CACHE_RECORD_TXT, MDNS_CACHE_CONSUMER_BROWSE);
+
+        return MDNS_CACHE_UPDATED;
+    }
+
+    if (!service_entry) {
+        owner_entry = cache_get_or_add_entry(NULL, esp_netif, ip_protocol);
+        if (!owner_entry) {
+            mdns_utils_free_txt_linked_list(txt);
+            return MDNS_CACHE_ERROR;
+        }
+
+        service_entry = cache_add_service(owner_entry, instance, service, proto);
+        if (!service_entry) {
+            cache_remove_entry_if_empty(owner_entry);
+            mdns_utils_free_txt_linked_list(txt);
+            return MDNS_CACHE_ERROR;
+        }
+
+        new_service = true;
+    }
+
+    result = service_cache_txt_update(service_entry, txt, ttl);
+
+    if (new_service) {
+        result = MDNS_CACHE_ADDED;
+    }
+
+    service_cache_mark_sync_out(service_entry, result, MDNS_CACHE_RECORD_TXT, MDNS_CACHE_CONSUMER_BROWSE);
+    return result;
+}
+
+static mdns_cache_update_result_t cache_update_addr(const esp_netif_t *esp_netif, mdns_ip_protocol_t ip_protocol,
+                                                    const char *hostname, const esp_ip_addr_t *addr, uint32_t ttl,
+                                                    bool create_if_absent)
+{
+    mdns_cache_entry_t *entry = NULL;
+    bool addr_added = false;
+    bool ttl_changed = false;
+    mdns_cache_update_result_t result = MDNS_CACHE_NO_CHANGE;
+
+    if (ttl == 0) {
+        entry = cache_find_entry(hostname, esp_netif, ip_protocol);
+        if (!entry) {
+            return MDNS_CACHE_NO_CHANGE;
+        }
+
+        // Remove addr
+        mdns_cache_addr_t **addr_ptr = &entry->addr_list;
+        while (*addr_ptr) {
+            if (addr_equal(&(*addr_ptr)->addr, addr)) {
+                mdns_cache_addr_t *removed_addr = *addr_ptr;
+                *addr_ptr = removed_addr->next;
+                mdns_mem_free(removed_addr);
+
+                for (mdns_service_cache_t *service = entry->service_cache_list; service; service = service->next) {
+                    service_cache_mark_sync_out(service, MDNS_CACHE_UPDATED, MDNS_CACHE_RECORD_ADDR, MDNS_CACHE_CONSUMER_BROWSE);
+                }
+
+                cache_remove_entry_if_empty(entry);
+
+                return MDNS_CACHE_REMOVED;
+            }
+            addr_ptr = &(*addr_ptr)->next;
+        }
+
+        return MDNS_CACHE_NO_CHANGE;
+    }
+
+    entry = create_if_absent ? cache_get_or_add_entry(hostname, esp_netif, ip_protocol)
+            : cache_find_entry(hostname, esp_netif, ip_protocol);
+    if (!entry) {
+        return create_if_absent ? MDNS_CACHE_ERROR : MDNS_CACHE_NO_CHANGE;
+    }
+
+    mdns_cache_addr_t *addr_entry = entry->addr_list;
+    while (addr_entry) {
+        if (addr_equal(&addr_entry->addr, addr)) {
+            ttl_changed = update_ttl(&addr_entry->ttl, ttl);
+            break;
+        }
+        addr_entry = addr_entry->next;
+    }
+
+    if (!addr_entry) {
+        mdns_cache_addr_t *new_addr = mdns_mem_calloc(1, sizeof(mdns_cache_addr_t));
+        if (!new_addr) {
+            HOOK_MALLOC_FAILED;
+            cache_remove_entry_if_empty(entry);
+            return MDNS_CACHE_ERROR;
+        }
+        new_addr->addr = *addr;
+        new_addr->ttl = ttl;
+        new_addr->next = entry->addr_list;
+        entry->addr_list = new_addr;
+        addr_added = true;
+    }
+
+    result = (addr_added || ttl_changed) ? MDNS_CACHE_UPDATED : MDNS_CACHE_NO_CHANGE;
+    for (mdns_service_cache_t *service = entry->service_cache_list; service; service = service->next) {
+        service_cache_mark_sync_out(service, result, MDNS_CACHE_RECORD_ADDR, MDNS_CACHE_CONSUMER_BROWSE);
+    }
+
+    return result;
+}
+
+mdns_cache_update_result_t mdns_priv_cache_update_addr(const esp_netif_t *esp_netif, mdns_ip_protocol_t ip_protocol,
+                                                       const char *hostname, const esp_ip_addr_t *addr, uint32_t ttl)
+{
+    return cache_update_addr(esp_netif, ip_protocol, hostname, addr, ttl, true);
+}
+
+mdns_cache_update_result_t mdns_priv_cache_update_existing_addr(const esp_netif_t *esp_netif, mdns_ip_protocol_t ip_protocol,
+                                                                const char *hostname, const esp_ip_addr_t *addr, uint32_t ttl)
+{
+    return cache_update_addr(esp_netif, ip_protocol, hostname, addr, ttl, false);
+}
+
+void mdns_priv_cache_clear(void)
+{
+    while (s_cache) {
+        mdns_cache_entry_t *entry = s_cache;
+        s_cache = s_cache->next;
+        cache_entry_free(entry);
+    }
+}
+
+static bool project_txt(const mdns_txt_linked_item_t *txt_list, mdns_txt_item_t **out_txt, uint8_t **out_value_len,
+                        size_t *out_count)
+{
+    esp_err_t __attribute__((unused))ret = ESP_OK;
+    *out_txt = NULL;
+    *out_value_len = NULL;
+    *out_count = 0;
+
+    size_t count = 0;
+    for (const mdns_txt_linked_item_t *txt = txt_list; txt; txt = txt->next) {
+        count++;
+    }
+    if (count == 0) {
+        return true;
+    }
+
+    mdns_txt_item_t *txt_items = mdns_mem_calloc(count, sizeof(mdns_txt_item_t));
+    if (!txt_items) {
+        HOOK_MALLOC_FAILED;
+        return false;
+    }
+    uint8_t *value_len = mdns_mem_calloc(count, sizeof(uint8_t));
+    if (!value_len) {
+        HOOK_MALLOC_FAILED;
+        mdns_mem_free(txt_items);
+        return false;
+    }
+
+    size_t i = 0;
+    for (const mdns_txt_linked_item_t *txt = txt_list; txt; txt = txt->next, i++) {
+        txt_items[i].key = mdns_mem_strdup(txt->key);
+        ESP_GOTO_ON_FALSE(txt_items[i].key, ESP_ERR_NO_MEM, error, TAG, "Failed to allocate key");
+
+        value_len[i] = txt->value_len;
+        if (txt->value_len == 0) {
+            continue;
+        }
+        ESP_GOTO_ON_FALSE(txt->value, ESP_ERR_INVALID_ARG, cleanup, TAG, "Invalid value");
+
+        txt_items[i].value = mdns_mem_calloc(txt->value_len + 1, sizeof(char));
+        ESP_GOTO_ON_FALSE(txt_items[i].value, ESP_ERR_NO_MEM, error, TAG, "Failed to allocate value");
+        memcpy((char *)txt_items[i].value, txt->value, txt->value_len);
+    }
+
+    *out_value_len = value_len;
+    *out_count = count;
+    *out_txt = txt_items;
+    return true;
+
+error:
+    HOOK_MALLOC_FAILED;
+cleanup:
+    for (size_t i = 0; i < count; i++) {
+        mdns_mem_free((char *)txt_items[i].key);
+        mdns_mem_free((char *)txt_items[i].value);
+    }
+    mdns_mem_free(value_len);
+    mdns_mem_free(txt_items);
+    return false;
+}
+
+static bool project_addr(const mdns_cache_addr_t *addr_list, mdns_ip_addr_t **out_addr_list)
+{
+    mdns_ip_addr_t *head = NULL;
+    mdns_ip_addr_t **tail = &head;
+
+    *out_addr_list = NULL;
+
+    for (const mdns_cache_addr_t *addr = addr_list; addr; addr = addr->next) {
+        mdns_ip_addr_t *new_addr = mdns_mem_calloc(1, sizeof(mdns_ip_addr_t));
+        if (!new_addr) {
+            HOOK_MALLOC_FAILED;
+            while (head) {
+                mdns_ip_addr_t *next = head->next;
+                mdns_mem_free(head);
+                head = next;
+            }
+            return false;
+        }
+        new_addr->addr = addr->addr;
+        *tail = new_addr;
+        tail = &new_addr->next;
+    }
+
+    *out_addr_list = head;
+    return true;
+}
+
+esp_err_t mdns_priv_service_cache_to_result(const mdns_cache_entry_t *entry, const mdns_service_cache_t *service,
+                                            mdns_result_t **out_result)
+{
+    esp_err_t ret = ESP_OK;
+    mdns_result_t *result = mdns_mem_calloc(1, sizeof(mdns_result_t));
+    ESP_GOTO_ON_FALSE(result, ESP_ERR_NO_MEM, error, TAG, "Failed to allocate result");
+
+    result->esp_netif = entry->esp_netif;
+    result->ttl = service->ptr_ttl;
+    result->ip_protocol = entry->ip_protocol;
+
+    if (!mdns_utils_str_null_or_empty(service->instance_name)) {
+        result->instance_name = mdns_mem_strdup(service->instance_name);
+        ESP_GOTO_ON_FALSE(result->instance_name, ESP_ERR_NO_MEM, error, TAG, "Failed to allocate instance name");
+    }
+    if (!mdns_utils_str_null_or_empty(service->service)) {
+        result->service_type = mdns_mem_strdup(service->service);
+        ESP_GOTO_ON_FALSE(result->service_type, ESP_ERR_NO_MEM, error, TAG, "Failed to allocate service type");
+    }
+    if (!mdns_utils_str_null_or_empty(service->proto)) {
+        result->proto = mdns_mem_strdup(service->proto);
+        ESP_GOTO_ON_FALSE(result->proto, ESP_ERR_NO_MEM, error, TAG, "Failed to allocate protocol");
+    }
+
+    if (service->srv_present) {
+        if (entry->hostname) {
+            result->hostname = mdns_mem_strdup(entry->hostname);
+            ESP_GOTO_ON_FALSE(result->hostname, ESP_ERR_NO_MEM, error, TAG, "Failed to allocate hostname");
+        }
+        result->port = service->port;
+        // Address list is bound to hostname, so when srv is removed, the address list should not be projected.
+        ESP_GOTO_ON_FALSE(project_addr(entry->addr_list, &result->addr), ESP_ERR_NO_MEM, error, TAG,
+                          "Failed to project address list");
+    }
+
+    if (service->txt_present) {
+        ESP_GOTO_ON_FALSE(project_txt(service->txt_list, &result->txt, &result->txt_value_len, &result->txt_count),
+                          ESP_ERR_NO_MEM, error, TAG, "Failed to project TXT");
+    }
+
+    *out_result = result;
+    return ret;
+
+error:
+    HOOK_MALLOC_FAILED;
+    mdns_priv_query_results_free(result);
+    return ret;
+}
+
+void mdns_priv_cache_process_sync(void)
+{
+    for (mdns_cache_entry_t *entry = s_cache; entry; entry = entry->next) {
+        for (mdns_service_cache_t *service = entry->service_cache_list; service; service = service->next) {
+            if (service->sync_consumers & MDNS_CACHE_CONSUMER_BROWSE) {
+                mdns_cache_record_mask_t records = service->sync_records;
+                if (!mdns_priv_browse_update_from_service_cache(entry, service, records)) {
+                    ESP_LOGW(TAG, "Failed to notify browse, dropping sync mark");
+                }
+                service_cache_clear_sync_out(service, MDNS_CACHE_CONSUMER_BROWSE, 0);
+            }
+            // TODO: When resolver is implemented, add resolver sync processing here.
+        }
+    }
+}
+
+bool mdns_priv_cache_notify_browse(mdns_browse_t *browse)
+{
+    if (!browse) {
+        return false;
+    }
+
+    bool notified = true;
+
+    for (mdns_cache_entry_t *entry = s_cache; entry; entry = entry->next) {
+        for (mdns_service_cache_t *service = entry->service_cache_list; service; service = service->next) {
+            notified &= mdns_priv_browse_notify_from_service_cache(entry, service, browse);
+        }
+    }
+
+    return notified;
+}
+
+void mdns_priv_cache_remove_service_cache_if_unused(const char *service, const char *proto)
+{
+    if (mdns_utils_str_null_or_empty(service) || mdns_utils_str_null_or_empty(proto)) {
+        return;
+    }
+
+    if (mdns_priv_browse_has_service(service, proto)) {
+        return;
+    }
+
+    remove_service_caches(service, proto);
+}

--- a/components/mdns/mdns_receive.c
+++ b/components/mdns/mdns_receive.c
@@ -21,6 +21,18 @@
 #include "mdns_querier.h"
 #include "mdns_pcb.h"
 #include "mdns_responder.h"
+#ifdef CONFIG_MDNS_ENABLE_BROWSE
+#include "mdns_cache.h"
+#endif
+
+#ifdef CONFIG_MDNS_ENABLE_BROWSE
+typedef struct mdns_rx_staged_ip_s {
+    char hostname[MDNS_NAME_BUF_LEN];
+    esp_ip_addr_t ip;
+    uint32_t ttl;
+    struct mdns_rx_staged_ip_s *next;
+} mdns_rx_staged_ip_t;
+#endif
 
 static const char *TAG = "mdns_receive";
 
@@ -220,6 +232,42 @@ static int get_txt_item_len(const uint8_t *data, size_t len)
     return len;
 }
 
+static esp_err_t parse_txt_item_data(const uint8_t *data, size_t item_len, const char **key_out, char **value_out,
+                                     uint8_t *value_len_out)
+{
+    int key_len = get_txt_item_len(data, item_len);
+    if (key_len < 0) {
+        // Invalid item with no key
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    *key_out = mdns_mem_strndup((const char *)data, key_len);
+    if (!*key_out) {
+        HOOK_MALLOC_FAILED;
+        return ESP_ERR_NO_MEM;
+    }
+
+    // Skips '=' only if presents
+    int value_index = key_len + ((key_len < item_len) ? 1 : 0);
+    uint8_t value_len = item_len > value_index ? item_len - value_index : 0;
+    *value_len_out = value_len;
+
+    if (value_len > 0) {
+        *value_out = (char *)mdns_mem_calloc(value_len + 1, sizeof(char));
+        if (!*value_out) {
+            HOOK_MALLOC_FAILED;
+            mdns_mem_free((char *)*key_out);
+            *key_out = NULL;
+            return ESP_ERR_NO_MEM;
+        }
+        memcpy(*value_out, data + value_index, value_len);
+    } else {
+        *value_out = NULL;
+    }
+
+    return ESP_OK;
+}
+
 /**
  * @brief  Create TXT result array from parsed TXT data
  */
@@ -227,9 +275,9 @@ static void result_txt_create(const uint8_t *data, size_t len, mdns_txt_item_t *
                               size_t *out_count)
 {
     *out_txt = NULL;
+    *out_value_len = NULL;
     *out_count = 0;
-    uint16_t i = 0, y;
-    size_t part_len = 0;
+
     int num_items = get_txt_items_count(data, len);
     if (num_items < 0 || num_items > SIZE_MAX / sizeof(mdns_txt_item_t)) {
         // Error: num_items is incorrect (or too large to allocate)
@@ -240,66 +288,51 @@ static void result_txt_create(const uint8_t *data, size_t len, mdns_txt_item_t *
         return;
     }
 
-    mdns_txt_item_t *txt = (mdns_txt_item_t *)mdns_mem_malloc(sizeof(mdns_txt_item_t) * num_items);
+    mdns_txt_item_t *txt = (mdns_txt_item_t *)mdns_mem_calloc(num_items, sizeof(mdns_txt_item_t));
     if (!txt) {
         HOOK_MALLOC_FAILED;
         return;
     }
-    uint8_t *txt_value_len = (uint8_t *)mdns_mem_malloc(num_items);
+    uint8_t *txt_value_len = (uint8_t *)mdns_mem_calloc(num_items, sizeof(uint8_t));
     if (!txt_value_len) {
         mdns_mem_free(txt);
         HOOK_MALLOC_FAILED;
         return;
     }
-    memset(txt, 0, sizeof(mdns_txt_item_t) * num_items);
-    memset(txt_value_len, 0, num_items);
+
+    uint16_t data_index = 0;
     size_t txt_num = 0;
 
-    while (i < len && txt_num < num_items) {
-        part_len = data[i++];
-        if (!part_len) {
+    while (data_index < len && txt_num < num_items) {
+        uint8_t item_len = data[data_index++];
+        if (item_len == 0) {
             break;
         }
 
-        if ((i + part_len) > len) {
+        if ((data_index + item_len) > len) {
             goto handle_error;//error
         }
 
-        int name_len = get_txt_item_len(data + i, part_len);
-        if (name_len < 0) {  //invalid item (no name)
-            i += part_len;
+        esp_err_t err = parse_txt_item_data(data + data_index, item_len, &txt[txt_num].key, (char **)&txt[txt_num].value,
+                                            &txt_value_len[txt_num]);
+        data_index += item_len;
+
+        switch (err) {
+        case ESP_OK:
+            txt_num++;
+            break;
+        case ESP_ERR_INVALID_ARG:
+            // Invalid item with no key
             continue;
+        default:
+            goto handle_error;
         }
-        char *key = (char *) mdns_mem_malloc(name_len + 1);
-        if (!key) {
-            HOOK_MALLOC_FAILED;
-            goto handle_error;//error
-        }
+    }
 
-        mdns_txt_item_t *t = &txt[txt_num];
-        uint8_t *value_len = &txt_value_len[txt_num];
-        txt_num++;
-
-        memcpy(key, data + i, name_len);
-        key[name_len] = 0;
-        i += name_len + (name_len < part_len); // skip '=' only if present
-        t->key = key;
-
-        int new_value_len = part_len - name_len - 1;
-        if (new_value_len > 0) {
-            char *value = (char *) mdns_mem_malloc(new_value_len + 1);
-            if (!value) {
-                HOOK_MALLOC_FAILED;
-                goto handle_error;//error
-            }
-            memcpy(value, data + i, new_value_len);
-            value[new_value_len] = 0;
-            *value_len = new_value_len;
-            i += new_value_len;
-            t->value = value;
-        } else {
-            t->value = NULL;
-        }
+    if (txt_num == 0) {
+        mdns_mem_free(txt);
+        mdns_mem_free(txt_value_len);
+        return;
     }
 
     *out_txt = txt;
@@ -308,7 +341,7 @@ static void result_txt_create(const uint8_t *data, size_t len, mdns_txt_item_t *
     return;
 
 handle_error :
-    for (y = 0; y < txt_num; y++) {
+    for (int y = 0; y < txt_num; y++) {
         mdns_txt_item_t *t = &txt[y];
         mdns_mem_free((char *)t->key);
         mdns_mem_free((char *)t->value);
@@ -316,6 +349,67 @@ handle_error :
     mdns_mem_free(txt_value_len);
     mdns_mem_free(txt);
 }
+
+#ifdef CONFIG_MDNS_ENABLE_BROWSE
+static bool result_txt_linked_list_create(const uint8_t *data, size_t len, mdns_txt_linked_item_t **out_txt)
+{
+    *out_txt = NULL;
+    mdns_txt_linked_item_t *txt_linked_list = NULL;
+    mdns_txt_linked_item_t **txt_ptr = &txt_linked_list;
+    uint16_t data_index = 0;
+    int txt_num = 0;
+    int num_items = get_txt_items_count(data, len);
+    if (num_items < 0 || num_items > SIZE_MAX / sizeof(mdns_txt_item_t)) {
+        // Error: num_items is incorrect (or too large to allocate)
+        return false;
+    }
+    if (num_items == 0) {
+        // Empty TXT, no need to allocate
+        return true;
+    }
+
+    while (data_index < len && txt_num < num_items) {
+        uint8_t item_len = data[data_index++];
+        if (item_len == 0) {
+            break;
+        }
+        if ((data_index + item_len) > len) {
+            goto error;
+        }
+
+        *txt_ptr = (mdns_txt_linked_item_t *)mdns_mem_calloc(1, sizeof(mdns_txt_linked_item_t));
+        if (!*txt_ptr) {
+            HOOK_MALLOC_FAILED;
+            goto error;
+        }
+
+        esp_err_t err = parse_txt_item_data(data + data_index, item_len, &(*txt_ptr)->key, &(*txt_ptr)->value,
+                                            &(*txt_ptr)->value_len);
+
+        data_index += item_len;
+        switch (err) {
+        case ESP_OK:
+            txt_num++;
+            txt_ptr = &(*txt_ptr)->next;
+            break;
+        case ESP_ERR_INVALID_ARG:
+            // Invalid item with no key
+            mdns_mem_free(*txt_ptr);
+            *txt_ptr = NULL;
+            continue;
+        default:
+            goto error;
+        }
+    }
+
+    *out_txt = txt_linked_list;
+    return true;
+
+error:
+    mdns_utils_free_txt_linked_list(txt_linked_list);
+    return false;
+}
+#endif /* CONFIG_MDNS_ENABLE_BROWSE */
 
 #ifdef CONFIG_LWIP_IPV4
 /**
@@ -585,6 +679,48 @@ static void remove_parsed_question(mdns_parsed_packet_t *parsed_packet, uint16_t
     }
 }
 
+#ifdef CONFIG_MDNS_ENABLE_BROWSE
+static void rx_staged_ip_free(mdns_rx_staged_ip_t *staged_ip)
+{
+    while (staged_ip) {
+        mdns_rx_staged_ip_t *next = staged_ip->next;
+        mdns_mem_free(staged_ip);
+        staged_ip = next;
+    }
+}
+
+static void rx_staged_ip_add(mdns_rx_staged_ip_t **staged_ip, const char *hostname, const esp_ip_addr_t *ip, uint32_t ttl)
+{
+    if (!staged_ip || mdns_utils_str_null_or_empty(hostname) || !ip) {
+        return;
+    }
+
+    mdns_rx_staged_ip_t *new_staged_ip = (mdns_rx_staged_ip_t *)mdns_mem_calloc(1, sizeof(mdns_rx_staged_ip_t));
+    if (!new_staged_ip) {
+        HOOK_MALLOC_FAILED;
+        return;
+    }
+
+    strncpy(new_staged_ip->hostname, hostname, MDNS_NAME_BUF_LEN - 1);
+    new_staged_ip->ip = *ip;
+    new_staged_ip->ttl = ttl;
+    new_staged_ip->next = *staged_ip;
+    *staged_ip = new_staged_ip;
+}
+
+static void rx_staged_ips_apply(const esp_netif_t *esp_netif, mdns_ip_protocol_t ip_protocol,
+                                const mdns_rx_staged_ip_t *staged_ips)
+{
+    if (!esp_netif || !staged_ips) {
+        return;
+    }
+
+    for (const mdns_rx_staged_ip_t *it = staged_ips; it; it = it->next) {
+        (void)mdns_priv_cache_update_existing_addr(esp_netif, ip_protocol, it->hostname, &it->ip, it->ttl);
+    }
+}
+#endif /* CONFIG_MDNS_ENABLE_BROWSE */
+
 /**
  * @brief  main packet parser
  *
@@ -601,19 +737,12 @@ static void mdns_parse_packet(mdns_rx_packet_t *packet)
     mdns_search_once_t *search_result = NULL;
 #ifdef CONFIG_MDNS_ENABLE_BROWSE
     mdns_browse_t *browse_result = NULL;
-    /*
-     * Browse packet limitations (see also mdns_browse_new() / mdns_browse_notify_t in mdns.h):
-     * - Only one active browse is tracked per incoming packet; if a packet answers
-     *   two different browsed service types, only the last match gets staged A/AAAA.
-     * - Staged A/AAAA are applied via mdns_priv_browse_result_add_ip(), which sets
-     *   addresses on the first browse result per target hostname only.
-     */
+    mdns_rx_staged_ip_t *staged_ips = NULL;
+
     mdns_browse_t *packet_browse = NULL;
     char *browse_result_instance = NULL;
     char *browse_result_service = NULL;
     char *browse_result_proto = NULL;
-    mdns_browse_sync_t *out_sync_browse = NULL;
-    mdns_browse_staged_ip_t *staged_browse_ips = NULL;
 #endif
 
     DBG_RX_PACKET(packet, data, len);
@@ -827,10 +956,7 @@ static void mdns_parse_packet(mdns_rx_packet_t *packet)
                 browse_result = mdns_priv_browse_find(name, type, packet->tcpip_if, packet->ip_protocol);
                 if (browse_result) {
                     packet_browse = browse_result;
-                    out_sync_browse = mdns_priv_browse_ensure_sync(browse_result, out_sync_browse);
-                    if (!out_sync_browse) {
-                        goto clear_rx_packet;
-                    }
+
                     if (!browse_result_service) {
                         browse_result_service = (char *)mdns_mem_malloc(MDNS_NAME_BUF_LEN);
                         if (!browse_result_service) {
@@ -874,13 +1000,9 @@ static void mdns_parse_packet(mdns_rx_packet_t *packet)
 #ifdef CONFIG_MDNS_ENABLE_BROWSE
                 if (browse_for_ptr) {
                     packet_browse = browse_for_ptr;
-                    out_sync_browse = mdns_priv_browse_ensure_sync(browse_for_ptr, out_sync_browse);
-                    if (!out_sync_browse) {
-                        goto clear_rx_packet;
-                    }
-                    mdns_priv_browse_result_add_ptr(browse_for_ptr, name->host, browse_for_ptr->service,
-                                                    browse_for_ptr->proto, packet->tcpip_if, packet->ip_protocol,
-                                                    ttl, out_sync_browse);
+                    (void)mdns_priv_cache_update_ptr(mdns_priv_get_esp_netif(packet->tcpip_if), packet->ip_protocol,
+                                                     name->host, browse_for_ptr->service, browse_for_ptr->proto,
+                                                     ttl);
                 } else if (search_result) {
 #else
                 if (search_result) {
@@ -979,11 +1101,9 @@ static void mdns_parse_packet(mdns_rx_packet_t *packet)
                 if (browse_result && !mdns_utils_str_null_or_empty(browse_result_instance)
                         && !mdns_utils_str_null_or_empty(browse_result_service)
                         && !mdns_utils_str_null_or_empty(browse_result_proto)) {
-                    mdns_priv_browse_result_add_srv(browse_result, name->host, browse_result_instance,
-                                                    browse_result_service,
-                                                    browse_result_proto, port, packet->tcpip_if, packet->ip_protocol,
-                                                    ttl,
-                                                    out_sync_browse);
+                    (void)mdns_priv_cache_update_srv(mdns_priv_get_esp_netif(packet->tcpip_if), packet->ip_protocol,
+                                                     name->host, browse_result_instance, browse_result_service,
+                                                     browse_result_proto, priority, weight, port, ttl);
                 }
 #endif
                 if (search_result) {
@@ -1058,15 +1178,17 @@ static void mdns_parse_packet(mdns_rx_packet_t *packet)
 
                 mdns_result_t *result = NULL;
 #ifdef CONFIG_MDNS_ENABLE_BROWSE
+                mdns_txt_linked_item_t *txt_linked_list = NULL;
                 if (browse_result && !mdns_utils_str_null_or_empty(browse_result_instance)
                         && !mdns_utils_str_null_or_empty(browse_result_service)
                         && !mdns_utils_str_null_or_empty(browse_result_proto)) {
-                    result_txt_create(data_ptr, data_len, &txt, &txt_value_len, &txt_count);
-                    mdns_priv_browse_result_add_txt(browse_result, browse_result_instance, browse_result_service,
-                                                    browse_result_proto,
-                                                    txt, txt_value_len, txt_count, packet->tcpip_if,
-                                                    packet->ip_protocol,
-                                                    ttl, out_sync_browse);
+
+                    if (result_txt_linked_list_create(data_ptr, data_len, &txt_linked_list)) {
+                        (void)mdns_priv_cache_update_txt(mdns_priv_get_esp_netif(packet->tcpip_if), packet->ip_protocol,
+                                                         browse_result_instance, browse_result_service, browse_result_proto, txt_linked_list, ttl);
+                        txt_linked_list = NULL;
+                    }
+
                 }
 #endif
                 if (search_result) {
@@ -1140,12 +1262,7 @@ static void mdns_parse_packet(mdns_rx_packet_t *packet)
                 memcpy(ip6.u_addr.ip6.addr, data_ptr, MDNS_ANSWER_AAAA_SIZE);
 #ifdef CONFIG_MDNS_ENABLE_BROWSE
                 if (packet_browse || browse_result) {
-                    mdns_browse_t *browse_ip = browse_result ? browse_result : packet_browse;
-                    out_sync_browse = mdns_priv_browse_ensure_sync(browse_ip, out_sync_browse);
-                    if (out_sync_browse && mdns_priv_browse_stage_ip(&staged_browse_ips, name->host, &ip6,
-                                                                     packet->tcpip_if, packet->ip_protocol, ttl) != ESP_OK) {
-                        goto clear_rx_packet;
-                    }
+                    rx_staged_ip_add(&staged_ips, name->host, &ip6, ttl);
                 }
 #endif
                 if (search_result) {
@@ -1208,12 +1325,7 @@ static void mdns_parse_packet(mdns_rx_packet_t *packet)
                 memcpy(&(ip.u_addr.ip4.addr), data_ptr, 4);
 #ifdef CONFIG_MDNS_ENABLE_BROWSE
                 if (packet_browse || browse_result) {
-                    mdns_browse_t *browse_ip = browse_result ? browse_result : packet_browse;
-                    out_sync_browse = mdns_priv_browse_ensure_sync(browse_ip, out_sync_browse);
-                    if (out_sync_browse && mdns_priv_browse_stage_ip(&staged_browse_ips, name->host, &ip,
-                                                                     packet->tcpip_if, packet->ip_protocol, ttl) != ESP_OK) {
-                        goto clear_rx_packet;
-                    }
+                    rx_staged_ip_add(&staged_ips, name->host, &ip, ttl);
                 }
 #endif
                 if (search_result) {
@@ -1273,44 +1385,16 @@ static void mdns_parse_packet(mdns_rx_packet_t *packet)
         }
     }
 
-#ifdef CONFIG_MDNS_ENABLE_BROWSE
-    if (staged_browse_ips) {
-        mdns_browse_t *browse_apply = packet_browse;
-        if (!browse_apply && out_sync_browse) {
-            browse_apply = out_sync_browse->browse;
-        }
-        out_sync_browse = mdns_priv_browse_ensure_sync(browse_apply, out_sync_browse);
-        if (browse_apply && out_sync_browse) {
-            mdns_priv_browse_apply_staged_ips(browse_apply, staged_browse_ips, out_sync_browse);
-        }
-    }
-    mdns_priv_browse_staged_ip_free(staged_browse_ips);
-    staged_browse_ips = NULL;
-#endif
-
     if (!do_not_reply && mdns_priv_pcb_is_after_probing(packet) && (parsed_packet->questions || parsed_packet->discovery)) {
         mdns_priv_create_answer_from_parsed_packet(parsed_packet);
     }
-#ifdef CONFIG_MDNS_ENABLE_BROWSE
-    if (out_sync_browse) {
-        DBG_BROWSE_RESULTS_WITH_MSG(out_sync_browse->browse->result,
-                                    "Browse %s%s total result:", out_sync_browse->browse->service, out_sync_browse->browse->proto);
-        if (out_sync_browse->sync_result) {
-            DBG_BROWSE_RESULTS_WITH_MSG(out_sync_browse->sync_result->result,
-                                        "Changed result:");
-            mdns_priv_browse_sync(out_sync_browse);
-        } else {
-            mdns_mem_free(out_sync_browse);
-        }
-        out_sync_browse = NULL;
-    }
-#endif
 
 clear_rx_packet:
 #ifdef CONFIG_MDNS_ENABLE_BROWSE
-    mdns_priv_browse_staged_ip_free(staged_browse_ips);
-    staged_browse_ips = NULL;
-#endif
+    rx_staged_ips_apply(mdns_priv_get_esp_netif(packet->tcpip_if), packet->ip_protocol, staged_ips);
+    mdns_priv_cache_process_sync();
+    rx_staged_ip_free(staged_ips);
+#endif /* CONFIG_MDNS_ENABLE_BROWSE */
     while (parsed_packet->questions) {
         mdns_parsed_question_t *question = parsed_packet->questions;
         parsed_packet->questions = parsed_packet->questions->next;
@@ -1348,7 +1432,6 @@ clear_rx_packet:
     mdns_mem_free(browse_result_instance);
     mdns_mem_free(browse_result_service);
     mdns_mem_free(browse_result_proto);
-    mdns_priv_browse_sync_free(out_sync_browse);
 #endif
 }
 

--- a/components/mdns/mdns_service.c
+++ b/components/mdns/mdns_service.c
@@ -23,6 +23,9 @@
 #include "mdns_querier.h"
 #include "mdns_pcb.h"
 #include "mdns_responder.h"
+#ifdef CONFIG_MDNS_ENABLE_BROWSE
+#include "mdns_cache.h"
+#endif
 
 #define MDNS_SERVICE_STACK_DEPTH    CONFIG_MDNS_TASK_STACK_SIZE
 #define MDNS_TASK_PRIORITY          CONFIG_MDNS_TASK_PRIORITY
@@ -145,7 +148,6 @@ static void free_action(mdns_action_t *action)
 #ifdef CONFIG_MDNS_ENABLE_BROWSE
     case ACTION_BROWSE_START:
     case ACTION_BROWSE_END:
-    case ACTION_BROWSE_SYNC:
         mdns_priv_browse_action(action, ACTION_CLEANUP);
         break;
 #endif
@@ -184,7 +186,6 @@ static void execute_action(mdns_action_t *action)
         break;
 #ifdef CONFIG_MDNS_ENABLE_BROWSE
     case ACTION_BROWSE_START:
-    case ACTION_BROWSE_SYNC:
     case ACTION_BROWSE_END:
         mdns_priv_browse_action(action, ACTION_RUN);
         break;
@@ -443,6 +444,7 @@ void mdns_free(void)
     mdns_priv_query_free();
 #ifdef CONFIG_MDNS_ENABLE_BROWSE
     mdns_priv_browse_free();
+    mdns_priv_cache_clear();
 #endif
     mdns_priv_responder_free();
 }

--- a/components/mdns/mdns_utils.c
+++ b/components/mdns/mdns_utils.c
@@ -294,3 +294,14 @@ uint8_t mdns_utils_append_u16(uint8_t *packet, uint16_t *index, uint16_t value)
     mdns_utils_append_u8(packet, index, value & 0xFF);
     return 2;
 }
+
+void mdns_utils_free_txt_linked_list(mdns_txt_linked_item_t *txt)
+{
+    while (txt) {
+        mdns_txt_linked_item_t *next = txt->next;
+        mdns_mem_free((char *)txt->key);
+        mdns_mem_free(txt->value);
+        mdns_mem_free(txt);
+        txt = next;
+    }
+}

--- a/components/mdns/private_include/mdns_browser.h
+++ b/components/mdns/private_include/mdns_browser.h
@@ -20,11 +20,20 @@ extern "C" {
 void mdns_priv_browse_free(void);
 
 /**
+ * @brief Check if a running browse `_service._proto` exists.
+ *
+ * @param service Service name.
+ * @param proto Protocol name.
+ * @return true if a running browse `_service._proto` exists, false otherwise.
+ */
+bool mdns_priv_browse_has_service(const char *service, const char *proto);
+
+/**
  *  @brief Looks for the name/type in active browse items
  *
  *  @note Called from the packet parser (mdns_receive.c)
  *
- *  @return browse results
+ *  @return matching browse item, or NULL if not found
  */
 mdns_browse_t *mdns_priv_browse_find(mdns_name_t *name, uint16_t type, mdns_if_t tcpip_if, mdns_ip_protocol_t ip_protocol);
 
@@ -34,55 +43,6 @@ mdns_browse_t *mdns_priv_browse_find(mdns_name_t *name, uint16_t type, mdns_if_t
  * @note Called from the packet parser (mdns_receive.c)
  */
 mdns_browse_t *mdns_priv_browse_find_ptr(mdns_name_t *name);
-
-/**
- * @brief Packet-scoped staging for browse A/AAAA records received before SRV
- */
-typedef struct mdns_browse_staged_ip {
-    struct mdns_browse_staged_ip *next;
-    char hostname[MDNS_NAME_BUF_LEN];
-    esp_ip_addr_t ip;
-    mdns_if_t tcpip_if;
-    mdns_ip_protocol_t ip_protocol;
-    uint32_t ttl;
-} mdns_browse_staged_ip_t;
-
-/**
- * @brief Allocate or return existing browse sync object for a packet
- */
-mdns_browse_sync_t *mdns_priv_browse_ensure_sync(mdns_browse_t *browse, mdns_browse_sync_t *sync);
-
-/**
- * @brief Free browse sync object and its pending result list
- */
-void mdns_priv_browse_sync_free(mdns_browse_sync_t *browse_sync);
-
-/**
- * @brief Stage an A/AAAA record to apply after all packet records are parsed
- */
-esp_err_t mdns_priv_browse_stage_ip(mdns_browse_staged_ip_t **staged, const char *hostname, esp_ip_addr_t *ip,
-                                    mdns_if_t tcpip_if, mdns_ip_protocol_t ip_protocol, uint32_t ttl);
-
-/**
- * @brief Apply staged A/AAAA records once SRV/hostnames are known
- *
- * @note Delegates to mdns_priv_browse_result_add_ip(), which updates only the
- *       first matching instance per hostname; see mdns_browse_new() in mdns.h.
- */
-void mdns_priv_browse_apply_staged_ips(mdns_browse_t *browse, mdns_browse_staged_ip_t *staged,
-                                       mdns_browse_sync_t *out_sync_browse);
-
-/**
- * @brief Free staged A/AAAA list
- */
-void mdns_priv_browse_staged_ip_free(mdns_browse_staged_ip_t *staged);
-
-/**
- * @brief Add a PTR record to the browse result (including TTL=0 removal)
- */
-void mdns_priv_browse_result_add_ptr(mdns_browse_t *browse, const char *instance, const char *service, const char *proto,
-                                     mdns_if_t tcpip_if, mdns_ip_protocol_t ip_protocol, uint32_t ttl,
-                                     mdns_browse_sync_t *out_sync_browse);
 
 /**
  * @brief Send out all browse queries
@@ -101,44 +61,41 @@ void mdns_priv_browse_send_all(mdns_if_t mdns_if);
 void mdns_priv_browse_send_by_ip_protocol(mdns_if_t mdns_if, mdns_ip_protocol_t ip_protocol);
 
 /**
- * @brief Sync browse results
- *
- * @note Called from the packet parser
- * @note Calls mdns_priv_queue_action() from mdns_engine
- */
-esp_err_t mdns_priv_browse_sync(mdns_browse_sync_t *browse_sync);
-
-/**
  * @brief Perform action from mdns service queue
  *
- * @note Called from the _mdns_service_task() in mdns.c
+ * @note Called by `free_action()` and `execute_action()` in mdns_service.c
  */
 void mdns_priv_browse_action(mdns_action_t *action, mdns_action_subtype_t type);
 
 /**
- * @brief  Add a TXT record to the browse result
+ * @brief  Build temporary result and queue for sync from service cache
  *
- * @note Called from the packet parser (mdns_receive.c)
+ * @param entry Owner cache entry.
+ * @param service Updated service cache.
+ * @param records Bitmask of cache record types to sync.
+ *
+ * @note Called from mdns_priv_cache_process_sync() in mdns_cache.c
+ *
+ * @return true if all matching browses have been notified about the updated service, false otherwise
  */
-void mdns_priv_browse_result_add_txt(mdns_browse_t *browse, const char *instance, const char *service, const char *proto,
-                                     mdns_txt_item_t *txt, uint8_t *txt_value_len, size_t txt_count, mdns_if_t tcpip_if, mdns_ip_protocol_t ip_protocol,
-                                     uint32_t ttl, mdns_browse_sync_t *out_sync_browse);
+bool mdns_priv_browse_update_from_service_cache(const mdns_cache_entry_t *entry, const mdns_service_cache_t *service,
+                                                mdns_cache_record_mask_t records);
+
 /**
- * @brief  Add an IP record to the browse result
+ * @brief Notify one browse about one visible cache service.
  *
- * @note Called from the packet parser (mdns_receive.c)
- * @note Attaches @p ip only to the first browse result with matching @p hostname
- *       on the given interface and IP protocol; see mdns_browse_new() in mdns.h.
+ * @return true if browse is successfully notified, false otherwise
  */
-void mdns_priv_browse_result_add_ip(mdns_browse_t *browse, const char *hostname, esp_ip_addr_t *ip,
-                                    mdns_if_t tcpip_if, mdns_ip_protocol_t ip_protocol, uint32_t ttl, mdns_browse_sync_t *out_sync_browse);
+bool mdns_priv_browse_notify_from_service_cache(const mdns_cache_entry_t *entry, const mdns_service_cache_t *service,
+                                                mdns_browse_t *browse);
+
 /**
- * @brief  Add a SRV record to the browse result
+ * @brief Notify the affected browse about a PTR goodbye.
  *
- * @note Called from the packet parser (mdns_receive.c)
+ * @note Must be called before the PTR service cache is removed to avoid UAF.
  */
-void mdns_priv_browse_result_add_srv(mdns_browse_t *browse, const char *hostname, const char *instance, const char *service, const char *proto,
-                                     uint16_t port, mdns_if_t tcpip_if, mdns_ip_protocol_t ip_protocol, uint32_t ttl, mdns_browse_sync_t *out_sync_browse);
+bool mdns_priv_browse_notify_ptr_goodbye_from_service_cache(const mdns_cache_entry_t *entry,
+                                                            const mdns_service_cache_t *service);
 #ifdef __cplusplus
 }
 #endif

--- a/components/mdns/private_include/mdns_cache.h
+++ b/components/mdns/private_include/mdns_cache.h
@@ -1,0 +1,177 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <stddef.h>
+#include "mdns_private.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Check if a host has a service by hostname, esp_netif, ip_protocol, service, and proto.
+ *
+ * @param hostname      The hostname to check.
+ * @param esp_netif     Pointer to the esp_netif to check.
+ * @param ip_protocol   IP protocol to check.
+ * @param service       The service name to check.
+ * @param proto         The protocol to check.
+ *
+ * @return true if the host has the service, false otherwise.
+ */
+bool mdns_priv_cache_host_has_service(const char *hostname, const esp_netif_t *esp_netif, mdns_ip_protocol_t ip_protocol,
+                                      const char *service, const char *proto);
+
+/**
+ * @brief Update a PTR record for service cache `_service._proto`.
+ *
+ * @param esp_netif     Pointer to the esp_netif.
+ * @param ip_protocol   IP protocol.
+ * @param instance      The instance name.
+ * @param service       The service name.
+ * @param proto         The protocol.
+ * @param ttl           The PTR TTL.
+ *
+ * @return The result of the update, see @ref mdns_cache_update_result_t.
+ *
+ * @note The PTR record will be marked to-sync when:
+ *      - A new service is added to the cache.
+ *      - The PTR TTL is updated.
+ *      - Receives a TTL=0 goodbye: all subscribing browsers will be notified of the goodbye.
+ *        Then the whole service cache entry will be removed.
+ */
+mdns_cache_update_result_t mdns_priv_cache_update_ptr(const esp_netif_t *esp_netif, mdns_ip_protocol_t ip_protocol,
+                                                      const char *instance, const char *service, const char *proto,
+                                                      uint32_t ttl);
+
+/**
+ * @brief Update a SRV record for service cache `instance._service._proto`.
+ *
+ * @param esp_netif     Pointer to the esp_netif.
+ * @param ip_protocol   IP protocol.
+ * @param hostname      The hostname to update.
+ * @param instance      The instance name.
+ * @param service       The service name.
+ * @param proto         The protocol.
+ * @param priority      The priority to update.
+ * @param weight        The weight to update.
+ * @param port          The port to update.
+ * @param ttl           The SRV TTL.
+ *
+ * @return The result of the update, see @ref mdns_cache_update_result_t.
+ *
+ * @note The SRV record will be marked to-sync when:
+ *      - A new SRV record is added to the service cache.
+ *      - The service cache is moved to the host designated by @ref hostname.
+ *      - The SRV record is updated.
+ *      - Receives a TTL=0 goodbye: the SRV record will be marked as absent.
+ */
+mdns_cache_update_result_t mdns_priv_cache_update_srv(const esp_netif_t *esp_netif, mdns_ip_protocol_t ip_protocol,
+                                                      const char *hostname, const char *instance, const char *service,
+                                                      const char *proto, uint16_t priority, uint16_t weight,
+                                                      uint16_t port, uint32_t ttl);
+
+/**
+ * @brief Update a TXT record for service cache `instance._service._proto`.
+ *
+ * @param esp_netif     Pointer to the esp_netif.
+ * @param ip_protocol   IP protocol.
+ * @param instance      The instance name.
+ * @param service       The service name.
+ * @param proto         The protocol.
+ * @param txt           The TXT record to update.
+ * @param ttl           The TXT TTL.
+ *
+ * @return The result of the update, see @ref mdns_cache_update_result_t.
+ *
+ * @note The TXT record will be marked to-sync when:
+ *      - A new TXT record is added to the service cache.
+ *      - The TXT record is updated.
+ *      - Receives a TTL=0 goodbye: the TXT record will be marked as absent.
+ */
+mdns_cache_update_result_t mdns_priv_cache_update_txt(const esp_netif_t *esp_netif, mdns_ip_protocol_t ip_protocol,
+                                                      const char *instance, const char *service, const char *proto,
+                                                      mdns_txt_linked_item_t *txt, uint32_t ttl);
+
+/**
+ * @brief Update an A/AAAA record for a cache entry `hostname`.
+ *
+ * @param esp_netif     Pointer to the esp_netif.
+ * @param ip_protocol   IP protocol.
+ * @param hostname      The hostname to update.
+ * @param addr          The address to update.
+ * @param ttl           The TTL.
+ *
+ * @return The result of the update, see @ref mdns_cache_update_result_t.
+ *
+ * @note When an A/AAAA record is updated (added, removed, or updated),
+ *       all services under this cache entry will be marked to-sync for browses.
+ */
+mdns_cache_update_result_t mdns_priv_cache_update_addr(const esp_netif_t *esp_netif, mdns_ip_protocol_t ip_protocol,
+                                                       const char *hostname, const esp_ip_addr_t *addr, uint32_t ttl);
+
+/**
+ * @brief Update an A/AAAA record for an existing cache entry `hostname`.
+ *
+ * @param esp_netif     Pointer to the esp_netif.
+ * @param ip_protocol   IP protocol.
+ * @param hostname      The hostname to update.
+ * @param addr          The address to update.
+ * @param ttl           The TTL.
+ *
+ * @return The result of the update, see @ref mdns_cache_update_result_t.
+ *         If the cache entry does not exist, return MDNS_CACHE_NO_CHANGE.
+ *
+ * @note When an A/AAAA record is updated (added, removed, or updated),
+ *       all services under this cache entry will be marked to-sync for browses.
+ *
+ * @note Used by browses in case ADDR records come before SRV record.
+ */
+mdns_cache_update_result_t mdns_priv_cache_update_existing_addr(const esp_netif_t *esp_netif, mdns_ip_protocol_t ip_protocol,
+                                                                const char *hostname, const esp_ip_addr_t *addr, uint32_t ttl);
+
+/**
+ * @brief Clear all cache entries.
+ */
+void mdns_priv_cache_clear(void);
+
+/**
+ * @brief Convert a service cache to a mdns_result_t.
+ *
+ * @param entry       Pointer to the cache entry.
+ * @param service     Pointer to the service cache.
+ * @param out_result  Pointer to the output mdns_result_t.
+ * @return ESP_OK on success, ESP_ERR_NO_MEM on allocation failure.
+ */
+esp_err_t mdns_priv_service_cache_to_result(const mdns_cache_entry_t *entry, const mdns_service_cache_t *service,
+                                            mdns_result_t **out_result);
+
+/**
+ * @brief Process all pending synchronization cache entries.
+ *
+ * @note This function is called by the MDNS task to process all pending synchronization cache entries.
+ *       It will generate temporary results, notify corresponding consumers, and clear the sync out flags.
+ */
+void mdns_priv_cache_process_sync(void);
+
+/**
+ * @brief Replay all currently visible cache services to a newly registered browse.
+ *
+ * @return true if successfully notified, false otherwise
+ */
+bool mdns_priv_cache_notify_browse(mdns_browse_t *browse);
+
+/**
+ * @brief Remove specific service cache entries if no consumers subscribe to them.
+ *
+ * @param service Service name.
+ * @param proto Protocol name.
+ */
+void mdns_priv_cache_remove_service_cache_if_unused(const char *service, const char *proto);
+#ifdef __cplusplus
+}
+#endif

--- a/components/mdns/private_include/mdns_private.h
+++ b/components/mdns/private_include/mdns_private.h
@@ -157,7 +157,6 @@ typedef enum {
     ACTION_SEARCH_SEND,
     ACTION_SEARCH_END,
     ACTION_BROWSE_START,
-    ACTION_BROWSE_SYNC,
     ACTION_BROWSE_END,
     ACTION_TX_HANDLE,
     ACTION_RX_HANDLE,
@@ -363,16 +362,6 @@ typedef struct mdns_browse_s {
     mdns_result_t *result;
 } mdns_browse_t;
 
-typedef struct mdns_browse_result_sync_t {
-    mdns_result_t *result;
-    struct mdns_browse_result_sync_t *next;
-} mdns_browse_result_sync_t;
-
-typedef struct mdns_browse_sync {
-    mdns_browse_t *browse;
-    mdns_browse_result_sync_t *sync_result;
-} mdns_browse_sync_t;
-
 typedef struct {
     mdns_action_type_t type;
     union {
@@ -401,11 +390,82 @@ typedef struct {
             mdns_browse_t *browse;
         } browse_add;
         struct {
-            mdns_browse_sync_t *browse_sync;
-        } browse_sync;
-        struct {
             mdns_if_t interface;
             mdns_ip_protocol_t ip_protocol;
         } browse_send;
     } data;
 } mdns_action_t;
+
+typedef enum {
+    MDNS_CACHE_CONSUMER_BROWSE     = (1U << 0),
+} mdns_cache_consumer_type_t;
+
+typedef uint8_t mdns_cache_consumer_mask_t;
+
+typedef enum {
+    MDNS_CACHE_RECORD_PTR       = (1U << 0),
+    MDNS_CACHE_RECORD_SRV       = (1U << 1),
+    MDNS_CACHE_RECORD_TXT       = (1U << 2),
+    MDNS_CACHE_RECORD_ADDR      = (1U << 3)
+} mdns_cache_record_type_t;
+
+typedef uint8_t mdns_cache_record_mask_t;
+
+/**
+ * @brief   mDNS cache ADDR list structure
+ */
+typedef struct mdns_cache_addr_s {
+    esp_ip_addr_t addr;
+    uint32_t ttl;
+    struct mdns_cache_addr_s *next;
+} mdns_cache_addr_t;
+
+/**
+ * @brief   mDNS cache service structure, contains PTR, SRV and TXT records
+ */
+typedef struct mdns_service_cache_s {
+    char *instance_name;
+    char *service;
+    char *proto;
+    // PTR
+    bool ptr_present;   /*!< true if PTR record is present */
+    uint32_t ptr_ttl;
+    // SRV
+    bool srv_present;   /*!< true if SRV record is present */
+    uint16_t priority;
+    uint16_t weight;
+    uint16_t port;
+    uint32_t srv_ttl;
+    // TXT
+    bool txt_present;   /*!< true if TXT record is present */
+    mdns_txt_linked_item_t *txt_list;
+    uint32_t txt_ttl;
+    // To-sync flags
+    mdns_cache_record_mask_t sync_records;      /*!< bitmask of records to sync, see @ref mdns_cache_record_type_t */
+    mdns_cache_consumer_mask_t sync_consumers;  /*!< bitmask of consumers to sync, see @ref mdns_cache_consumer_type_t */
+    struct mdns_service_cache_s *next;
+} mdns_service_cache_t;
+
+/**
+ * @brief   mDNS cache entry structure, contains hostname, IP address list and service cache list
+ */
+typedef struct mdns_cache_entry_s {
+    char *hostname;
+    esp_netif_t *esp_netif;
+    mdns_ip_protocol_t ip_protocol;
+
+    mdns_cache_addr_t *addr_list;
+    mdns_service_cache_t *service_cache_list;
+    struct mdns_cache_entry_s *next;
+} mdns_cache_entry_t;
+
+/**
+ * @brief   mDNS cache update result structure
+ */
+typedef enum {
+    MDNS_CACHE_NO_CHANGE,   /*!< no change to the cache */
+    MDNS_CACHE_ADDED,       /*!< new cache entry or service cache appended */
+    MDNS_CACHE_UPDATED,     /*!< existing service cache entry updated */
+    MDNS_CACHE_REMOVED,     /*!< existing service cache entry removed */
+    MDNS_CACHE_ERROR,       /*!< error occurred while updating the cache */
+} mdns_cache_update_result_t;

--- a/components/mdns/private_include/mdns_utils.h
+++ b/components/mdns/private_include/mdns_utils.h
@@ -153,3 +153,10 @@ static inline uint8_t mdns_utils_append_u8(uint8_t *packet, uint16_t *index, uin
     *index += 1;
     return 1;
 }
+
+/**
+ * @brief Free a TXT linked list.
+ *
+ * @param txt Pointer to the TXT linked list.
+ */
+void mdns_utils_free_txt_linked_list(mdns_txt_linked_item_t *txt);

--- a/components/mdns/tests/host_unit_test/CMakeLists.txt
+++ b/components/mdns/tests/host_unit_test/CMakeLists.txt
@@ -63,6 +63,7 @@ set(SOURCES
     ${MDNS_DIR}/mdns_send.c
     ${MDNS_DIR}/mdns_pcb.c
     ${MDNS_DIR}/mdns_netif.c
+    ${MDNS_DIR}/mdns_cache.c
 )
 
 if(ENABLE_UNIT_TESTS)

--- a/components/mdns/tests/host_unit_test/stubs/mdns_engine.c
+++ b/components/mdns/tests/host_unit_test/stubs/mdns_engine.c
@@ -23,7 +23,6 @@ static void execute_action(mdns_action_t *action)
         mdns_priv_query_action(action, ACTION_RUN);
         break;
     case ACTION_BROWSE_START:
-    case ACTION_BROWSE_SYNC:
     case ACTION_BROWSE_END:
         mdns_priv_browse_action(action, ACTION_RUN);
         break;

--- a/components/mdns/tests/host_unit_test/stubs/mdns_mem_caps.c
+++ b/components/mdns/tests/host_unit_test/stubs/mdns_mem_caps.c
@@ -44,10 +44,7 @@ char *mdns_mem_strndup(const char *s, size_t n)
         return NULL;
     }
 
-    size_t len = strlen(s);
-    if (len > n) {
-        len = n;
-    }
+    size_t len = strnlen(s, n);
 
     char *new_str = mdns_mem_malloc(len + 1);
     if (new_str == NULL) {


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

I'm currently implementing OpenThread DNS-SD interfaces for ESP Thread libraries. Those interfaces require a PTR browser and continuous resolvers for PTR, SRV, and ADDR records. Current `mdns` component cannot provide full functions, thus a series of PRs will be proposed to implement necessary contents.

As for browser, the existing browser in `mdns` component provides continuous browser through `mdns_browse_*`, but it lacks these functions to meet OpenThread interface requirements:

- Public interfaces `mdns_browse_new()` and `mdns_browse_delete()` do not support browsers for subtypes.
- The notifier type `mdns_browse_notify_t` only returns a `mdns_result_t`, where `ttl` is the minimum TTL of all records parsed from packet, not specific PTR TTL.

This PR introduces `mdns_cache` to store cached results that match running browses (and future continuous resolvers). If cache is updated, matching browses will generate temporary results from cache and notify. When a browse is deleted, the matching cache entry will be removed.

### Cache structure
Cache is made up of two structures:
```c
/**
 * @brief   mDNS cache service structure, contains PTR (with subtype list), SRV and TXT records
 */
typedef struct mdns_service_cache_s {
    char *instance_name;
    char *service;
    char *proto;
    // PTR
    bool ptr_present;   /*!< true if PTR record is present */
    uint32_t ptr_ttl;
    // Subtype list
    mdns_cache_subtype_t *subtype_list;
    // SRV
    bool srv_present;   /*!< true if SRV record is present */
    uint16_t priority;
    uint16_t weight;
    uint16_t port;
    uint32_t srv_ttl;
    // TXT
    bool txt_present;   /*!< true if TXT record is present */
    mdns_txt_linked_item_t *txt_list;
    uint32_t txt_ttl;
    // Dirty flag
    bool dirty;         /*!< true if the service cache is modified but not yet notified */
    struct mdns_service_cache_s *next;
} mdns_service_cache_t;

/**
 * @brief   mDNS cache entry structure, contains hostname, IP address list and service cache list
 */
typedef struct mdns_cache_entry_s {
    char *hostname;
    esp_netif_t *esp_netif;
    mdns_ip_protocol_t ip_protocol;

    mdns_cache_addr_t *addr_list;
    mdns_service_cache_t *service_cache_list;
    struct mdns_cache_entry_s *next;
} mdns_cache_entry_t;
```

`mdns_cache.c` holds a `static mdns_cache_entry_t * s_cache` as the head of cache entry linked list. Cache entry is identified with hostname, netif, and IP protocol. Every cache entry holds a list of addresses binded to hostname and a list of services. Every service cache entry is identified with instance name, service name, and protocol. A service entry contains all content for PTR, SRV, and TXT record, as well as flags to mark the presence of each record and whether the cache is dirty.

### New routines

Browse registration routine is almost unchanged.

For notify events, the routine is as follow:
- `mdns_parse_packet()` works the same until `if (type == MDNS_TYPE_PTR)`
- If a running browse match the parsed PTR/SRV/TXT/A/AAAA record, call `mdns_priv_cache_update_*()` to update cache and mark the matching cache dirty.
- After all data have been processed, call `mdns_priv_cache_process_dirty()`, this function will call `mdns_priv_browse_update_from_service_cache()` for every dirty service cache.
- Find the matching browse to the dirty cache, generate a temporary result and invoke notifier. The result will be freed after the notifier returns.

When a browse is removed, the routine is as follow:
- If no more browse with identical service name and protocol exists, remove all cache that match the service name and protocol of the browse.
- If other browses with identical service name and protocol exist (only differ in subtype), and the browse to remove has subtype, just remove the subtype from the subtype list of the service cache.

The cache is updated in such a way:

For regular events (TTL>0):
- PTR record: If no matching service cache is found, create a new cache entry with hostname=NULL, and insert the new service under this entry. If subtype is not NULL, just add subtype to subtype list, otherwise update `ptr_present` and ttl.
- SRV record: If no matching service cache is found, create a new cache entry with hostname. If previously a new PTR record with the same service has created a hostname=NULL entry, move the service to this entry. Then update SRV record data.
- TXT record: Create new cache entry or service cache if not found, then update TXT record data.
- A/AAAA record: Create new cache entry if not found, insert address into address list of the cacthe entry or update TTL, then mark all service cache under this entry as dirty.

When a TTL=0 record is sent in, PTR will notify a goodbye event, then remove subtype from subtype list if subtype is not NULL, otherwise set ptr_present = false. SRV and TXT will mark present = false and clear record. A/AAAA will remove the address from address list of the cache entry and mark all its services as dirty. If all records under a service cache are absent, it will be removed; if an entry has no services, the entry will be removed.

All update functions return a `mdns_cache_update_result_t`, `MDNS_CACHE_ADDED` and `MDNS_CACHE_REMOVED` refer to whether a cache entry or a service cache is created or freed. `MDNS_CACHE_UPDATED` and `MDNS_CACHE_NO_CHANGE` refer to whether cache content is changed. `MDNS_CACHE_ERROR` means error occurred while handling cache.

### Changed behaviors

These behaviors are different from previous versions and need careful consideration:

- The `mdns_result_t *result` under `mdns_browse_t` is now removed, as the result of browse is only generated when notifies. As a result, the `next` pointer of a result obtained from notifier will always be NULL.
- Previously `mdns_parse_packet` assume that a packet only contains data of one service, thus only one browse will be notified. Now browses are notified based on dirty cache, therefore multiple browses can be notified, including batch TTL=0 events previously mentioned in `mdns_notifier_t`. Users should no longer traverse the results obtained from browses.
- The `ttl` in `mdns_result_t` used to represent the minimum TTL of all records, which may cause ambiguity. Now `ttl` only presents PTR TTL, it is recommended to use one-shot queries, or continuous resolvers which may be proposed in the future, to obtain TTL of SRV/TXT/A/AAAA records.
- A new member `char *subtype` has been appended to `mdns_result_t`, to distinguish subtype information for browse notifications. This may not cause ABI breaking change as `subtype` is appended to the end and offsets of other members remain unchanged. But all binaries using `sizeof(mdns_result_t)` need to be re-compiled.

## Related

Previously PR #1028 has proposed browse and query with subtypes, but it has not been pushed forward since March 2026. This PR uses some of the code in #1028 for subtype browse, the query part is not used. #1028 or a new PR should be pushed to implement one-shot query with subtypes, and support subtype for `mdns_lookup_selfhosted_service()` and `mdns_lookup_delegated_service()`.

## Testing

This PR has only been tested under mdns browse with one Thread BR and one Thread router, where browse and cache are created and removed in expected routine. A new PR should be made to implement unit tests for mdns_cache and mdns_browse.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors browse data flow and callback lifetime semantics—apps that walked `result->next`, kept notifier pointers, or assumed old TTL/shared-hostname behavior need updates. Core mDNS task locking and memory paths change but stay localized to browse-enabled builds.
> 
> **Overview**
> **Moves continuous mDNS browse off per-browse result lists** and onto a shared internal cache (`mdns_cache.c`) keyed by netif, IP version, hostname, and service instance. Incoming PTR/SRV/TXT/A/AAAA answers update the cache during `mdns_parse_packet()`; **`mdns_priv_cache_process_sync()`** at the end of each packet drives browse notifications.
> 
> **Browse notifier contract changes:** callbacks receive a **temporary** `mdns_result_t` built from the cache (freed when the callback returns), **`result->next` is always NULL**, and registering a browse replays matching cached services. **`ACTION_BROWSE_SYNC`** and the old staged-IP / per-packet single-browse sync path are removed.
> 
> When the last browse for a `_service._proto` is deleted, matching cache entries for that type are dropped if nothing else subscribes. Public docs in `mdns.h` are updated to match; unit test build adds `mdns_cache.c`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18d5421d1d5382ed2166d69e4a8f9a9183252451. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->