### PR TITLE
[mdns]: making fuzzing more effective

### DIFF
--- a/.github/workflows/mdns__host-tests.yml
+++ b/.github/workflows/mdns__host-tests.yml
@@ -112,10 +112,12 @@ jobs:
 
   fuzz_test:
     if: contains(github.event.pull_request.labels.*.name, 'mdns-fuzz') || github.event_name == 'push'
-    name: Fuzzer tests for mdns lib
+    name: Fuzzer (${{ matrix.fuzz_target }})
     strategy:
+      fail-fast: false
       matrix:
         idf_ver: ["latest"]
+        fuzz_target: [receive, browse]
 
     runs-on: ubuntu-22.04
     container: aflplusplus/aflplusplus:v4.34c
@@ -135,20 +137,27 @@ jobs:
           apt-get update -y
           apt-get install -y libbsd-dev
 
-      - name: Run AFL++
+      - name: Run AFL++ (${{ matrix.fuzz_target }})
         shell: bash
+        env:
+          ASAN_OPTIONS: abort_on_error=1:halt_on_error=1:symbolize=0:detect_stack_use_after_return=1:max_malloc_fill_size=1073741824
+          UBSAN_OPTIONS: halt_on_error=1:abort_on_error=1
         run: |
           export IDF_PATH=$GITHUB_WORKSPACE/idf
           cd components/mdns/tests/host_unit_test/
           pip install dnslib
           cd input && python generate_cases.py && cd ..
-          cmake -B build2 -S . -G "Ninja" -DCMAKE_C_COMPILER=afl-cc
-          cmake --build build2
-          timeout 10m afl-fuzz -i input -o out -- build2/mdns_host_unit_test || \
+          BUILD_DIR=build_fuzz_${{ matrix.fuzz_target }}
+          OUT_DIR=out_${{ matrix.fuzz_target }}
+          cmake -B "${BUILD_DIR}" -S . -G Ninja \
+            -DCMAKE_C_COMPILER=afl-clang-fast \
+            -DFUZZ_TARGET=${{ matrix.fuzz_target }}
+          cmake --build "${BUILD_DIR}"
+          timeout 10m afl-fuzz -i input -o "${OUT_DIR}" -- "${BUILD_DIR}/mdns_host_unit_test" || \
           if [ $? -eq 124 ]; then  # timeout exit code
-            if [ -n "$(find out/default/crashes -type f 2>/dev/null)" ]; then
+            if [ -n "$(find "${OUT_DIR}/default/crashes" -type f 2>/dev/null)" ]; then
               echo "Crashes found!";
-              tar -czf out/default/crashes.tar.gz -C out/default crashes;
+              tar -czf "${OUT_DIR}/default/crashes.tar.gz" -C "${OUT_DIR}/default" crashes;
               exit 1;
             fi
           else
@@ -159,6 +168,6 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: fuzz-crashes
-          path: components/mdns/tests/host_unit_test/out/default/crashes.tar.gz
+          name: fuzz-crashes-${{ matrix.fuzz_target }}
+          path: components/mdns/tests/host_unit_test/out_${{ matrix.fuzz_target }}/default/crashes.tar.gz
           if-no-files-found: ignore

--- a/ci/ignore_build_warnings.txt
+++ b/ci/ignore_build_warnings.txt
@@ -8,3 +8,4 @@ warning: unknown kconfig symbol 'EXAMPLE_ETH_PHY_IP101'
 WARNING: The following Kconfig variables were used in "if" clauses, but not
 warning: unknown kconfig symbol 'LIBC_NEWLIB'
 warning: 'MBEDTLS_PSA_BUILTIN_[A-Z0-9_]+' redefined
+The smallest .+ partition is nearly full \(\d+% free space left\)!

--- a/components/mdns/tests/host_unit_test/CMakeLists.txt
+++ b/components/mdns/tests/host_unit_test/CMakeLists.txt
@@ -10,12 +10,16 @@ endif()
 
 project(mdns_host_unit_test C)
 
-# Set ENABLE_UNIT_TESTS with a default of OFF
-if(NOT DEFINED UNIT_TESTS)
-    set(UNIT_TESTS "OFF" CACHE STRING "Unit tests: OFF, test_receiver, test_sender")
-else()
+# Unit tests are enabled only for a real suite name (fuzz builds leave this OFF).
+set(UNIT_TESTS "OFF" CACHE STRING "Unit tests: OFF, test_receiver, test_sender, test_browse")
+set_property(CACHE UNIT_TESTS PROPERTY STRINGS OFF test_receiver test_sender test_browse)
+
+if(UNIT_TESTS AND NOT UNIT_TESTS STREQUAL "OFF")
     set(ENABLE_UNIT_TESTS 1)
     message(STATUS "Unit testing enabled with UNIT_TESTS=${UNIT_TESTS}")
+else()
+    unset(ENABLE_UNIT_TESTS)
+    message(STATUS "Unit testing disabled (fuzz/harness build)")
 endif()
 
 # Set variables for directories
@@ -69,6 +73,17 @@ set(SOURCES
 if(ENABLE_UNIT_TESTS)
     include(unity/unit_test.cmake)
 else()
+    # Fuzz harness target: receive (parse/query) or browse (cache/TXT path)
+    set(FUZZ_TARGET "receive" CACHE STRING "Fuzz harness: receive, browse")
+    set_property(CACHE FUZZ_TARGET PROPERTY STRINGS receive browse)
+    if(FUZZ_TARGET STREQUAL "browse")
+        add_definitions(-DFUZZ_TARGET_BROWSE=1)
+    elseif(FUZZ_TARGET STREQUAL "receive")
+        add_definitions(-DFUZZ_TARGET_RECEIVE=1)
+    else()
+        message(FATAL_ERROR "FUZZ_TARGET must be 'receive' or 'browse' (got '${FUZZ_TARGET}')")
+    endif()
+    message(STATUS "Fuzz harness target: ${FUZZ_TARGET}")
     list(APPEND SOURCES main.c)
 endif()
 
@@ -84,8 +99,12 @@ endif()
 
 # Sanitizers for AFL fuzzing (unit tests enable these in unity/enable_testing.cmake)
 if(NOT ENABLE_UNIT_TESTS)
-    target_compile_options(${PROJECT_NAME} PRIVATE -fsanitize=address -fsanitize=undefined)
-    target_link_options(${PROJECT_NAME} PRIVATE -fsanitize=address -fsanitize=undefined)
+    target_compile_options(${PROJECT_NAME} PRIVATE
+        -g3
+        -fsanitize=address,undefined
+        -fno-omit-frame-pointer
+    )
+    target_link_options(${PROJECT_NAME} PRIVATE -fsanitize=address,undefined)
 endif()
 
 # Enable testing if unit tests are enabled

--- a/components/mdns/tests/host_unit_test/README.md
+++ b/components/mdns/tests/host_unit_test/README.md
@@ -52,29 +52,38 @@ Repeat with `-DUNIT_TESTS=test_sender` or `-DUNIT_TESTS=test_browse` in a separa
 
 ## Fuzzer tests
 
-Build the AFL-instrumented harness (no `-DUNIT_TESTS`; uses `main.c`):
+See [fuzzing.md](fuzzing.md) for the AFL++ effectiveness checklist and rationale.
+
+Build separate harnesses for **receive** (parse/query) and **browse** (cache/TXT). Prefer `afl-clang-fast`. Set sanitizer options before fuzzing or reproducing:
 
 ```bash
 export IDF_PATH=/path/to/esp-idf   # required in the fuzz container
+export ASAN_OPTIONS="abort_on_error=1:halt_on_error=1:symbolize=0:detect_stack_use_after_return=1:max_malloc_fill_size=$((1<<30))"
+export UBSAN_OPTIONS="halt_on_error=1:abort_on_error=1"
 
 cd input && python generate_cases.py && cd ..
 
-cmake -B build2 -S . -G Ninja -DCMAKE_C_COMPILER=afl-cc
-cmake --build build2
+cmake -B build_fuzz_recv -S . -G Ninja \
+  -DCMAKE_C_COMPILER=afl-clang-fast -DFUZZ_TARGET=receive
+cmake --build build_fuzz_recv
+afl-fuzz -i input -o out_recv -- build_fuzz_recv/mdns_host_unit_test
 
-afl-fuzz -i input -o out -- build2/mdns_host_unit_test
+cmake -B build_fuzz_browse -S . -G Ninja \
+  -DCMAKE_C_COMPILER=afl-clang-fast -DFUZZ_TARGET=browse
+cmake --build build_fuzz_browse
+afl-fuzz -i input -o out_browse -- build_fuzz_browse/mdns_host_unit_test
 ```
 
-The harness reads packets from stdin and exercises IPv4/IPv6 and port 5353/53 combinations. Crashes are written to `out/default/crashes/`.
+Each execution feeds one packet (exact-size copy) into `mdns_packet_push`, with IPv4/IPv6 and port 53/5353 derived from the input. Crashes land under `out_*/default/crashes/`.
 
 ### Reproducing a crash
 
-Build the non-unit-test binary with a normal compiler, then pass a crash file:
+Build the same `FUZZ_TARGET` with a normal compiler, keep `ASAN_OPTIONS` set, then pass the crash file:
 
 ```bash
-cmake -B build2 -S .
-cmake --build build2
-./build2/mdns_host_unit_test out/default/crashes/id_000000,...
+cmake -B build_repro -S . -G Ninja -DFUZZ_TARGET=receive
+cmake --build build_repro
+./build_repro/mdns_host_unit_test out_recv/default/crashes/id_000000,...
 ```
 
 With sanitizers enabled, ASan/UBSan report buffer overruns and undefined behaviour directly during unit tests and fuzzing.

--- a/components/mdns/tests/host_unit_test/fuzzing.md
+++ b/components/mdns/tests/host_unit_test/fuzzing.md
@@ -1,0 +1,75 @@
+# mDNS AFL++ fuzzing notes
+
+Checklist from `fuzzing_info.txt` (AFL++ effectiveness tips), applied to
+`components/mdns/tests/host_unit_test`. Each item states what we do here and why.
+
+Preferred compiler: `afl-clang-fast` / `afl-cc` (LLVM persistent + deferred forkserver).
+
+Required ASan env when running `afl-fuzz` or reproducing crashes:
+
+```bash
+export ASAN_OPTIONS="abort_on_error=1:halt_on_error=1:symbolize=0:detect_stack_use_after_return=1:max_malloc_fill_size=$((1<<30))"
+export UBSAN_OPTIONS="halt_on_error=1:abort_on_error=1"
+```
+
+## (1) Configure sanitizers and assertions
+
+CMake already links the fuzz binary with `-fsanitize=address,undefined`, `-g3`, and frame pointers. That matches the tip’s default of ASan+UBSan for C targets. Runtime sensitivity (abort-on-error, use-after-return, full malloc fill) must be set via `ASAN_OPTIONS` / `UBSAN_OPTIONS` as above—AFL++ will refuse to run if abort/halt are missing when ASan is linked. We do not enable `_GLIBCXX_DEBUG` because this harness is pure C.
+
+## (2) Prefer the persistent mode
+
+`main.c` uses `__AFL_LOOP(10000)` with deferred init (`__AFL_FUZZ_INIT` / `__AFL_INIT`) and the shared-memory testcase buffer when built with `afl-clang-fast`. That avoids re-execing the process per input and is roughly an order of magnitude faster than plain fork+exec. Crash reproduction builds (normal `cc`) skip these macros and take a crash file path instead.
+
+## (3) Include source files, not header files
+
+Not adopted for this tree. The host harness already has a deliberate multi-file CMake build (mdns sources + Linux stubs + generated `sdkconfig` headers), and pulling `.c` files into one TU would fight IDF’s include layout without unlocking static-only APIs we need—the public receive entry is already `mdns_packet_push` → `mdns_priv_receive_action`. Keep the existing build; use stubs for symbol substitution instead of `#include "foo.c"`.
+
+## (4) Isolate fuzz tests from each other
+
+Persistent mode reuses process-global mdns state (responder, queries/browsers, cache). After each input we call `mdns_priv_cache_clear()` so cache entries from a previous packet cannot change coverage or hide bugs on the next one. Full deinit/init every iteration would be stronger isolation but much slower; AFL still recycles the process periodically, which resets remaining globals.
+
+## (5) Do not test directly on the fuzz test buffer
+
+The harness `realloc`s an exact-size `input_copy` and `memcpy`s the AFL buffer into it before calling `send_packet`. That way ASan can catch reads past the logical length—AFL’s SHM backing store is larger than `len`, so passing `buf` straight through would miss overflows. The networking stub also copies into a `malloc(len)` packet payload; the harness copy is intentional defense in depth for tip (5).
+
+## (6) Don’t bother freeing memory
+
+Partially followed. We do not free the persistent `input_copy` between iterations (only grow via `realloc`), and we avoid noisy per-packet teardown. We *do* clear the mdns cache each iteration (see (4)) because unbounded cache growth would OOM or make crashes unreproducible—tip (6)’s “skip destructors” advice loses to isolation for this stateful protocol stack.
+
+## (7) Use a memory file descriptor to back named paths
+
+Not applicable. The fuzz surface is an in-memory API (`mdns_packet_push(addr, port, if, data, len)`), not a pathname/`open` interface. No `memfd_create` / `/proc/self/fd/N` wrapper is required.
+
+## (8) Configure the target for smaller buffers
+
+Not changed in production headers. The harness explicitly caps every path (AFL SHM, legacy stdin, crash repro) at `FUZZ_MAX_INPUT_LEN` (`MDNS_MAX_PACKET_SIZE` / 1460) so fuzzing and reproduction stay aligned on the realistic UDP/mDNS bound. Shrinking that further mostly invents artificial TX-path limits rather than exposing RX bugs faster. Name/TXT limits (`MDNS_NAME_MAX_LEN`, `MDNS_TXT_MAX_LEN`) could be reduced under a future fuzz-only compile switch if corpus depth stalls on those paths; document-only for now.
+
+---
+
+## Harness split: `receive` vs `browse`
+
+Unit tests already isolate receiver vs browser with different mocks. Fuzzing benefits from the same split so AFL’s coverage map is not dominated by whichever path mutates first:
+
+| `-DFUZZ_TARGET=` | Context | What it stresses |
+|------------------|---------|------------------|
+| `receive` (default) | Responder + async queries | Parse, questions/answers, query matching |
+| `browse` | Responder + `mdns_browse_new` | Browse/cache/TXT comparison path |
+
+Build separate output dirs and run two `afl-fuzz` instances (or one after the other). Each input still hits a single IPv4/IPv6 × port 53/5353 combo derived from a XOR of the packet bytes (full DNS payload preserved for the seed corpus).
+
+```bash
+export ASAN_OPTIONS="abort_on_error=1:halt_on_error=1:symbolize=0:detect_stack_use_after_return=1:max_malloc_fill_size=$((1<<30))"
+export UBSAN_OPTIONS="halt_on_error=1:abort_on_error=1"
+
+cd input && python generate_cases.py && cd ..
+
+cmake -B build_fuzz_recv -S . -G Ninja \
+  -DCMAKE_C_COMPILER=afl-clang-fast -DFUZZ_TARGET=receive
+cmake --build build_fuzz_recv
+afl-fuzz -i input -o out_recv -- build_fuzz_recv/mdns_host_unit_test
+
+cmake -B build_fuzz_browse -S . -G Ninja \
+  -DCMAKE_C_COMPILER=afl-clang-fast -DFUZZ_TARGET=browse
+cmake --build build_fuzz_browse
+afl-fuzz -i input -o out_browse -- build_fuzz_browse/mdns_host_unit_test
+```

--- a/components/mdns/tests/host_unit_test/main.c
+++ b/components/mdns/tests/host_unit_test/main.c
@@ -2,29 +2,53 @@
  * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Unlicense OR CC0-1.0
+ *
+ * AFL++ fuzz harness for the mDNS receive path.
+ *
+ * Build with -DFUZZ_TARGET=receive (default) or -DFUZZ_TARGET=browse.
+ * See fuzzing.md for how this maps to AFL++ effectiveness tips.
  */
+#include <assert.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <stdint.h>
 #include <unistd.h>
 #include "esp_err.h"
 #include "mdns.h"
+#include "mdns_private.h"
 #include "mdns_receive.h"
 #include "mdns_responder.h"
 #include "mdns_querier.h"
 #include "mdns_browser.h"
+#include "mdns_cache.h"
 #include "mdns_mem_caps.h"
 
-esp_err_t mdns_packet_push(esp_ip_addr_t *addr, int port, mdns_if_t tcpip_if, uint8_t*data, size_t len);
+/* Keep AFL, legacy stdin, and crash-repro paths on the same length bound. */
+#define FUZZ_MAX_INPUT_LEN MDNS_MAX_PACKET_SIZE
 
-mdns_search_once_t *s_a, *s_aaaa, *s_ptr, *s_srv, *s_txt;
+#ifndef FUZZ_TARGET_BROWSE
+#define FUZZ_TARGET_RECEIVE 1
+#endif
 
+esp_err_t mdns_packet_push(esp_ip_addr_t *addr, int port, mdns_if_t tcpip_if, uint8_t *data, size_t len);
+
+#ifdef FUZZ_TARGET_RECEIVE
+static mdns_search_once_t *s_a, *s_aaaa, *s_ptr, *s_srv, *s_txt;
+#endif
+
+#ifdef FUZZ_TARGET_BROWSE
 static void browse_notifier(mdns_result_t *result)
 {
     (void)result;
 }
+#endif
 
-void init_responder(void)
+/*
+ * Shared services / hostname setup used by both fuzz targets.
+ * Keep this lean: more state means more cross-test interference.
+ */
+static void init_common(void)
 {
     mdns_ip_addr_t addr = { .addr = { .u_addr = ESP_IPADDR_TYPE_V4 } };
     addr.addr.u_addr.ip4.addr = 0x11111111;
@@ -50,19 +74,38 @@ void init_responder(void)
     mdns_service_add("inst5", "_scanner", "_tcp", 80, NULL, 0);
     mdns_service_add("inst6", "_http", "_tcp", 80, NULL, 0);
     mdns_service_add("inst7", "_sleep", "_udp", 80, NULL, 0);
+}
 
-    s_a = mdns_query_async_new("host_name", NULL, NULL, MDNS_TYPE_A, 1000, 1, NULL);
-    s_aaaa = mdns_query_async_new("host_name2", NULL, NULL, MDNS_TYPE_AAAA, 1000, 1, NULL);
-    s_ptr = mdns_query_async_new("minifritz", "_http", "_tcp", MDNS_TYPE_PTR, 1000, 1, NULL);
-    s_srv = mdns_query_async_new("fritz", "_http", "_tcp", MDNS_TYPE_SRV, 1000, 1, NULL);
-    s_txt = mdns_query_async_new("fritz", "_http", "_tcp", MDNS_TYPE_TXT, 1000, 1, NULL);
-
+#ifdef FUZZ_TARGET_BROWSE
+static void init_fuzz_context(void)
+{
+    init_common();
+    /* Browse path: active browsers so PTR/SRV/TXT answers hit cache + TXT compare. */
     mdns_browse_new("_http", "_tcp", browse_notifier);
     mdns_browse_new("_scanner", "_tcp", browse_notifier);
     mdns_browse_new("_sleep", "_udp", browse_notifier);
 }
 
-void deinit_responder(void)
+static void deinit_fuzz_context(void)
+{
+    mdns_priv_browse_free();
+    mdns_priv_cache_clear();
+    mdns_service_remove_all();
+    mdns_priv_responder_free();
+}
+#else /* FUZZ_TARGET_RECEIVE */
+static void init_fuzz_context(void)
+{
+    init_common();
+    /* Receive/parse path: outstanding queries exercise answer matching without browse. */
+    s_a = mdns_query_async_new("host_name", NULL, NULL, MDNS_TYPE_A, 1000, 1, NULL);
+    s_aaaa = mdns_query_async_new("host_name2", NULL, NULL, MDNS_TYPE_AAAA, 1000, 1, NULL);
+    s_ptr = mdns_query_async_new("minifritz", "_http", "_tcp", MDNS_TYPE_PTR, 1000, 1, NULL);
+    s_srv = mdns_query_async_new("fritz", "_http", "_tcp", MDNS_TYPE_SRV, 1000, 1, NULL);
+    s_txt = mdns_query_async_new("fritz", "_http", "_tcp", MDNS_TYPE_TXT, 1000, 1, NULL);
+}
+
+static void deinit_fuzz_context(void)
 {
     mdns_priv_search_once_free(s_a);
     mdns_priv_search_once_free(s_aaaa);
@@ -70,7 +113,7 @@ void deinit_responder(void)
     mdns_priv_search_once_free(s_srv);
     mdns_priv_search_once_free(s_txt);
     mdns_priv_query_free();
-    mdns_priv_browse_free();
+    mdns_priv_cache_clear();
     mdns_service_remove_all();
     mdns_priv_responder_free();
     s_a = NULL;
@@ -79,51 +122,123 @@ void deinit_responder(void)
     s_srv = NULL;
     s_txt = NULL;
 }
+#endif
 
-static void send_packet(bool ip4, bool mdns_port, uint8_t*data, size_t len)
+/*
+ * Feed one sized packet into the receive path.
+ * Derive IPv4/IPv6 and port 53/5353 from the input so each AFL execution
+ * explores one transport combo without mutating/stripping the DNS bytes
+ * (seed corpus from generate_cases.py stays valid).
+ */
+static void send_packet(const uint8_t *data, size_t len)
 {
     esp_ip_addr_t addr4 = ESP_IP4ADDR_INIT(192, 168, 1, 1);
     esp_ip_addr_t addr6 = ESP_IP6ADDR_INIT(0x000002ff, 0, 0, 0xfe800000);
-    esp_ip_addr_t *addr = ip4 ? &addr4 : &addr6;
-    int port = mdns_port ? 53 : 5353;
-
-    if (mdns_packet_push(addr, port, 0, data, len) != ESP_OK) {
-        printf("Failed to push packet\n");
+    uint8_t sel = 0;
+    for (size_t i = 0; i < len; i++) {
+        sel ^= data[i];
     }
+    bool ip4 = (sel & 1u) == 0;
+    bool mdns_port = (sel & 2u) == 0;
+    esp_ip_addr_t *addr = ip4 ? &addr4 : &addr6;
+    int port = mdns_port ? 5353 : 53;
+
+    (void)mdns_packet_push(addr, port, 0, (uint8_t *)data, len);
 }
+
+/*
+ * Reset mutable global state between persistent-mode iterations so one input
+ * cannot poison the next (cache entries from previous packets).
+ */
+static void reset_between_inputs(void)
+{
+    mdns_priv_cache_clear();
+}
+
+/*
+ * Copy at most FUZZ_MAX_INPUT_LEN bytes into *input_copy and feed the receive path.
+ * Caps SHM / file lengths so fuzzing and crash reproduction stay aligned.
+ */
+static void process_fuzz_input(uint8_t **input_copy, const uint8_t *src, size_t len)
+{
+    if (len > FUZZ_MAX_INPUT_LEN) {
+        len = FUZZ_MAX_INPUT_LEN;
+    }
+    *input_copy = realloc(*input_copy, len ? len : 1);
+    if (!*input_copy) {
+        return;
+    }
+    if (len > 0) {
+        memcpy(*input_copy, src, len);
+    }
+    send_packet(*input_copy, len);
+    reset_between_inputs();
+}
+
+#ifdef __AFL_HAVE_MANUAL_CONTROL
+__AFL_FUZZ_INIT();
+#endif
 
 int main(int argc, char **argv)
 {
-    init_responder();
+    uint8_t *input_copy = NULL;
 
-    // Original fuzzing code
-    uint8_t buf[1460];
-    FILE *file;
-    size_t len = 1460;
-    memset(buf, 0, len);
-#ifndef __AFL_LOOP
-    //
-    // Note: parameter1 is a file (mangled packet) which caused the crash
+#ifdef __AFL_HAVE_MANUAL_CONTROL
+    __AFL_INIT();
+#endif
+
+    init_fuzz_context();
+
+#ifdef __AFL_LOOP
+#ifdef __AFL_HAVE_MANUAL_CONTROL
+    {
+        unsigned char *buf = __AFL_FUZZ_TESTCASE_BUF;
+
+        while (__AFL_LOOP(10000)) {
+            int len = __AFL_FUZZ_TESTCASE_LEN;
+            if (len < 0) {
+                continue;
+            }
+            process_fuzz_input(&input_copy, buf, (size_t)len);
+        }
+    }
+#else
+    {
+        /* Persistent mode without deferred SHM (legacy afl-gcc style). */
+        unsigned char stack_buf[FUZZ_MAX_INPUT_LEN];
+
+        while (__AFL_LOOP(10000)) {
+            memset(stack_buf, 0, sizeof(stack_buf));
+            int len = (int)read(0, stack_buf, sizeof(stack_buf));
+            if (len < 0) {
+                continue;
+            }
+            process_fuzz_input(&input_copy, stack_buf, (size_t)len);
+        }
+    }
+#endif /* __AFL_HAVE_MANUAL_CONTROL */
+#else
+    /* Crash reproduction: pass an AFL crash file on the command line. */
+    uint8_t file_buf[FUZZ_MAX_INPUT_LEN];
+    size_t len;
+
     if (argc != 2) {
-        printf("Non-instrumentation mode: please supply a file name created by AFL to reproduce crash\n");
+        fprintf(stderr, "Usage: %s <crash-file>\n", argv[0]);
         return 1;
     }
-    file = fopen(argv[1], "r");
-    assert(file >= 0);
-    len = fread(buf, 1, 1460, file);
-    fclose(file);
-    {
-#else
-    while (__AFL_LOOP(1000)) {
-        memset(buf, 0, 1460);
-        size_t len = read(0, buf, 1460);
-#endif
-        send_packet(true, true, buf, len);
-        send_packet(true, false, buf, len);
-        send_packet(false, true, buf, len);
-        send_packet(false, false, buf, len);
+    FILE *file = fopen(argv[1], "rb");
+    assert(file != NULL);
+    len = fread(file_buf, 1, sizeof(file_buf), file);
+    if (!feof(file)) {
+        fprintf(stderr, "warning: crash file larger than FUZZ_MAX_INPUT_LEN (%d); truncating\n",
+                FUZZ_MAX_INPUT_LEN);
     }
-    deinit_responder();
+    fclose(file);
 
+    process_fuzz_input(&input_copy, file_buf, len);
+    free(input_copy);
+#endif
+
+    deinit_fuzz_context();
     return 0;
 }

--- a/examples/esp_netif/eth_endpoint_wifi_ap/sdkconfig.defaults
+++ b/examples/esp_netif/eth_endpoint_wifi_ap/sdkconfig.defaults
@@ -1,6 +1,9 @@
 # This file was generated using idf.py save-defconfig. It can be edited manually.
 # Espressif IoT Development Framework (ESP-IDF) Project Minimal Configuration
 #
+# Larger factory partition (WiFi+ETH+NAPT exceeds default 1MB on some targets)
+CONFIG_PARTITION_TABLE_SINGLE_APP_LARGE=y
+#
 # WiFi AP Configuration
 CONFIG_EXAMPLE_WIFI_AP_SSID="myssid-ext"
 CONFIG_EXAMPLE_WIFI_AP_PASS="mypassword"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are confined to test harnesses, CI, docs, and an example partition default—not production mDNS runtime code.
> 
> **Overview**
> **Improves mDNS host AFL++ fuzzing** by splitting coverage into **receive** (parse/query matching) and **browse** (cache/TXT) harnesses, and aligning CI, CMake, and docs with AFL++ effectiveness practices.
> 
> The fuzz harness in `main.c` now uses **persistent mode** (`__AFL_LOOP`, deferred `__AFL_INIT`, SHM testcase buffer), copies inputs to an exact-size buffer before `mdns_packet_push` (so ASan can catch over-reads), clears the cache between iterations, and picks one IPv4/IPv6 × port 53/5353 combo per input via a byte XOR (instead of feeding the same packet four ways). **Receive** builds register async queries; **browse** builds register browsers—selected at compile time with `-DFUZZ_TARGET=receive|browse`.
> 
> **CI** runs a matrix job for both fuzz targets with `afl-clang-fast`, required `ASAN_OPTIONS`/`UBSAN_OPTIONS`, and per-target artifact paths. **CMake** exposes `FUZZ_TARGET`, tightens fuzz sanitizer flags (`-g3`, combined ASan/UBSan), and treats unit tests as off unless a real `UNIT_TESTS` suite is set. New **`fuzzing.md`** documents the checklist; README steps are updated.
> 
> **Unrelated to fuzzing:** `eth_endpoint_wifi_ap` switches to `CONFIG_PARTITION_TABLE_SINGLE_APP_LARGE`, and CI ignores “partition nearly full” build warnings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4e5f273a4e0baacd00b591bc8686136d632488f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->