### PR TITLE
fix(mdns): ensure buffer is always NUL-terminated in rx_staged_ip_add()

### DIFF
--- a/components/mdns/mdns_receive.c
+++ b/components/mdns/mdns_receive.c
@@ -702,6 +702,7 @@ static void rx_staged_ip_add(mdns_rx_staged_ip_t **staged_ip, const char *hostna
     }
 
     strncpy(new_staged_ip->hostname, hostname, MDNS_NAME_BUF_LEN - 1);
+    new_staged_ip->hostname[MDNS_NAME_BUF_LEN - 1] = '\0';
     new_staged_ip->ip = *ip;
     new_staged_ip->ttl = ttl;
     new_staged_ip->next = *staged_ip;


### PR DESCRIPTION


<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

This PR fixes a GCC strncpy() truncation warning in `mdns_receive.c` in `rx_staged_ip_add()`.

In some cases, GCC thinks the host buffer from the `mdns_name_t` struct extends over all the other adjacent buffers and therefore thinks this is a copy from a 262 byte to 64 byte buffer and therefore emits this warning. Explicitly NUL-terminate the buffer here to be safe and silence the warning. Other `strncpy()` uses in this file already follow this same explicit NUL-termination pattern.

All call sites of this function already pass a buffer of the same size as `new_staged_ip->hostname` (i.e. `MDNS_NAME_BUF_LEN`), so this should only change the behaviour if the terminating `NUL` byte is already missing in the source buffer.

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

Our ESP32-based embedded products use the `mdns` component and are confirmed to build and work with this fix.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [X] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [X] Documentation is updated as needed. (none needed)
- [X] Tests are updated or added as necessary. (none needed)
- [X] Code is well-commented, especially in complex areas.
- [X] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single defensive string-termination line in mDNS browse staging; no behavior change beyond safer truncated hostnames and quieter builds.
> 
> **Overview**
> Adds an explicit NUL terminator after `strncpy` when copying a hostname into staged browse IP entries in `rx_staged_ip_add()`.
> 
> This matches the same post-`strncpy` pattern already used elsewhere in `mdns_receive.c`, guarantees a terminated string when the name is truncated, and addresses a GCC `strncpy` truncation warning tied to how it models the source buffer layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b370a9abc29390b4adc612d251cc2dbbb325ff6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->