### PR TITLE
fix(eppp): Use modern eth-transmit function on new IDF

### DIFF
--- a/components/eppp_link/eppp_eth.c
+++ b/components/eppp_link/eppp_eth.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2024-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -155,7 +155,15 @@ esp_err_t eppp_transport_tx(void *h, void *buffer, size_t len)
     if (len > ETH_MAX_PAYLOAD_LEN) {
         return ESP_FAIL;
     }
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 1, 0)
+    esp_eth_buf_desc_t bufs[] = {
+        { .buf = out_buffer, .len = ETH_HEADER_LEN },
+        { .buf = (uint8_t *)buffer, .len = len },
+    };
+    return esp_eth_transmit_ctrl_bufs(s_eth_handles[0], NULL, bufs, 2);
+#else
     return esp_eth_transmit_vargs(s_eth_handles[0], 2, out_buffer, ETH_HEADER_LEN, buffer, len);
+#endif
 }
 
 static esp_err_t start_driver(esp_netif_t *esp_netif)


### PR DESCRIPTION
use `esp_eth_transmit_ctrl_bufs()`  on IDF v6.1+

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, version-gated swap to the newer Ethernet transmit API with the same two-buffer transmit behavior; no auth or data-model changes.
> 
> **Overview**
> On **ESP-IDF 6.1+**, EPPP Ethernet transmit in `eppp_transport_tx` now uses **`esp_eth_transmit_ctrl_bufs()`** with an **`esp_eth_buf_desc_t`** scatter list (Ethernet header + payload) instead of **`esp_eth_transmit_vargs()`**.
> 
> Older IDF versions still call **`esp_eth_transmit_vargs()`** behind **`ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 1, 0)`**. Packet layout and length checks are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5f9dd04deb5a71aae5cb9e9e3e1e04942e2377a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->