### PR TITLE
fix(mdns): Don't free a browse result already freed by an earlier sync batch

### DIFF
--- a/components/mdns/mdns_browser.c
+++ b/components/mdns/mdns_browser.c
@@ -57,6 +57,24 @@ static void browse_item_free(mdns_browse_t *browse)
 }
 
 /**
+ * @brief Check that a result node is still linked in the browse cache
+ *
+ * Sync entries hold a borrowed pointer to a node in @c browse->result. One node
+ * can be referenced by several queued sync batches, and the first batch to see
+ * it with @c ttl==0 detaches and frees it, so a later batch must not use its
+ * pointer without checking.
+ */
+static bool result_is_cached(const mdns_browse_t *browse, const mdns_result_t *result)
+{
+    for (const mdns_result_t *r = browse->result; r != NULL; r = r->next) {
+        if (r == result) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
  * @brief Deliver browse updates to the user notifier
  *
  * Invokes the notifier once per changed result accumulated for the current
@@ -70,6 +88,11 @@ static void browse_sync(mdns_browse_sync_t *browse_sync)
     mdns_browse_result_sync_t *sync_result = browse_sync->sync_result;
     while (sync_result) {
         mdns_result_t *result = sync_result->result;
+        if (!result_is_cached(browse, result)) {
+            // Already removed and freed by an earlier sync batch
+            sync_result = sync_result->next;
+            continue;
+        }
         DBG_BROWSE_RESULTS(result, browse_sync->browse);
         browse->notifier(result);
         if (result->ttl == 0) {


### PR DESCRIPTION
`browse_sync()` frees `sync_result->result` whenever `result->ttl` is `0` at processing time, but sync entries only borrow the node: one packet produces one `mdns_browse_sync_t`, each queued as its own `ACTION_BROWSE_SYNC`, and `add_browse_result()` dedupes within a single batch only. `mdns_priv_query_update_result_ttl()` takes the minimum, so a goodbye lowers a cached node's TTL to `0` and re-adds it to a fresh batch while an older batch still references it. Processing the older batch frees the node; processing the newer one reads `result->ttl` from freed memory and frees it again:

  assert failed: `tlsf_free` ... block already marked as free:
    `mdns_mem_free`                         (`mdns_mem_caps.c`)
    `mdns_priv_query_results_free`  (`mdns_querier.c`)
    `browse_sync`                                (`mdns_browser.c`)
    `mdns_priv_browse_action`          (`mdns_browser.c`)
    `execute_action`                             (`mdns_service.c`)

Skip sync entries whose node is no longer linked in `browse->result`. That covers both the use-after-free read and the second free, and needs no change to the result lifetime or to the sync batch layout.

NOTE: Issue was identified thanks to Claude Code Opus 5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches browse result lifetime and freeing in the mDNS service task; incorrect skipping could hide goodbye notifications, but the fix is narrowly scoped to stale borrowed pointers.
> 
> **Overview**
> Fixes a **double-free / use-after-free** in mDNS browse delivery when the same cached `mdns_result_t` appears in **multiple queued `ACTION_BROWSE_SYNC` batches** (sync entries only borrow the node). An earlier batch can detach and free the result on **TTL=0**; a later batch must not read `result->ttl` or call `mdns_priv_query_results_free()` on that pointer.
> 
> The change adds **`result_is_cached()`**, which walks `browse->result`, and **`browse_sync()`** now **skips** sync entries whose `sync_result->result` is no longer linked in the cache before notifying or freeing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9057f2d955332960051ccb55fc66f863ebfdce69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->