### PR TITLE
feat(mdns): post event when hostname changes

### DIFF
--- a/components/mdns/include/mdns.h
+++ b/components/mdns/include/mdns.h
@@ -171,6 +171,21 @@ typedef void (*mdns_query_notify_t)(mdns_search_once_t *search);
 typedef void (*mdns_browse_notify_t)(mdns_result_t *result);
 
 /**
+ * @brief Hostname change notifier
+ *
+ * Called from the mDNS service task after the hostname changes.
+ * The @p hostname argument is the new hostname. It remains valid until the
+ * callback returns.
+ *
+ * @warning Do not call mDNS APIs from this callback. The callback runs while
+ *          the mDNS service is processing an action.
+ *
+ * @param hostname  The new responder hostname.
+ * @param arg       User context supplied when registering the callback.
+ */
+typedef void (*mdns_hostname_changed_cb_t)(const char *hostname, void *arg);
+
+/**
  * @brief  Initialize mDNS on given interface
  *
  * @return
@@ -199,6 +214,24 @@ void mdns_free(void);
  *     - ESP_ERR_NO_MEM memory error
  */
 esp_err_t mdns_hostname_set(const char *hostname);
+
+/**
+ * @brief Register a callback notified when the hostname changes
+ *
+ * Multiple callbacks can be registered. Registering the same callback and
+ * context more than once has no effect. Callbacks cannot be unregistered and
+ * remain registered until mdns_free() is called.
+ *
+ * @param cb   Callback to invoke when the hostname changes.
+ * @param arg  User context passed to @p cb.
+ *
+ * @return
+ *     - ESP_OK on success
+ *     - ESP_ERR_INVALID_STATE when mDNS is not initialized
+ *     - ESP_ERR_INVALID_ARG when @p cb is NULL
+ *     - ESP_ERR_NO_MEM when the callback cannot be registered
+ */
+esp_err_t mdns_register_hostname_changed_callback(mdns_hostname_changed_cb_t cb, void *arg);
 
 /**
  * @brief Get the hostname for mDNS server

--- a/components/mdns/mdns_responder.c
+++ b/components/mdns/mdns_responder.c
@@ -16,8 +16,15 @@
 #include "mdns_pcb.h"
 #include "mdns_service.h"
 
+typedef struct mdns_hostname_changed_callback_s {
+    mdns_hostname_changed_cb_t cb;
+    void *arg;
+    struct mdns_hostname_changed_callback_s *next;
+} mdns_hostname_changed_callback_t;
+
 typedef struct mdns_server_s {
     const char *hostname;
+    mdns_hostname_changed_callback_t *hostname_changed_cbs;
     const char *instance;
     mdns_srv_item_t *services;
     mdns_host_item_t *host_list;
@@ -59,6 +66,17 @@ static void free_delegated_hostnames(void)
     s_server->host_list = NULL;
 }
 
+static void free_hostname_changed_callbacks(void)
+{
+    mdns_hostname_changed_callback_t *callback = s_server->hostname_changed_cbs;
+    while (callback != NULL) {
+        mdns_hostname_changed_callback_t *next = callback->next;
+        mdns_mem_free(callback);
+        callback = next;
+    }
+    s_server->hostname_changed_cbs = NULL;
+}
+
 void mdns_priv_responder_free(void)
 {
     if (s_server->action_sema != NULL) {
@@ -71,6 +89,7 @@ void mdns_priv_responder_free(void)
     mdns_mem_free((char *)s_server->hostname);
     mdns_mem_free((char *)s_server->instance);
     free_delegated_hostnames();
+    free_hostname_changed_callbacks();
     mdns_mem_free(s_server);
     s_server = NULL;
 }
@@ -98,11 +117,19 @@ mdns_host_item_t *mdns_priv_get_self_host(void)
 void mdns_priv_set_global_hostname(const char *hostname)
 {
     if (s_server) {
+        bool hostname_changed = s_server->hostname != hostname &&
+                                (!s_server->hostname || !hostname || strcmp(s_server->hostname, hostname) != 0);
         if (s_server->hostname) {
             mdns_mem_free((void *)s_server->hostname);
         }
         s_server->hostname = hostname;
         s_server->self_host.hostname = hostname;
+        if (hostname_changed) {
+            for (mdns_hostname_changed_callback_t *callback = s_server->hostname_changed_cbs;
+                    callback != NULL; callback = callback->next) {
+                callback->cb(hostname, callback->arg);
+            }
+        }
     }
 }
 
@@ -551,9 +578,7 @@ void mdns_priv_responder_action(mdns_action_t *action, mdns_action_subtype_t typ
         case ACTION_HOSTNAME_SET:
             send_bye_all_pcbs_no_instance(true);
             mdns_priv_remap_self_service_hostname(s_server->hostname, action->data.hostname_set.hostname);
-            mdns_mem_free((char *)s_server->hostname);
-            s_server->hostname = action->data.hostname_set.hostname;
-            s_server->self_host.hostname = action->data.hostname_set.hostname;
+            mdns_priv_set_global_hostname(action->data.hostname_set.hostname);
             mdns_priv_restart_all_pcbs();
             xSemaphoreGive(s_server->action_sema);
             break;
@@ -640,6 +665,38 @@ esp_err_t mdns_hostname_set(const char *hostname)
         return ESP_ERR_NO_MEM;
     }
     xSemaphoreTake(s_server->action_sema, portMAX_DELAY);
+    return ESP_OK;
+}
+
+esp_err_t mdns_register_hostname_changed_callback(mdns_hostname_changed_cb_t cb, void *arg)
+{
+    if (!s_server) {
+        return ESP_ERR_INVALID_STATE;
+    }
+    if (!cb) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    mdns_priv_service_lock();
+    for (mdns_hostname_changed_callback_t *callback = s_server->hostname_changed_cbs;
+            callback != NULL; callback = callback->next) {
+        if (callback->cb == cb && callback->arg == arg) {
+            mdns_priv_service_unlock();
+            return ESP_OK;
+        }
+    }
+
+    mdns_hostname_changed_callback_t *callback = mdns_mem_malloc(sizeof(*callback));
+    if (!callback) {
+        HOOK_MALLOC_FAILED;
+        mdns_priv_service_unlock();
+        return ESP_ERR_NO_MEM;
+    }
+    callback->cb = cb;
+    callback->arg = arg;
+    callback->next = s_server->hostname_changed_cbs;
+    s_server->hostname_changed_cbs = callback;
+    mdns_priv_service_unlock();
     return ESP_OK;
 }
 

--- a/components/mdns/tests/host_unit_test/unity/test_receiver/test_receiver.c
+++ b/components/mdns/tests/host_unit_test/unity/test_receiver/test_receiver.c
@@ -12,6 +12,38 @@
 #include "mdns_private.h"
 #include "mdns_utils.h"
 
+typedef struct {
+    size_t count;
+    char hostname[MDNS_NAME_BUF_LEN];
+} hostname_changed_callback_context_t;
+
+static void hostname_changed_callback(const char *hostname, void *arg)
+{
+    hostname_changed_callback_context_t *context = arg;
+
+    ++context->count;
+    strncpy(context->hostname, hostname, sizeof(context->hostname));
+    context->hostname[sizeof(context->hostname) - 1] = '\0';
+}
+
+static void test_hostname_changed_callback(void)
+{
+    hostname_changed_callback_context_t context = { 0 };
+
+    TEST_ASSERT_EQUAL(ESP_OK, mdns_register_hostname_changed_callback(hostname_changed_callback, &context));
+
+    TEST_ASSERT_EQUAL(ESP_OK, mdns_hostname_set("renamed-hostname"));
+    TEST_ASSERT_EQUAL_UINT(1, context.count);
+    TEST_ASSERT_EQUAL_STRING("renamed-hostname", context.hostname);
+
+    TEST_ASSERT_EQUAL(ESP_OK, mdns_hostname_set("renamed-hostname"));
+    TEST_ASSERT_EQUAL_UINT(1, context.count);
+
+    TEST_ASSERT_EQUAL(ESP_OK, mdns_hostname_set("renamed-hostname-again"));
+    TEST_ASSERT_EQUAL_UINT(2, context.count);
+    TEST_ASSERT_EQUAL_STRING("renamed-hostname-again", context.hostname);
+}
+
 static void test_mdns_hostname_queries(void)
 {
     // Define the queries for test4.local and test.local
@@ -136,6 +168,8 @@ void run_unity_tests(void)
 
     // Run hostname queries test
     RUN_TEST(test_mdns_hostname_queries);
+
+    RUN_TEST(test_hostname_changed_callback);
 
     // Run test with answers
     RUN_TEST(test_mdns_with_answers);

--- a/components/mdns/tests/unit_test/main/test_mdns.c
+++ b/components/mdns/tests/unit_test/main/test_mdns.c
@@ -42,6 +42,19 @@ static void yield_to_all_priorities(void)
     vTaskPrioritySet(NULL, test_task_prio_before);
 }
 
+typedef struct {
+    size_t count;
+    char hostname[MDNS_NAME_BUF_LEN];
+} hostname_changed_callback_context_t;
+
+static void hostname_changed_callback(const char *hostname, void *arg)
+{
+    hostname_changed_callback_context_t *context = arg;
+
+    ++context->count;
+    strncpy(context->hostname, hostname, sizeof(context->hostname));
+    context->hostname[sizeof(context->hostname) - 1] = '\0';
+}
 
 TEST(mdns, api_fails_with_invalid_state)
 {
@@ -49,6 +62,7 @@ TEST(mdns, api_fails_with_invalid_state)
     TEST_ASSERT_NOT_EQUAL(ESP_OK, mdns_hostname_set(MDNS_HOSTNAME));
     TEST_ASSERT_NOT_EQUAL(ESP_OK, mdns_instance_name_set(MDNS_INSTANCE));
     TEST_ASSERT_NOT_EQUAL(ESP_OK, mdns_service_add(MDNS_INSTANCE, MDNS_SERVICE_NAME, MDNS_SERVICE_PROTO, MDNS_SERVICE_PORT, NULL, 0));
+    TEST_ASSERT_EQUAL(ESP_ERR_INVALID_STATE, mdns_register_hostname_changed_callback(hostname_changed_callback, NULL));
 }
 
 TEST(mdns, init_deinit)
@@ -57,6 +71,34 @@ TEST(mdns, init_deinit)
     TEST_ASSERT_EQUAL(ESP_OK, esp_event_loop_create_default());
     TEST_ASSERT_EQUAL(ESP_OK, mdns_init());
     yield_to_all_priorities(); // Make sure that mdns task has executed to complete initialization
+    mdns_free();
+    esp_event_loop_delete_default();
+}
+
+TEST(mdns, hostname_changed_callback)
+{
+    hostname_changed_callback_context_t context = { 0 };
+
+    test_case_uses_tcpip();
+    TEST_ASSERT_EQUAL(ESP_OK, esp_event_loop_create_default());
+    TEST_ASSERT_EQUAL(ESP_OK, mdns_init());
+    TEST_ASSERT_EQUAL(ESP_ERR_INVALID_ARG, mdns_register_hostname_changed_callback(NULL, NULL));
+    TEST_ASSERT_EQUAL(ESP_OK, mdns_register_hostname_changed_callback(hostname_changed_callback, &context));
+
+    TEST_ASSERT_EQUAL(ESP_OK, mdns_hostname_set(MDNS_HOSTNAME));
+    yield_to_all_priorities();
+    TEST_ASSERT_EQUAL_UINT(1, context.count);
+    TEST_ASSERT_EQUAL_STRING(MDNS_HOSTNAME, context.hostname);
+
+    TEST_ASSERT_EQUAL(ESP_OK, mdns_hostname_set(MDNS_HOSTNAME));
+    yield_to_all_priorities();
+    TEST_ASSERT_EQUAL_UINT(1, context.count);
+
+    TEST_ASSERT_EQUAL(ESP_OK, mdns_hostname_set("renamed-hostname"));
+    yield_to_all_priorities();
+    TEST_ASSERT_EQUAL_UINT(2, context.count);
+    TEST_ASSERT_EQUAL_STRING("renamed-hostname", context.hostname);
+
     mdns_free();
     esp_event_loop_delete_default();
 }


### PR DESCRIPTION
## Summary

- Add the public `mdns_hostname_changed_cb_t` callback type and `mdns_register_hostname_changed_callback()` API.
- Notify registered callbacks after the hostname changes, including automatic hostname conflict resolution.
- Support multiple callback registrations and ignore duplicate `(cb, arg)` registrations.
- Keep hostname-change notification independent of the system event loop; callbacks receive the new hostname directly and must not call mDNS APIs.

## Tests

- Add Linux host-unit coverage for callback registration, initial hostname assignment, unchanged hostname, and subsequent hostname changes.
- Add ESP target unit coverage for invalid registration arguments and hostname-change notification behavior.

## Validation

- Linux host-unit `test_receiver`: 4 tests passed, including `test_hostname_changed_callback`.
- Built and flashed the M5Stack Thread Border Router example with the local mDNS component. The example now uses the callback API, and hostname updates were confirmed on the connected boards.