### PR TITLE
fix(examples): Fix The smallest * partition is nearly full warning

### DIFF
--- a/.github/workflows/examples_build-host-test.yml
+++ b/.github/workflows/examples_build-host-test.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Build with IDF-${{ matrix.idf_ver }}
         env:
-          EXPECTED_WARNING: "Warning: The smallest app partition is nearly full"
+          EXPECTED_WARNING: "The smallest .+ partition is nearly full"
         shell: bash
         run: |
           . ${IDF_PATH}/export.sh


### PR DESCRIPTION
* Fixing https://github.com/espressif/esp-protocols/actions/runs/33491256659/job/99803030305

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to an allowed warning pattern; no runtime or application behavior is affected.
> 
> **Overview**
> Updates the **examples build/host-tests** workflow so CI still accepts the ESP-IDF “partition nearly full” size warning after the toolchain changed the message.
> 
> `EXPECTED_WARNING` now matches **`The smallest .+ partition is nearly full`** instead of the fixed string **`Warning: The smallest app partition is nearly full`**, so the check tolerates dropped **`Warning:`** prefix and partition names other than **`app`** (fed into `ci/build_apps.py` via `ignore_warning_strs`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 584bf7d441a1f39750f11e3bf2baca86e28209af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->