### PR TITLE
fix(common): Update smallest app partition full regex

### DIFF
--- a/.github/workflows/modem__build-host-tests.yml
+++ b/.github/workflows/modem__build-host-tests.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Build ${{ matrix.example }} with IDF-${{ matrix.idf_ver }}
         shell: bash
         env:
-          EXPECTED_WARNING: "Warning: The smallest app partition is nearly full\nwarning: unknown kconfig symbol 'ESP32_PANIC_PRINT_HALT'"
+          EXPECTED_WARNING: "The smallest .+ partition is nearly full\nwarning: unknown kconfig symbol 'ESP32_PANIC_PRINT_HALT'"
         run: |
           . ${IDF_PATH}/export.sh
           python -m pip install idf-build-apps

--- a/.github/workflows/tls_cxx__build.yml
+++ b/.github/workflows/tls_cxx__build.yml
@@ -23,6 +23,8 @@ jobs:
         with:
           submodules: recursive
       - name: Build ${{ matrix.test.app }} with IDF-${{ matrix.idf_ver }}
+        env:
+          EXPECTED_WARNING: "The smallest .+ partition is nearly full"
         shell: bash
         run: |
           . ${IDF_PATH}/export.sh

--- a/ci/ignore_build_warnings.txt
+++ b/ci/ignore_build_warnings.txt
@@ -1,9 +1,9 @@
 DeprecationWarning: pkg_resources is deprecated as an API
-Warning: Deprecated: Option '--flash_size' is deprecated. Use '--flash-size' instead.
-Warning: Deprecated: Option '--flash_mode' is deprecated. Use '--flash-mode' instead.
-Warning: Deprecated: Option '--flash_freq' is deprecated. Use '--flash-freq' instead.
-Warning: Deprecated: Command 'sign_data' is deprecated. Use 'sign-data' instead.
-Warning: Deprecated: Command 'extract_public_key' is deprecated. Use 'extract-public-key' instead.
+Deprecated: Option '--flash_size' is deprecated
+Deprecated: Option '--flash_mode' is deprecated
+Deprecated: Option '--flash_freq' is deprecated
+Deprecated: Command 'sign_data' is deprecated
+Deprecated: Command 'extract_public_key' is deprecated
 warning: unknown kconfig symbol 'EXAMPLE_ETH_PHY_IP101'
 WARNING: The following Kconfig variables were used in "if" clauses, but not
 warning: unknown kconfig symbol 'LIBC_NEWLIB'


### PR DESCRIPTION
* smallest app partition full regex
* deprecated option regex

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only changes to warning ignore patterns; no application or runtime behavior is affected.
> 
> **Overview**
> Updates CI build warning allowlists so builds keep passing when Espressif tooling changes warning text.
> 
> **Partition nearly full:** `EXPECTED_WARNING` in the esp-modem examples workflow now uses a regex (`The smallest .+ partition is nearly full`) instead of the fixed “app partition” string. The mbedtls-cxx build workflow gets the same `EXPECTED_WARNING` env var on its build step.
> 
> **Deprecated CLI options:** Entries in `ci/ignore_build_warnings.txt` are shortened and drop the `Warning:` prefix so they still match updated deprecation messages for `--flash_size`, `--flash_mode`, `--flash_freq`, `sign_data`, and `extract_public_key`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecd7d1990e441d538b39c7b8777f651900307618. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->