### PR TITLE
feat(websocket): Add non-blocking stop request and bounded stop wait

### DIFF
--- a/components/esp_websocket_client/esp_websocket_client.c
+++ b/components/esp_websocket_client/esp_websocket_client.c
@@ -1496,6 +1496,37 @@ esp_err_t esp_websocket_client_stop(esp_websocket_client_handle_t client)
     return stop_wait_task(client);
 }
 
+esp_err_t esp_websocket_client_request_stop(esp_websocket_client_handle_t client)
+{
+    if (client == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    if (xEventGroupGetBits(client->status_bits) & STOPPED_BIT) {
+        return ESP_OK;
+    }
+
+    /* A running client cannot be stopped from the websocket task/event handler */
+    if (xTaskGetCurrentTaskHandle() == client->task_handle) {
+        ESP_LOGE(TAG, "Client cannot be stopped from websocket task");
+        return ESP_FAIL;
+    }
+
+    client->run = false;
+    /* REQUESTED_STOP_BIT also wakes a WEBSOCKET_STATE_WAIT_TIMEOUT wait early,
+     * so a task idling between reconnect attempts exits immediately */
+    xEventGroupSetBits(client->status_bits, REQUESTED_STOP_BIT);
+    return ESP_OK;
+}
+
+bool esp_websocket_client_wait_stopped(esp_websocket_client_handle_t client, TickType_t timeout)
+{
+    if (client == NULL) {
+        return false;
+    }
+    return (STOPPED_BIT & xEventGroupWaitBits(client->status_bits, STOPPED_BIT, false, true, timeout)) != 0;
+}
+
 static int esp_websocket_client_send_close(esp_websocket_client_handle_t client, int code, const char *additional_data, int total_len, TickType_t timeout)
 {
     uint8_t *close_status_data = NULL;

--- a/components/esp_websocket_client/include/esp_websocket_client.h
+++ b/components/esp_websocket_client/include/esp_websocket_client.h
@@ -242,6 +242,51 @@ esp_err_t esp_websocket_client_start(esp_websocket_client_handle_t client);
 esp_err_t esp_websocket_client_stop(esp_websocket_client_handle_t client);
 
 /**
+ * @brief      Request the client task to stop, without waiting for it
+ *
+ * This is the non-blocking half of esp_websocket_client_stop(): it flags the
+ * client task to exit (and wakes it early if it is idling between reconnect
+ * attempts), then returns immediately. The task still finishes any blocking
+ * call it is currently inside (transport connect, read poll) before it
+ * notices the request. Pair with esp_websocket_client_wait_stopped() to
+ * bound the join, and call esp_websocket_client_destroy() only once the
+ * client is stopped.
+ *
+ * This allows an application tearing down several clients to request all
+ * stops first so the task exits overlap, then wait for each against a single
+ * deadline — instead of serializing the full teardown time of every client
+ * as back-to-back esp_websocket_client_stop() calls would.
+ *
+ *  Notes:
+ *  - Safe to call when the client is already stopped (returns ESP_OK)
+ *  - Cannot be called from the websocket event handler
+ *
+ * @param[in]  client  The client
+ *
+ * @return     esp_err_t
+ */
+esp_err_t esp_websocket_client_request_stop(esp_websocket_client_handle_t client);
+
+/**
+ * @brief      Wait, bounded, for the client task to have stopped
+ *
+ *  Notes:
+ *  - Passing portMAX_DELAY reproduces the unbounded wait of
+ *    esp_websocket_client_stop()
+ *
+ * @param[in]  client   The client
+ * @param[in]  timeout  Maximum number of ticks to wait for the client task
+ *                      to reach its stopped state
+ *
+ * @return
+ *     - true when the client task is stopped; esp_websocket_client_destroy()
+ *       will then complete without blocking on the task
+ *     - false on timeout: the client task is still winding down — do not
+ *       destroy the client yet (destroy would block unboundedly), retry later
+ */
+bool esp_websocket_client_wait_stopped(esp_websocket_client_handle_t client, TickType_t timeout);
+
+/**
  * @brief      Destroy the WebSocket connection and free all resources.
  *             This function must be the last function to call for an session.
  *             It is the opposite of the esp_websocket_client_init function and must be called with the same handle as input that a esp_websocket_client_init call returned.


### PR DESCRIPTION
## Problem

`esp_websocket_client_stop()` — and `esp_websocket_client_destroy()`, which calls it — joins the client task with `portMAX_DELAY`. That is fine for callers that can block, but there is a real deadlock-adjacent class it creates: **a task that must not block unboundedly has no bounded way to tear a client down.**

Concrete case (ESP32-S3 battery device, two websocket clients): a power-management task with a fixed sleep-readiness deadline tears down both clients back to back on the way into deep sleep. A link blip is exactly when sleep tends to get requested, so both client tasks are typically mid-reconnect — each join then waits out the full TLS/transport connect timeout before the task notices `run == false`, and the two unbounded joins stack. With a ~15 s connect timeout per client, the teardown can exceed a 30 s system deadline, and the caller can neither cancel nor bound it.

## Change

Split the stop into the two halves it is already made of internally:

- **`esp_websocket_client_request_stop()`** — the non-blocking half: sets `run = false` and `REQUESTED_STOP_BIT` (which also wakes a `WEBSOCKET_STATE_WAIT_TIMEOUT` reconnect wait early, so a task idling between retries exits immediately), then returns.
- **`esp_websocket_client_wait_stopped(client, timeout)`** — a bounded wait on `STOPPED_BIT`. Only after it returns `true` is `esp_websocket_client_destroy()` guaranteed not to block on the task; on `false` the caller keeps the handle and retries later.

An application tearing down several clients can request all stops first — the task exits overlap — and then wait for each against a single shared deadline, instead of serializing every client's worst-case teardown.

`esp_websocket_client_stop()` is unchanged (still request + unbounded wait); no existing behavior is affected. No new state or bits are introduced — the split only exposes the existing `REQUESTED_STOP_BIT` / `STOPPED_BIT` machinery with a caller-chosen timeout.

## Notes

- `request_stop` mirrors `stop_wait_task`'s guard: it cannot be called from the websocket task itself, and is a no-op `ESP_OK` when already stopped.
- `wait_stopped(portMAX_DELAY)` reproduces the current unbounded join exactly.
- Field-tested in production firmware (vendored copy of this component) since 2026-08: two clients' teardowns bounded by one shared 5 s budget; an abandoned (timed-out) join is reaped by a later stop/destroy once the task exits on its own.

I'm happy to adjust naming, add a test under `components/esp_websocket_client/tests`, or fold this into a different API shape if the maintainers prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
