### PR TITLE
fix(examples): Fix ethernet_init component version

### DIFF
--- a/.github/workflows/examples_build-host-test.yml
+++ b/.github/workflows/examples_build-host-test.yml
@@ -13,7 +13,7 @@ jobs:
     name: Build examples
     strategy:
       matrix:
-        idf_ver: ["latest", "release-v5.1", "release-v5.2", "release-v5.3", "release-v5.4", "release-v5.5", "release-v6.0"]
+        idf_ver: ["latest", "release-v5.3", "release-v5.4", "release-v5.5", "release-v6.0", "release-v6.1"]
     runs-on: ubuntu-22.04
     container: espressif/idf:${{ matrix.idf_ver }}
     env:
@@ -79,7 +79,7 @@ jobs:
     needs: build_all_examples
     strategy:
       matrix:
-        idf_ver: ["release-v5.5", "latest"]
+        idf_ver: ["release-v5.5", "release-v6.0", "latest"]
     runs-on:
       - self-hosted
       - modem

--- a/examples/.build-test-rules.yml
+++ b/examples/.build-test-rules.yml
@@ -1,3 +1,20 @@
+.wifi_no_h2_p4: &wifi_no_h2_p4
+  disable:
+    - if: IDF_TARGET in ["esp32h2", "esp32p4"]
+      reason: target has no native Wi-Fi
+
 examples/esp_netif/multiple_netifs:
   disable:
     - if: IDF_TARGET != "esp32"
+
+examples/esp_netif/eth_endpoint_wifi_ap:
+  <<: *wifi_no_h2_p4
+
+examples/esp_netif/eth_endpoint_wifi_sta:
+  <<: *wifi_no_h2_p4
+
+examples/esp_netif/eth_gateway_wifi_ap:
+  <<: *wifi_no_h2_p4
+
+examples/esp_netif/eth_gateway_wifi_sta:
+  <<: *wifi_no_h2_p4

--- a/examples/esp_netif/eth_endpoint_wifi_ap/main/eth_endpoint_wifi_ap.c
+++ b/examples/esp_netif/eth_endpoint_wifi_ap/main/eth_endpoint_wifi_ap.c
@@ -21,6 +21,7 @@
 #include "esp_wifi.h"
 #include "esp_wifi_types.h"
 #include "esp_mac.h"
+#include "esp_idf_version.h"
 #include "nvs_flash.h"
 #include "dhcpserver/dhcpserver.h"
 #include "dhcpserver/dhcpserver_options.h"
@@ -31,6 +32,14 @@ static const char *TAG = "eth_endpoint_wifi_ap";
 
 /** Event group bit: set when Ethernet endpoint receives IPv4 (IP_EVENT_ETH_GOT_IP). */
 #define EXAMPLE_ETH_ENDPOINT_GOT_IP_BIT (1U << 0)
+
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+#define EXAMPLE_IP_EVENT_ASSIGNED_IP_TO_CLIENT IP_EVENT_ASSIGNED_IP_TO_CLIENT
+typedef ip_event_assigned_ip_to_client_t example_ap_staipassigned_event_t;
+#else
+#define EXAMPLE_IP_EVENT_ASSIGNED_IP_TO_CLIENT IP_EVENT_AP_STAIPASSIGNED
+typedef ip_event_ap_staipassigned_t example_ap_staipassigned_event_t;
+#endif
 
 static EventGroupHandle_t event_group = NULL;
 
@@ -120,8 +129,8 @@ static void wifi_ap_event_handler(void *arg, esp_event_base_t event_base,
             ESP_LOGW(TAG, "Unhandled Wi-Fi AP event: id=%ld", event_id);
             break;
         }
-    } else if (event_base == IP_EVENT && event_id == IP_EVENT_ASSIGNED_IP_TO_CLIENT) {
-        ip_event_assigned_ip_to_client_t* event = (ip_event_assigned_ip_to_client_t*) event_data;
+    } else if (event_base == IP_EVENT && event_id == EXAMPLE_IP_EVENT_ASSIGNED_IP_TO_CLIENT) {
+        example_ap_staipassigned_event_t *event = (example_ap_staipassigned_event_t *) event_data;
         ESP_LOGI(TAG, "Wi-Fi AP assigned IP to client: " IPSTR, IP2STR(&event->ip));
     }
 }
@@ -302,7 +311,7 @@ void app_main(void)
     ESP_ERROR_CHECK(esp_event_handler_register(WIFI_EVENT, WIFI_EVENT_AP_STOP, wifi_ap_event_handler, NULL));
     ESP_ERROR_CHECK(esp_event_handler_register(WIFI_EVENT, WIFI_EVENT_AP_STACONNECTED, wifi_ap_event_handler, NULL));
     ESP_ERROR_CHECK(esp_event_handler_register(WIFI_EVENT, WIFI_EVENT_AP_STADISCONNECTED, wifi_ap_event_handler, NULL));
-    ESP_ERROR_CHECK(esp_event_handler_register(IP_EVENT, IP_EVENT_ASSIGNED_IP_TO_CLIENT, wifi_ap_event_handler, NULL));
+    ESP_ERROR_CHECK(esp_event_handler_register(IP_EVENT, EXAMPLE_IP_EVENT_ASSIGNED_IP_TO_CLIENT, wifi_ap_event_handler, NULL));
 
     // Initialize WiFi AP netif
     esp_netif_t *ap_netif = wifi_init_ap();

--- a/examples/esp_netif/eth_endpoint_wifi_ap/main/idf_component.yml
+++ b/examples/esp_netif/eth_endpoint_wifi_ap/main/idf_component.yml
@@ -1,6 +1,10 @@
 dependencies:
   idf: ">=5.0"
   espressif/ethernet_init:
-    version: "~1.2.0"
+    matches:
+      - if: idf_version >=6.0
+        version: ^1.0.0
+      - if: idf_version <6.0
+        version: "==0.3.0"
     rules:
       - if: "target != linux"

--- a/examples/esp_netif/eth_endpoint_wifi_sta/main/idf_component.yml
+++ b/examples/esp_netif/eth_endpoint_wifi_sta/main/idf_component.yml
@@ -1,6 +1,10 @@
 dependencies:
   idf: ">=5.0"
   espressif/ethernet_init:
-    version: "~1.2.0"
+    matches:
+      - if: idf_version >=6.0
+        version: ^1.0.0
+      - if: idf_version <6.0
+        version: "==0.3.0"
     rules:
       - if: "target != linux"

--- a/examples/esp_netif/eth_gateway/main/idf_component.yml
+++ b/examples/esp_netif/eth_gateway/main/idf_component.yml
@@ -1,6 +1,10 @@
 dependencies:
   idf: "*"
   espressif/ethernet_init:
-    version: "~1.2.0"
+    matches:
+      - if: idf_version >=6.0
+        version: ^1.0.0
+      - if: idf_version <6.0
+        version: "==0.3.0"
     rules:
       - if: "target != linux"

--- a/examples/esp_netif/eth_gateway_wifi_ap/main/idf_component.yml
+++ b/examples/esp_netif/eth_gateway_wifi_ap/main/idf_component.yml
@@ -1,6 +1,10 @@
 dependencies:
   idf: "*"
   espressif/ethernet_init:
-    version: "~1.2.0"
+    matches:
+      - if: idf_version >=6.0
+        version: ^1.0.0
+      - if: idf_version <6.0
+        version: "==0.3.0"
     rules:
       - if: "target != linux"

--- a/examples/esp_netif/eth_gateway_wifi_sta/main/idf_component.yml
+++ b/examples/esp_netif/eth_gateway_wifi_sta/main/idf_component.yml
@@ -1,6 +1,10 @@
 dependencies:
   idf: "*"
   espressif/ethernet_init:
-    version: "~1.2.0"
+    matches:
+      - if: idf_version >=6.0
+        version: ^1.0.0
+      - if: idf_version <6.0
+        version: "==0.3.0"
     rules:
       - if: "target != linux"


### PR DESCRIPTION
Add version ifdefs to ethernet_init dependencies

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-only and CI configuration changes; no production library or security-sensitive logic.
> 
> **Overview**
> Aligns **esp_netif** Ethernet+Wi‑Fi examples with **ESP-IDF 6.x** by pinning **`espressif/ethernet_init`** per IDF version (`^1.0.0` on IDF ≥ 6.0, `==0.3.0` on older IDF) instead of a single `~1.2.0` constraint across several `idf_component.yml` files.
> 
> **`eth_endpoint_wifi_ap`** now maps DHCP “client got IP” events and types across the IDF rename (`IP_EVENT_AP_STAIPASSIGNED` / pre-6 vs `IP_EVENT_ASSIGNED_IP_TO_CLIENT` on IDF 6+).
> 
> CI updates the examples build matrix (drops 5.1/5.2, adds **release-v6.1**; target slip test adds **release-v6.0**). **`.build-test-rules.yml`** skips the four eth+Wi‑Fi gateway/endpoint examples on **esp32h2** and **esp32p4** (no native Wi‑Fi).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94a0c3dc1dd727420f363ff6d5a75a51aa54e7af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->