### PR TITLE
fix(websocket): free cfg->host before reassignment to prevent memory leak

### DIFF
--- a/components/esp_websocket_client/esp_websocket_client.c
+++ b/components/esp_websocket_client/esp_websocket_client.c
@@ -384,8 +384,10 @@ static esp_err_t esp_websocket_client_set_config(esp_websocket_client_handle_t c
     }
 
     if (config->host) {
-        cfg->host = strdup(config->host);
-        ESP_WS_CLIENT_MEM_CHECK(TAG, cfg->host, return ESP_ERR_NO_MEM);
+        char *new_host = strdup(config->host);
+        ESP_WS_CLIENT_MEM_CHECK(TAG, new_host, return ESP_ERR_NO_MEM);
+        free(cfg->host);
+        cfg->host = new_host;
     }
 
     if (config->port) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small memory-management fix in config setup; behavior is unchanged except preventing a leak when host is reassigned.
> 
> **Overview**
> When `esp_websocket_client_set_config` applies a new `config->host`, it now **frees the previous `cfg->host` buffer** before assigning the duplicated string, matching the pattern already used for `username`, `uri`, `path`, and other heap-backed config fields.
> 
> This matters on client init when **`set_uri` runs before `set_config`**: the host allocated from the URI would be orphaned if `config->host` was also set, leaking that allocation for the lifetime of the client.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3c20d39e9ac60564f5c221f96ba69c81184c497. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->