### PR TITLE
fix(mdns): handle subtype questions correctly

### DIFF
--- a/components/mdns/mdns_debug.c
+++ b/components/mdns/mdns_debug.c
@@ -103,6 +103,38 @@ static void mdns_dbg_printf(const char *fmt, ...)
 #define mdns_dbg_flush()
 #endif
 
+static void dbg_print_name_and_type(const char *prefix, const mdns_name_t *name, uint16_t type)
+{
+    if (type == MDNS_TYPE_A) {
+        dbg_printf("%s%s.%s. A ", prefix, name->host, name->domain);
+    } else if (type == MDNS_TYPE_AAAA) {
+        dbg_printf("%s%s.%s. AAAA ", prefix, name->host, name->domain);
+    } else if (type == MDNS_TYPE_OPT) {
+        dbg_printf("%s. OPT ", prefix);
+    } else {
+        const char *type_name = NULL;
+        if (type == MDNS_TYPE_PTR) {
+            type_name = "PTR";
+        } else if (type == MDNS_TYPE_SRV) {
+            type_name = "SRV";
+        } else if (type == MDNS_TYPE_TXT) {
+            type_name = "TXT";
+        } else if (type == MDNS_TYPE_NSEC) {
+            type_name = "NSEC";
+        } else if (type == MDNS_TYPE_ANY) {
+            type_name = "ANY";
+        }
+
+        dbg_printf("%s%s%s%s%s.%s.%s. ", prefix, name->host, name->host[0] ? "." : "",
+                   name->sub ? "_sub." : "", name->service, name->proto, name->domain);
+        if (type_name) {
+            dbg_printf("%s ", type_name);
+        } else {
+            dbg_printf("%04X ", type);
+        }
+    }
+}
+
 void static dbg_packet(const uint8_t *data, size_t len)
 {
     static mdns_name_t n;
@@ -153,23 +185,7 @@ void static dbg_packet(const uint8_t *data, size_t len)
             if (unicast) {
                 dbg_printf("*U* ");
             }
-            if (type == MDNS_TYPE_PTR) {
-                dbg_printf("%s.%s%s.%s.%s. PTR ", name->host, name->sub ? "_sub." : "", name->service, name->proto, name->domain);
-            } else if (type == MDNS_TYPE_SRV) {
-                dbg_printf("%s.%s%s.%s.%s. SRV ", name->host, name->sub ? "_sub." : "", name->service, name->proto, name->domain);
-            } else if (type == MDNS_TYPE_TXT) {
-                dbg_printf("%s.%s%s.%s.%s. TXT ", name->host, name->sub ? "_sub." : "", name->service, name->proto, name->domain);
-            } else if (type == MDNS_TYPE_A) {
-                dbg_printf("%s.%s. A ", name->host, name->domain);
-            } else if (type == MDNS_TYPE_AAAA) {
-                dbg_printf("%s.%s. AAAA ", name->host, name->domain);
-            } else if (type == MDNS_TYPE_NSEC) {
-                dbg_printf("%s.%s%s.%s.%s. NSEC ", name->host, name->sub ? "_sub." : "", name->service, name->proto, name->domain);
-            } else if (type == MDNS_TYPE_ANY) {
-                dbg_printf("%s.%s%s.%s.%s. ANY ", name->host, name->sub ? "_sub." : "", name->service, name->proto, name->domain);
-            } else {
-                dbg_printf("%s.%s%s.%s.%s. %04X ", name->host, name->sub ? "_sub." : "", name->service, name->proto, name->domain, type);
-            }
+            dbg_print_name_and_type("", name, type);
 
             if (mdns_class == 0x0001) {
                 dbg_printf("IN");
@@ -227,25 +243,7 @@ void static dbg_packet(const uint8_t *data, size_t len)
                 dbg_printf("    A");
             }
 
-            if (type == MDNS_TYPE_PTR) {
-                dbg_printf(": %s%s%s.%s.%s. PTR ", name->host, name->host[0] ? "." : "", name->service, name->proto, name->domain);
-            } else if (type == MDNS_TYPE_SRV) {
-                dbg_printf(": %s.%s.%s.%s. SRV ", name->host, name->service, name->proto, name->domain);
-            } else if (type == MDNS_TYPE_TXT) {
-                dbg_printf(": %s.%s.%s.%s. TXT ", name->host, name->service, name->proto, name->domain);
-            } else if (type == MDNS_TYPE_A) {
-                dbg_printf(": %s.%s. A ", name->host, name->domain);
-            } else if (type == MDNS_TYPE_AAAA) {
-                dbg_printf(": %s.%s. AAAA ", name->host, name->domain);
-            } else if (type == MDNS_TYPE_NSEC) {
-                dbg_printf(": %s.%s.%s.%s. NSEC ", name->host, name->service, name->proto, name->domain);
-            } else if (type == MDNS_TYPE_ANY) {
-                dbg_printf(": %s.%s.%s.%s. ANY ", name->host, name->service, name->proto, name->domain);
-            } else if (type == MDNS_TYPE_OPT) {
-                dbg_printf(": . OPT ");
-            } else {
-                dbg_printf(": %s.%s.%s.%s. %04X ", name->host, name->service, name->proto, name->domain, type);
-            }
+            dbg_print_name_and_type(": ", name, type);
 
             if (mdns_class == 0x0001) {
                 dbg_printf("IN ");

--- a/components/mdns/mdns_receive.c
+++ b/components/mdns/mdns_receive.c
@@ -734,7 +734,7 @@ static void mdns_parse_packet(mdns_rx_packet_t *packet)
                 continue;
             }
 
-            if (type == MDNS_TYPE_ANY && !mdns_utils_str_null_or_empty(name->host)) {
+            if (type == MDNS_TYPE_ANY && !name->sub && !mdns_utils_str_null_or_empty(name->host)) {
                 parsed_packet->probe = true;
             }
 

--- a/components/mdns/mdns_send.c
+++ b/components/mdns/mdns_send.c
@@ -257,7 +257,7 @@ static bool create_answer_from_service(mdns_tx_packet_t *packet, mdns_service_t 
 {
     mdns_host_item_t *host = get_host_item(service->hostname);
     bool is_delegated = (host != mdns_priv_get_self_host());
-    bool is_instance_question = !mdns_utils_str_null_or_empty(question->host);
+    bool is_instance_question = !question->sub && !mdns_utils_str_null_or_empty(question->host);
     if ((question->type == MDNS_TYPE_ANY) && is_instance_question) {
         // Instance-scoped ANY queries expect the resolved data (SRV/TXT) to be
         // part of the answer section so that queriers can stop searching as soon

--- a/components/mdns/mdns_send.c
+++ b/components/mdns/mdns_send.c
@@ -540,6 +540,12 @@ void mdns_priv_create_answer_from_parsed_packet(mdns_parsed_packet_t *parsed_pac
     uint32_t out_record_nums = 0;
     while (q) {
         shared = q->type == MDNS_TYPE_PTR || q->type == MDNS_TYPE_SDPTR || !parsed_packet->probe;
+        // DNS-SD subtypes only define PTR records at the subtype owner name.
+        // Do not interpret the subtype label as an instance name for SRV/TXT.
+        if (q->sub && (q->type == MDNS_TYPE_SRV || q->type == MDNS_TYPE_TXT)) {
+            q = q->next;
+            continue;
+        }
         if (q->type == MDNS_TYPE_SRV || q->type == MDNS_TYPE_TXT) {
             mdns_srv_item_t *service = mdns_utils_get_service_item_instance(q->host, q->service, q->proto, NULL);
             if (service == NULL) {  // Service not found, but we continue to the next question

--- a/components/mdns/mdns_utils.c
+++ b/components/mdns/mdns_utils.c
@@ -51,7 +51,13 @@ static const uint8_t *mdns_utils_read_fqdn_impl(const uint8_t *packet, const uin
                 strlcat(name->host, ".", sizeof(name->host));
                 strlcat(name->host, buf, sizeof(name->host));
             } else if (strcasecmp(buf, MDNS_SUB_STR) == 0) {
-                name->sub = 1;
+                // A DNS-SD subtype name has the form <subtype>._sub.<service>.<proto>.<domain>.
+                // Keep the subtype label in host, but reject _sub in any other position.
+                if (name->parts != 1 || name->sub) {
+                    name->invalid = true;
+                } else {
+                    name->sub = 1;
+                }
             } else if (!name->invalid) {
                 char *mdns_name_ptrs[] = {name->host, name->service, name->proto, name->domain};
                 memcpy(mdns_name_ptrs[name->parts++], buf, len + 1);
@@ -100,6 +106,9 @@ const uint8_t *mdns_utils_parse_fqdn(const uint8_t *packet, const uint8_t *start
     const uint8_t *next_data = (uint8_t *) mdns_utils_read_fqdn(packet, start, name, buf, packet_len);
     if (!next_data) {
         return 0;
+    }
+    if (name->sub && name->parts != 4) {
+        name->invalid = true;
     }
     if (!name->parts || name->invalid) {
         return next_data;

--- a/components/mdns/tests/host_unit_test/unity/test_receiver/test_receiver.c
+++ b/components/mdns/tests/host_unit_test/unity/test_receiver/test_receiver.c
@@ -10,6 +10,7 @@
 #include "mock_mdns_pcb.h"
 #include "mock_mdns_send.h"
 #include "mdns_private.h"
+#include "mdns_utils.h"
 
 static void test_mdns_hostname_queries(void)
 {
@@ -82,9 +83,38 @@ static void test_mdns_reject_short_packet(void)
     }
 }
 
+static void test_mdns_subtype_any_question_is_not_a_probe(void)
+{
+    mdns_test_query_t queries[] = {
+        { "subtype._sub._http._tcp.local", MDNS_TYPE_ANY, 1 },
+    };
+    size_t packet_len;
+    uint8_t *packet = create_mdns_test_packet(queries, 1, NULL, 0, NULL, 0, &packet_len);
+
+    send_test_packet_multiple(packet, packet_len);
+}
+
+static void test_mdns_reject_misplaced_sub_label(void)
+{
+    uint8_t fqdn[MDNS_NAME_BUF_LEN] = {};
+    mdns_name_t name = {};
+    size_t fqdn_len = encode_dns_name(fqdn, "instance._http._sub._tcp.local");
+
+    TEST_ASSERT_NOT_NULL(mdns_utils_parse_fqdn(fqdn, fqdn, &name, fqdn_len));
+    TEST_ASSERT_TRUE(name.invalid);
+
+    fqdn_len = encode_dns_name(fqdn, "subtype._sub._http._tcp.local");
+    TEST_ASSERT_NOT_NULL(mdns_utils_parse_fqdn(fqdn, fqdn, &name, fqdn_len));
+    TEST_ASSERT_FALSE(name.invalid);
+    TEST_ASSERT_TRUE(name.sub);
+}
+
 static void mdns_priv_create_answer_from_parsed_packet_Callback(mdns_parsed_packet_t* parsed_packet, int cmock_num_calls)
 {
     printf("callback\n");
+    if (parsed_packet->questions && parsed_packet->questions->sub && parsed_packet->questions->type == MDNS_TYPE_ANY) {
+        TEST_ASSERT_FALSE(parsed_packet->probe);
+    }
 }
 
 void setup_cmock(void)
@@ -111,6 +141,10 @@ void run_unity_tests(void)
     RUN_TEST(test_mdns_with_answers);
 
     RUN_TEST(test_mdns_reject_short_packet);
+
+    RUN_TEST(test_mdns_subtype_any_question_is_not_a_probe);
+
+    RUN_TEST(test_mdns_reject_misplaced_sub_label);
 
     UNITY_END();
 }


### PR DESCRIPTION
## Background

A user reported that an `ANY` query containing a DNS-SD subtype could be handled as an instance query. For example, when parsing `_aa._sub._print._udp.local`, the parser stores `_aa` in `host`; subsequent code could therefore mistake it for an instance name.

We reviewed the related subtype handling paths and fixed the issues below.

## Fixes

1. Distinguish subtype `ANY` questions from instance `ANY` questions, so subtype questions are answered without being marked as probes.
2. Ignore `SRV` and `TXT` questions at a subtype owner name. DNS-SD subtypes define `PTR` records at that name only.
3. Share the mDNS debug-name formatting path so record-owner output consistently retains `_sub`.
4. Validate that `_sub` appears only in the DNS-SD subtype position: `<subtype>._sub.<service>.<proto>.<domain>`.

## Tests

Added coverage for:

- A subtype `ANY` question, ensuring it is parsed as a subtype and is not marked as a probe.
- Rejection of a misplaced `_sub` label, while accepting a valid subtype query name.

Verified with the Linux host receiver and sender unit-test suites.