### PR TITLE
fix(mdns): Only depend on esp_wifi when Wi-Fi is enabled

### DIFF
--- a/components/mdns/CMakeLists.txt
+++ b/components/mdns/CMakeLists.txt
@@ -26,7 +26,7 @@ if(${target} STREQUAL "linux")
     set(srcs ${MDNS_CORE} ${MDNS_MEMORY} ${MDNS_NETWORKING} ${MDNS_CONSOLE})
 else()
     set(dependencies lwip console esp_netif)
-    set(private_dependencies esp_timer esp_wifi)
+    set(private_dependencies esp_timer)
     set(srcs ${MDNS_CORE} ${MDNS_MEMORY} ${MDNS_NETWORKING} ${MDNS_CONSOLE})
 endif()
 
@@ -43,6 +43,20 @@ endif()
 
 if(CONFIG_ETH_ENABLED)
     idf_component_optional_requires(PRIVATE esp_eth)
+endif()
+
+# esp_wifi is only used by the predefined STA/AP interface event handlers in
+# mdns_netif.c; mirror the MDNS_ESP_WIFI_ENABLED condition used there so
+# builds without Wi-Fi do not pull the Wi-Fi stack into the build.
+if(NOT ${target} STREQUAL "linux")
+    if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER "5.1")
+        if(CONFIG_ESP_WIFI_ENABLED OR CONFIG_ESP_WIFI_REMOTE_ENABLED)
+            idf_component_optional_requires(PRIVATE esp_wifi)
+        endif()
+    elseif(CONFIG_SOC_WIFI_SUPPORTED)
+        # ESP_WIFI_ENABLED is not available on IDF <= 5.1
+        idf_component_optional_requires(PRIVATE esp_wifi)
+    endif()
 endif()
 
 idf_component_get_property(MDNS_VERSION ${COMPONENT_NAME} COMPONENT_VERSION)


### PR DESCRIPTION
esp_wifi is only used by the predefined STA/AP interface handlers in mdns_netif.c, but it was declared as an unconditional private requirement, so every project using mdns compiled the whole Wi-Fi stack even when it could never be used.

This declares it conditionally with idf_component_optional_requires, following the existing esp_eth pattern. The condition mirrors the MDNS_ESP_WIFI_ENABLED logic in mdns_netif.c, including the SOC_WIFI_SUPPORTED fallback for IDF 5.1 and older.

Measured on an Ethernet only ESP32 project (IDF 5.5.5) with esp_wifi, wpa_supplicant, esp_phy and esp_coex excluded from the build: all 83 wpa_supplicant objects plus esp_wifi, esp_phy and esp_coex drop out of the build. Also verified on hardware that a Wi-Fi less Ethernet device still announces and resolves mDNS correctly, and that a BLE build (where the bt component pulls esp_wifi back via its own requirements) still builds and runs.

Closes https://github.com/espressif/esp-protocols/issues/835

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-system only: optional `esp_wifi` dependency. Runtime mDNS behavior is unchanged when Wi-Fi is present; risk is limited to mis-matching Kconfig vs. compile guards on older IDF.
> 
> **Overview**
> Stops mDNS from always pulling in the Wi-Fi stack. `esp_wifi` is now an optional private dependency, matching the `MDNS_ESP_WIFI_ENABLED` guards in `mdns_netif.c` (including the IDF ≤ 5.1 `SOC_WIFI_SUPPORTED` fallback).
> 
> Ethernet-only and other Wi-Fi-less builds can drop `esp_wifi`, `wpa_supplicant`, `esp_phy`, and `esp_coex`. Wi-Fi STA/AP predefined-netif handlers still require `esp_wifi` when those configs are on.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47724b7d8facba39852db96f6ea22884041a3058. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->