### PR TITLE
fix(common): Bump eradicate to 3.0.1 to setup pre-commit in Python 3.14

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/myint/eradicate/
-    rev: 3.0.0
+    rev: 3.0.1
     hooks:
       - id: eradicate
   - repo: https://github.com/espressif/check-copyright/


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

I met these error log when trying to setup pre-commit hooks in my WSL enviroment. I am running in Ubuntu 26.04 and Python 3.14.4.
```bash
~/develop/esp-protocols master ❯ pip install pre-commit && pre-commit install-hooks                            19:36:52
Requirement already satisfied: pre-commit in /home/siflourite/.espressif/python_env/idf6.2_py3.14_env/lib/python3.14/site-packages (4.6.2)
Requirement already satisfied: cfgv>=2.0.0 in /home/siflourite/.espressif/python_env/idf6.2_py3.14_env/lib/python3.14/site-packages (from pre-commit) (3.5.0)
Requirement already satisfied: identify>=1.0.0 in /home/siflourite/.espressif/python_env/idf6.2_py3.14_env/lib/python3.14/site-packages (from pre-commit) (2.6.19)
Requirement already satisfied: nodeenv>=0.11.1 in /home/siflourite/.espressif/python_env/idf6.2_py3.14_env/lib/python3.14/site-packages (from pre-commit) (1.10.0)
Requirement already satisfied: pyyaml>=5.1 in /home/siflourite/.espressif/python_env/idf6.2_py3.14_env/lib/python3.14/site-packages (from pre-commit) (6.0.3)
Requirement already satisfied: virtualenv>=20.10.0 in /home/siflourite/.espressif/python_env/idf6.2_py3.14_env/lib/python3.14/site-packages (from pre-commit) (21.7.7)
Requirement already satisfied: distlib<1,>=0.3.7 in /home/siflourite/.espressif/python_env/idf6.2_py3.14_env/lib/python3.14/site-packages (from virtualenv>=20.10.0->pre-commit) (0.4.3)
Requirement already satisfied: filelock<4,>=3.24.2 in /home/siflourite/.espressif/python_env/idf6.2_py3.14_env/lib/python3.14/site-packages (from virtualenv>=20.10.0->pre-commit) (3.32.4)
Requirement already satisfied: platformdirs<5,>=3.9.1 in /home/siflourite/.espressif/python_env/idf6.2_py3.14_env/lib/python3.14/site-packages (from virtualenv>=20.10.0->pre-commit) (4.11.5)
Requirement already satisfied: python-discovery>=1.6 in /home/siflourite/.espressif/python_env/idf6.2_py3.14_env/lib/python3.14/site-packages (from virtualenv>=20.10.0->pre-commit) (1.6.0)
[INFO] Installing environment for https://github.com/myint/eradicate/.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
An unexpected error has occurred: CalledProcessError: command: ('/home/siflourite/.cache/pre-commit/repo7_zwfmej/py_env-python3.14/bin/python', '-mpip', 'install', '.')
return code: 1
stdout:
    Processing ./.
      Installing build dependencies: started
      Installing build dependencies: finished with status 'done'
      Getting requirements to build wheel: started
      Getting requirements to build wheel: finished with status 'error'
stderr:
      error: subprocess-exited-with-error

      × Getting requirements to build wheel did not run successfully.
      │ exit code: 1
      ╰─> [24 lines of output]
          Traceback (most recent call last):
            File "/home/siflourite/.cache/pre-commit/repo7_zwfmej/py_env-python3.14/lib/python3.14/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 389, in <module>
              main()
              ~~~~^^
            File "/home/siflourite/.cache/pre-commit/repo7_zwfmej/py_env-python3.14/lib/python3.14/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 373, in main
              json_out["return_val"] = hook(**hook_input["kwargs"])
                                       ~~~~^^^^^^^^^^^^^^^^^^^^^^^^
            File "/home/siflourite/.cache/pre-commit/repo7_zwfmej/py_env-python3.14/lib/python3.14/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 143, in get_requires_for_build_wheel
              return hook(config_settings)
            File "/tmp/pip-build-env-3b1i1xxs/overlay/lib/python3.14/site-packages/setuptools/build_meta.py", line 333, in get_requires_for_build_wheel
              return self._get_build_requires(config_settings, requirements=[])
                     ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            File "/tmp/pip-build-env-3b1i1xxs/overlay/lib/python3.14/site-packages/setuptools/build_meta.py", line 301, in _get_build_requires
              self.run_setup()
              ~~~~~~~~~~~~~~^^
            File "/tmp/pip-build-env-3b1i1xxs/overlay/lib/python3.14/site-packages/setuptools/build_meta.py", line 520, in run_setup
              super().run_setup(setup_script=setup_script)
              ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
            File "/tmp/pip-build-env-3b1i1xxs/overlay/lib/python3.14/site-packages/setuptools/build_meta.py", line 317, in run_setup
              exec(code, locals())  # noqa: S102 # exec is intentional here
              ~~~~^^^^^^^^^^^^^^^^
            File "<string>", line 20, in <module>
            File "<string>", line 14, in version
          AttributeError: 'Constant' object has no attribute 's'
          [end of output]

      note: This error originates from a subprocess, and is likely not a problem with pip.
    ERROR: Failed to build 'file:///home/siflourite/.cache/pre-commit/repo7_zwfmej' when getting requirements to build wheel
Check the log at /home/siflourite/.cache/pre-commit/pre-commit.log
```

The reason is that `.pre-commit-config.yaml` uses `eradicate 3.0.0`, which gets Python version in this way:
```Python
def version():
    """Return version string."""
    with open('eradicate.py') as input_file:
        for line in input_file:
            if line.startswith('__version__'):
                return ast.parse(line).body[0].value.s
```
The compatible layer between `ast.Str(s)` and `ast.Constant(value)` was removed in Python 3.14, and `eradicate` updates to 3.0.1 to fix this problem (PyCQA/eradicate#60).
I bumped `eradicate` in `.pre-commit-config.yaml` to 3.0.1, and pre-commit hooks can be successfully installed and run.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single dependency pin in pre-commit config; no runtime or application code changes.
> 
> **Overview**
> **Bumps the `eradicate` pre-commit hook** from `3.0.0` to `3.0.1` in `.pre-commit-config.yaml` so `pre-commit install-hooks` works on Python 3.14.
> 
> Older `eradicate` read `__version__` via `ast` in a way that assumed `.s` on string nodes; Python 3.14 only exposes those values on `ast.Constant`, which caused hook environment install to fail. No other hooks or config are changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 066591730e642b77def8afa6f4d55178d6005a3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->