### PR TITLE
eppp_link: reset s_retry_num in on_ip_event() and eppp_init()

### DIFF
--- a/components/eppp_link/eppp_link.c
+++ b/components/eppp_link/eppp_link.c
@@ -171,6 +171,7 @@ static void on_ip_event(void *arg, esp_event_base_t base, int32_t event_id, void
     if (event_id == IP_EVENT_PPP_GOT_IP) {
         ESP_LOGI(TAG, "Got IPv4 event: Interface \"%s(%s)\" address: " IPSTR, esp_netif_get_desc(netif),
                  esp_netif_get_ifkey(netif), IP2STR(&event->ip_info.ip));
+        s_retry_num = 0;
         xEventGroupSetBits(s_event_group, GOT_IPV4 << (netif_cnt * 2));
     } else if (event_id == IP_EVENT_PPP_LOST_IP) {
         ESP_LOGI(TAG, "Disconnected");
@@ -229,6 +230,13 @@ esp_netif_t *eppp_init(eppp_type_t role, eppp_config_t *config)
         ESP_LOGE(TAG, "Invalid configuration or role");
         return NULL;
     }
+    // Every fresh eppp_init() call starts a brand new connection attempt, so
+    // any retry count accumulated by a previous, now-torn-down session must
+    // not carry over. s_retry_num is a module-static that was never reset
+    // here, so a caller that repeatedly deinits/reinits an endpoint (e.g. to
+    // switch transports) could inherit a stale count and reach
+    // CONFIG_EPPP_LINK_CONN_MAX_RETRY / report CONNECTION_FAILED prematurely.
+    s_retry_num = 0;
 
     eppp_transport_handle_t h = EPPP_TRANSPORT_INIT(config);
     ESP_GOTO_ON_FALSE(h, ESP_ERR_NO_MEM, err, TAG, "Failed to init EPPP transport");


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

`s_retry_num` is a module-static reconnect counter that is incremented on every
`IP_EVENT_PPP_LOST_IP` but was never reset in two places where it should be.
This PR resets it to 0 in:

- `on_ip_event()`, `IP_EVENT_PPP_GOT_IP` branch — a successful reconnect
  proves the link is healthy, so prior failures should no longer count
  toward the retry ceiling.
- `eppp_init()` — each new session (`eppp_open()`/`eppp_connect()`/
  `eppp_listen()`) gets its own fresh retry budget instead of inheriting a
  possibly-exhausted count from a previous, unrelated session.

Without these resets, `s_retry_num` only ever increases and is never
cleared, so on boards that repeatedly reconnect or tear down/recreate an
EPPP/PPP endpoint at runtime (e.g. switching between WiFi and cellular/PPP
as the active transport), the accumulated count can reach
`CONFIG_EPPP_LINK_CONN_MAX_RETRY` and report `CONNECTION_FAILED` (giving up
reconnecting) much sooner than expected, even though the link had since
recovered or the failing attempts belonged to an earlier, already
torn-down session.

## Related

Fixes #1126

## Testing

Reproduced the stale-retry-count issue on an ESP32-S3 based device that
switches between Wi-Fi and cellular (PPP over UART) as the active network
transport, where repeated `eppp_init()`/`eppp_deinit()` cycles caused
`CONNECTION_FAILED` after far fewer real failures than
`CONFIG_EPPP_LINK_CONN_MAX_RETRY`. Applied this fix locally and confirmed
the retry counter resets correctly on both a successful `GOT_IP` and on
each new `eppp_init()` call, restoring the expected reconnect behavior.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to reconnect retry bookkeeping in eppp_link with no API or security impact; behavior aligns retry limits with successful links and new sessions.
> 
> **Overview**
> Fixes **stale PPP reconnect accounting** in `eppp_link.c` by clearing the module-static `s_retry_num` in two places where it previously only increased on `IP_EVENT_PPP_LOST_IP`.
> 
> On **`IP_EVENT_PPP_GOT_IP`**, the counter is reset to **0** before signaling `GOT_IPV4`, so earlier disconnect/retry attempts no longer count toward `CONFIG_EPPP_LINK_CONN_MAX_RETRY` after the link is healthy again.
> 
> At the start of **`eppp_init()`**, the counter is reset so each new EPPP/PPP session (e.g. after `eppp_deinit()` / transport switches via `eppp_open()` / `eppp_connect()` / `eppp_listen()`) gets a fresh retry budget instead of inheriting an exhausted count from a torn-down session.
> 
> Together this prevents **`CONNECTION_FAILED`** and giving up on reconnects sooner than Kconfig intends when devices repeatedly reconnect or tear down and recreate the endpoint at runtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7030ff8a71c345378dbfe463a3295f3aa4f53868. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->