### PR TITLE
Fix mdns_browse_new() return dangling pointer + test update

### DIFF
--- a/components/mdns/tests/host_test/bonjour_order_responder.py
+++ b/components/mdns/tests/host_test/bonjour_order_responder.py
@@ -9,6 +9,9 @@ Default response order mimics Bonjour browse answers:
 
 Use ``--goodbye-after N`` to answer the first N browse queries normally and then
 reply with a standalone PTR TTL=0 (Bonjour service removal).
+
+Use ``--unsolicited-goodbye-after N`` to answer N browse queries normally and then
+multicast an unsolicited PTR TTL=0 announcement (keeps the active browse item).
 """
 
 from __future__ import annotations
@@ -18,6 +21,7 @@ import logging
 import socket
 import struct
 import sys
+import time
 
 import dns.flags
 import dns.message
@@ -64,6 +68,24 @@ def build_goodbye_response(
         dns.rrset.from_text(service_name, 0, dns.rdataclass.IN, dns.rdatatype.PTR, instance_name)
     )
     return response
+
+
+def build_unsolicited_goodbye(
+    *,
+    service: str,
+    proto: str,
+    instance: str,
+) -> dns.message.Message:
+    """Build a multicast goodbye announcement (QR+AA, no question section)."""
+    service_name = _fqdn(service, proto)
+    instance_name = _fqdn(instance, service, proto)
+
+    msg = dns.message.Message(id=0)
+    msg.flags = dns.flags.QR | dns.flags.AA
+    msg.answer.append(
+        dns.rrset.from_text(service_name, 0, dns.rdataclass.IN, dns.rdatatype.PTR, instance_name)
+    )
+    return msg
 
 
 def build_ptr_response(
@@ -150,11 +172,34 @@ def send_mdns_response(sock: socket.socket, payload: bytes, source: tuple[str, i
     logger.info('Sent %d byte response to %s (query source %s:%d)', len(payload), destination, *source)
 
 
+def send_mdns_multicast(sock: socket.socket, payload: bytes) -> None:
+    destination = (MDNS_ADDR, MDNS_PORT)
+    sock.sendto(payload, destination)
+    logger.info('Sent %d byte multicast announcement to %s', len(payload), destination)
+
+
+def maybe_send_unsolicited_goodbye(sock: socket.socket, args: argparse.Namespace, response_count: int) -> bool:
+    """After N normal answers, multicast one unsolicited PTR TTL=0. Returns True if sent."""
+    if args.unsolicited_goodbye_after < 0 or response_count != args.unsolicited_goodbye_after:
+        return False
+    if args.unsolicited_goodbye_delay > 0:
+        time.sleep(args.unsolicited_goodbye_delay)
+    goodbye = build_unsolicited_goodbye(
+        service=args.service,
+        proto=args.proto,
+        instance=args.instance,
+    )
+    send_mdns_multicast(sock, goodbye.to_wire())
+    logger.info('Multicasted unsolicited PTR goodbye (TTL=0)')
+    return True
+
+
 def serve(args: argparse.Namespace) -> None:
     sock = create_socket(args.interface)
     order = 'SRV, TXT, A, AAAA' if args.srv_first else 'A, AAAA, SRV, TXT'
     logger.info(
-        'Listening on %s:%d (%s) for PTR %s.%s.local; additional order: %s; goodbye-after=%s',
+        'Listening on %s:%d (%s) for PTR %s.%s.local; additional order: %s; '
+        'goodbye-after=%s; unsolicited-goodbye-after=%s',
         MDNS_ADDR,
         MDNS_PORT,
         args.interface or 'all interfaces',
@@ -162,9 +207,11 @@ def serve(args: argparse.Namespace) -> None:
         args.proto,
         order,
         args.goodbye_after,
+        args.unsolicited_goodbye_after,
     )
 
     response_count = 0
+    unsolicited_goodbye_sent = False
     while True:
         try:
             data, source = sock.recvfrom(9000)
@@ -209,6 +256,9 @@ def serve(args: argparse.Namespace) -> None:
         send_mdns_response(sock, response.to_wire(), source)
         response_count += 1
 
+        if not unsolicited_goodbye_sent:
+            unsolicited_goodbye_sent = maybe_send_unsolicited_goodbye(sock, args, response_count)
+
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -231,6 +281,18 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         type=int,
         default=-1,
         help='After N normal browse responses, reply with PTR TTL=0 only (-1 disables)',
+    )
+    parser.add_argument(
+        '--unsolicited-goodbye-after',
+        type=int,
+        default=-1,
+        help='After N normal browse responses, multicast one unsolicited PTR TTL=0 (-1 disables)',
+    )
+    parser.add_argument(
+        '--unsolicited-goodbye-delay',
+        type=float,
+        default=0.5,
+        help='Seconds to wait after the Nth normal response before multicasting goodbye',
     )
     return parser.parse_args(argv)
 

--- a/components/mdns/tests/host_test/pytest_mdns.py
+++ b/components/mdns/tests/host_test/pytest_mdns.py
@@ -63,7 +63,11 @@ class MdnsConsole:
         assert self.process.exitstatus == 0
 
 
-def _bonjour_responder_cmd(srv_first: bool = False, goodbye_after: int = -1) -> list[str]:
+def _bonjour_responder_cmd(
+    srv_first: bool = False,
+    goodbye_after: int = -1,
+    unsolicited_goodbye_after: int = -1,
+) -> list[str]:
     cmd = [
         sys.executable,
         str(Path(__file__).with_name('bonjour_order_responder.py')),
@@ -78,12 +82,24 @@ def _bonjour_responder_cmd(srv_first: bool = False, goodbye_after: int = -1) -> 
         cmd.append('--srv-first')
     if goodbye_after >= 0:
         cmd.extend(['--goodbye-after', str(goodbye_after)])
+    if unsolicited_goodbye_after >= 0:
+        cmd.extend(['--unsolicited-goodbye-after', str(unsolicited_goodbye_after)])
     return cmd
 
 
-def _run_bonjour_responder(*, srv_first: bool = False, goodbye_after: int = -1, label: str):
+def _run_bonjour_responder(
+    *,
+    srv_first: bool = False,
+    goodbye_after: int = -1,
+    unsolicited_goodbye_after: int = -1,
+    label: str,
+):
     proc = subprocess.Popen(
-        _bonjour_responder_cmd(srv_first=srv_first, goodbye_after=goodbye_after),
+        _bonjour_responder_cmd(
+            srv_first=srv_first,
+            goodbye_after=goodbye_after,
+            unsolicited_goodbye_after=unsolicited_goodbye_after,
+        ),
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,
@@ -119,7 +135,10 @@ def bonjour_responder_srv_first():
 
 @pytest.fixture
 def bonjour_responder_goodbye():
-    proc = _run_bonjour_responder(goodbye_after=1, label='Goodbye responder')
+    proc = _run_bonjour_responder(
+        unsolicited_goodbye_after=1,
+        label='Unsolicited-goodbye responder',
+    )
     yield proc
     _stop_bonjour_responder(proc)
 
@@ -335,18 +354,37 @@ def test_browse_srv_first_includes_ip(mdns_console, bonjour_responder_srv_first)
 
 
 def test_browse_ptr_goodbye_notifies_removal(mdns_console, bonjour_responder_goodbye):
-    """Bonjour service removal via standalone PTR TTL=0 must notify browse consumers."""
+    """Same live browse must see normal result then unsolicited PTR TTL=0 removal."""
     service = DEFAULTS['service']
     proto = DEFAULTS['proto']
     mdns_console.send_input(f'mdns_browse_del {service} {proto}')
     mdns_console.get_output('mdns>')
     mdns_console.send_input(f'mdns_browse {service} {proto}')
     mdns_console.wait_for_browse_result(timeout=10)
-    mdns_console.send_input(f'mdns_browse {service} {proto}')
     output = mdns_console.wait_for_browse_goodbye(timeout=10)
     assert _console_line('PTR : ', DEFAULTS['instance']) in output
     mdns_console.send_input(f'mdns_browse_del {service} {proto}')
     mdns_console.get_output('mdns>')
+
+
+def test_browse_duplicate_rejected(mdns_console, bonjour_responder):
+    """Duplicate mdns_browse_new() for the same service/proto must fail and leave the original active."""
+    service = DEFAULTS['service']
+    proto = DEFAULTS['proto']
+    mdns_console.send_input(f'mdns_browse_del {service} {proto}')
+    mdns_console.get_output('mdns>')
+    mdns_console.send_input(f'mdns_browse {service} {proto}')
+    mdns_console.wait_for_browse_result(timeout=10)
+
+    mdns_console.send_input(f'mdns_browse {service} {proto}')
+    mdns_console.get_output('Browse already exists')
+    mdns_console.get_output('Command returned non-zero error code')
+    mdns_console.get_output('mdns>')
+
+    # Original browse remains usable (delete must succeed).
+    mdns_console.send_input(f'mdns_browse_del {service} {proto}')
+    out = mdns_console.get_output('mdns>')
+    assert 'Command returned non-zero' not in out
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
https://github.com/espressif/esp-protocols/pull/1125 + one test fix

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Host-only pytest and mock responder changes; no production mDNS code in this diff.
> 
> **Overview**
> Updates mDNS host browse tests so service removal is exercised as an **unsolicited** multicast PTR TTL=0 on the same live browse, instead of a second browse plus a solicited goodbye reply.
> 
> The mock Bonjour responder gains `--unsolicited-goodbye-after` / `--unsolicited-goodbye-delay` to answer N queries normally, then multicast a QR+AA announcement with no question section.
> 
> Also adds `test_browse_duplicate_rejected`: a second `mdns_browse` for the same service/proto must fail (`Browse already exists`) while the original browse remains deletable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab03980d596acb4de885adee75dec77a66fb3b70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->