### PR TITLE
bump(eppp): 1.1.5 -> 1.1.6

### DIFF
--- a/components/eppp_link/.cz.yaml
+++ b/components/eppp_link/.cz.yaml
@@ -3,6 +3,6 @@ commitizen:
   bump_message: 'bump(eppp): $current_version -> $new_version'
   pre_bump_hooks: python ../../ci/changelog.py eppp_link
   tag_format: eppp-v$version
-  version: 1.1.5
+  version: 1.1.6
   version_files:
   - idf_component.yml

--- a/components/eppp_link/CHANGELOG.md
+++ b/components/eppp_link/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.1.6](https://github.com/espressif/esp-protocols/commits/eppp-v1.1.6)
+
+### Updated
+
+- eppp_link: reset s_retry_num in on_ip_event() and eppp_init() ([7030ff8a](https://github.com/espressif/esp-protocols/commit/7030ff8a), [#1126](https://github.com/espressif/esp-protocols/issues/1126))
+
 ## [1.1.5](https://github.com/espressif/esp-protocols/commits/eppp-v1.1.5)
 
 ### Bug Fixes

--- a/components/eppp_link/idf_component.yml
+++ b/components/eppp_link/idf_component.yml
@@ -1,4 +1,4 @@
-version: 1.1.5
+version: 1.1.6
 url: https://github.com/espressif/esp-protocols/tree/master/components/eppp_link
 description: The component provides a general purpose PPP connectivity, typically used as WiFi-PPP router
 dependencies:


### PR DESCRIPTION
## 1.1.6

### Updated
- eppp_link: reset s_retry_num in on_ip_event() and eppp_init() (7030ff8a, #1126)
